### PR TITLE
exposing javax.lang.model.type package via equinox system bundle

### DIFF
--- a/distribution/kernel/carbon-home/repository/conf/etc/launch.ini
+++ b/distribution/kernel/carbon-home/repository/conf/etc/launch.ini
@@ -28,6 +28,7 @@ osgi.clean=true
 
 # Following system property allows us to control the public JDK packages exported through the system bundle.
 org.osgi.framework.system.packages=javax.accessibility,\
+javax.lang.model.type,\
 javax.activity,\
 javax.crypto,\
 javax.crypto.interfaces,\


### PR DESCRIPTION
This package is needed for some dependencies in Apache Stratos