### PR TITLE
fixing password heap inspection vulnerability in user core level

### DIFF
--- a/core/org.wso2.carbon.user.core/pom.xml
+++ b/core/org.wso2.carbon.user.core/pom.xml
@@ -85,6 +85,10 @@
             <groupId>commons-collections.wso2</groupId>
             <artifactId>commons-collections</artifactId>
         </dependency>
+        <dependency>
+            <groupId>commons-lang.wso2</groupId>
+            <artifactId>commons-lang</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
@@ -3304,7 +3304,7 @@ public abstract class AbstractUserStoreManager implements UserStoreManager {
 
         if (!systemUserRoleManager.isExistingSystemUser(systemUser)) {
             systemUserRoleManager.addSystemUser(systemUser,
-                    UserCoreUtil.getPolicyFriendlyRandomPassword(systemUser), null);
+                    UserCoreUtil.getPolicyFriendlyRandomPasswordInChars(systemUser), null);
         }
 
         if (!systemUserRoleManager.isExistingRole(systemRole)) {

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
@@ -22,6 +22,8 @@ import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.CarbonConstants;
 import org.wso2.carbon.context.CarbonContext;
 import org.wso2.carbon.user.api.RealmConfiguration;
+import org.wso2.carbon.user.core.listener.SecretHandleableListener;
+import org.wso2.carbon.utils.Secret;
 import org.wso2.carbon.user.core.Permission;
 import org.wso2.carbon.user.core.UserCoreConstants;
 import org.wso2.carbon.user.core.UserRealm;
@@ -43,10 +45,12 @@ import org.wso2.carbon.user.core.profile.ProfileConfigurationManager;
 import org.wso2.carbon.user.core.service.RealmService;
 import org.wso2.carbon.user.core.system.SystemUserRoleManager;
 import org.wso2.carbon.user.core.util.UserCoreUtil;
+import org.wso2.carbon.utils.UnsupportedSecretTypeException;
 import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 
 import javax.sql.DataSource;
 import java.lang.reflect.Constructor;
+import java.nio.CharBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -376,51 +380,75 @@ public abstract class AbstractUserStoreManager implements UserStoreManager {
                     credential, domainProvided);
         }
 
+        Secret credentialObj;
+        try {
+            credentialObj = Secret.getSecret(credential);
+        } catch (UnsupportedSecretTypeException e) {
+            throw new UserStoreException("Unsupported credential type", e);
+        }
+
         // #################### Domain Name Free Zone Starts Here ################################
 
         // #################### <Listeners> #####################################################
-        for (UserStoreManagerListener listener : UMListenerServiceComponent
-                .getUserStoreManagerListeners()) {
-            if (!listener.authenticate(userName, credential, this)) {
-                return true;
-            }
-        }
-
-        for (UserOperationEventListener listener : UMListenerServiceComponent
-                .getUserOperationEventListeners()) {
-            if (!listener.doPreAuthenticate(userName, credential, this)) {
-                return false;
-            }
-        }
-        // #################### </Listeners> #####################################################
-
-        int tenantId = getTenantId();
-
         try {
-            RealmService realmService = UserCoreUtil.getRealmService();
-            if (realmService != null) {
-                boolean tenantActive = realmService.getTenantManager().isTenantActive(tenantId);
+            for (UserStoreManagerListener listener : UMListenerServiceComponent.getUserStoreManagerListeners()) {
+                Object credentialArgument;
+                if (listener instanceof SecretHandleableListener) {
+                    credentialArgument = credentialObj;
+                } else {
+                    credentialArgument = credential;
+                }
 
-                if (!tenantActive) {
-                    log.warn("Tenant has been deactivated. TenantID : " + tenantId);
+                if (!listener.authenticate(userName, credentialArgument, this)) {
+                    return true;
+                }
+            }
+
+            for (UserOperationEventListener listener : UMListenerServiceComponent.getUserOperationEventListeners()) {
+                Object credentialArgument;
+                if (listener instanceof SecretHandleableListener) {
+                    credentialArgument = credentialObj;
+                } else {
+                    credentialArgument = credential;
+                }
+
+                if (!listener.doPreAuthenticate(userName, credentialArgument, this)) {
                     return false;
                 }
             }
-        } catch (org.wso2.carbon.user.api.UserStoreException e) {
-            throw new UserStoreException("Error while trying to check Tenant status for Tenant : "
-                    + tenantId, e);
-        }
+            // #################### </Listeners> #####################################################
 
-        // We are here due to two reason. Either there is no secondary UserStoreManager or no
-        // domain name provided with user name.
+            int tenantId = getTenantId();
 
-        try {
-            // Let's authenticate with the primary UserStoreManager.
-            authenticated = doAuthenticate(userName, credential);
-        } catch (Exception e) {
-            // We can ignore and proceed. Ignore the results from this user store.
-            log.error(e);
-            authenticated = false;
+            try {
+                RealmService realmService = UserCoreUtil.getRealmService();
+                if (realmService != null) {
+                    boolean tenantActive = realmService.getTenantManager().isTenantActive(tenantId);
+
+                    if (!tenantActive) {
+                        log.warn("Tenant has been deactivated. TenantID : " + tenantId);
+                        return false;
+                    }
+                }
+            } catch (org.wso2.carbon.user.api.UserStoreException e) {
+                throw new UserStoreException("Error while trying to check Tenant status for Tenant : "
+                                             + tenantId, e);
+            }
+
+            // We are here due to two reason. Either there is no secondary UserStoreManager or no
+            // domain name provided with user name.
+
+            try {
+                // Let's authenticate with the primary UserStoreManager.
+                authenticated = doAuthenticate(userName, credentialObj);
+            } catch (Exception e) {
+                // We can ignore and proceed. Ignore the results from this user store.
+                log.error(e);
+                authenticated = false;
+            }
+
+        } finally {
+            credentialObj.clear();
         }
 
         if (authenticated) {
@@ -690,43 +718,73 @@ public abstract class AbstractUserStoreManager implements UserStoreManager {
             throw new UserStoreException("Invalid operation. User store is read only");
         }
 
+        Secret newCredentialObj;
+        Secret oldCredentialObj;
+        try {
+            newCredentialObj = Secret.getSecret(newCredential);
+            oldCredentialObj = Secret.getSecret(oldCredential);
+        } catch (UnsupportedSecretTypeException e) {
+            throw new UserStoreException("Unsupported credential type");
+        }
+
         // #################### <Listeners> #####################################################
-        for (UserStoreManagerListener listener : UMListenerServiceComponent
-                .getUserStoreManagerListeners()) {
-            if (!listener.updateCredential(userName, newCredential, oldCredential, this)) {
-                return;
-            }
-        }
-
-        for (UserOperationEventListener listener : UMListenerServiceComponent
-                .getUserOperationEventListeners()) {
-            if (!listener.doPreUpdateCredential(userName, newCredential, oldCredential, this)) {
-                return;
-            }
-        }
-        // #################### </Listeners> #####################################################
-
-        // This user name here is domain-less.
-        // We directly authenticate user against the selected UserStoreManager.
-        boolean isAuth = this.doAuthenticate(userName, oldCredential);
-
-        if (isAuth) {
-
-            this.doUpdateCredential(userName, newCredential, oldCredential);
-
-            // #################### <Listeners> ##################################################
-            for (UserOperationEventListener listener : UMListenerServiceComponent
-                    .getUserOperationEventListeners()) {
-                if (!listener.doPostUpdateCredential(userName, newCredential, this)) {
-                    return;
+        try {
+            for (UserStoreManagerListener listener : UMListenerServiceComponent.getUserStoreManagerListeners()) {
+                if (listener instanceof SecretHandleableListener) {
+                    if (!listener.updateCredential(userName, newCredentialObj, oldCredentialObj, this)) {
+                        return;
+                    }
+                } else {
+                    if (!listener.updateCredential(userName, newCredential, oldCredential, this)) {
+                        return;
+                    }
                 }
             }
-            // #################### </Listeners> ##################################################
 
-            return;
-        } else {
-            throw new UserStoreException(
-                    "Old credential does not match with the existing credentials.");
+            for (UserOperationEventListener listener : UMListenerServiceComponent.getUserOperationEventListeners()) {
+                if (listener instanceof SecretHandleableListener) {
+                    if (!listener.doPreUpdateCredential(userName, newCredentialObj, oldCredentialObj, this)) {
+                        return;
+                    }
+                } else {
+                    if (!listener.doPreUpdateCredential(userName, newCredential, oldCredential, this)) {
+                        return;
+                    }
+                }
+            }
+            // #################### </Listeners> #####################################################
+
+            // This user name here is domain-less.
+            // We directly authenticate user against the selected UserStoreManager.
+            boolean isAuth = this.doAuthenticate(userName, oldCredentialObj);
+
+            if (isAuth) {
+
+                this.doUpdateCredential(userName, newCredentialObj, oldCredentialObj);
+
+                // #################### <Listeners> ##################################################
+                for (UserOperationEventListener listener : UMListenerServiceComponent
+                        .getUserOperationEventListeners()) {
+                    if (listener instanceof SecretHandleableListener) {
+                        if (!listener.doPostUpdateCredential(userName, newCredentialObj, this)) {
+                            return;
+                        }
+                    } else {
+                        if (!listener.doPostUpdateCredential(userName, newCredential, this)) {
+                            return;
+                        }
+                    }
+                }
+                // #################### </Listeners> ##################################################
+
+                return;
+            } else {
+                throw new UserStoreException(
+                        "Old credential does not match with the existing credentials.");
+            }
+        } finally {
+            newCredentialObj.clear();
+            oldCredentialObj.clear();
         }
     }
 
@@ -749,40 +807,77 @@ public abstract class AbstractUserStoreManager implements UserStoreManager {
             throw new UserStoreException("Invalid operation. User store is read only");
         }
 
-        // #################### <Listeners> #####################################################
-        for (UserStoreManagerListener listener : UMListenerServiceComponent
-                .getUserStoreManagerListeners()) {
-            if (!listener.updateCredentialByAdmin(userName, newCredential, this)) {
-                return;
-            }
+        Secret newCredentialObj;
+        try {
+            newCredentialObj = Secret.getSecret(newCredential);
+        } catch (UnsupportedSecretTypeException e) {
+            throw new UserStoreException("Unsupported credential type", e);
         }
-        // using string buffers to allow the password to be changed by listener
-        for (UserOperationEventListener listener : UMListenerServiceComponent
-                .getUserOperationEventListeners()) {
-            if (newCredential == null) { // a default password will be set
-                StringBuffer credBuff = new StringBuffer();
-                if (!listener.doPreUpdateCredentialByAdmin(userName, newCredential, this)) {
-                    return;
-                }
-                newCredential = credBuff.toString(); // reading the modified value
-            } else if (newCredential instanceof String) {
-                StringBuffer credBuff = new StringBuffer((String) newCredential);
-                if (!listener.doPreUpdateCredentialByAdmin(userName, credBuff, this)) {
-                    return;
-                }
-                newCredential = credBuff.toString(); // reading the modified value
-            }
-        }
-        // #################### </Listeners> #####################################################
-
-        doUpdateCredentialByAdmin(userName, newCredential);
 
         // #################### <Listeners> #####################################################
-        for (UserOperationEventListener listener : UMListenerServiceComponent
-                .getUserOperationEventListeners()) {
-            if (!listener.doPostUpdateCredentialByAdmin(userName, newCredential, this)) {
-                return;
+        try {
+            for (UserStoreManagerListener listener : UMListenerServiceComponent.getUserStoreManagerListeners()) {
+                Object credentialArgument;
+                if (listener instanceof SecretHandleableListener) {
+                    credentialArgument = newCredentialObj;
+                } else {
+                    credentialArgument = newCredential;
+                }
+
+                if (!listener.updateCredentialByAdmin(userName, credentialArgument, this)) {
+                    return;
+                }
             }
+
+            for (UserOperationEventListener listener : UMListenerServiceComponent.getUserOperationEventListeners()) {
+
+                if (listener instanceof SecretHandleableListener) {
+                    if (!listener.doPreUpdateCredentialByAdmin(userName, newCredentialObj, this)) {
+                        return;
+                    }
+                } else {
+                    // using string buffers to allow the password to be changed by listener
+                    StringBuffer credBuff = null;
+                    if (newCredential == null) { // a default password will be set
+                        credBuff = new StringBuffer();
+                    } else if (newCredential instanceof String) {
+                        credBuff = new StringBuffer((String) newCredential);
+                    }
+
+                    if (credBuff != null) {
+                        if (!listener.doPreUpdateCredentialByAdmin(userName, credBuff, this)) {
+                            return;
+                        }
+                        // reading the modified value
+                        newCredential = credBuff.toString();
+                        newCredentialObj.clear();
+                        try {
+                            newCredentialObj = Secret.getSecret(newCredential);
+                        } catch (UnsupportedSecretTypeException e) {
+                            throw new UserStoreException("Unsupported credential type", e);
+                        }
+                    }
+                }
+            }
+            // #################### </Listeners> #####################################################
+
+            doUpdateCredentialByAdmin(userName, newCredentialObj);
+
+            // #################### <Listeners> #####################################################
+            for (UserOperationEventListener listener : UMListenerServiceComponent.getUserOperationEventListeners()) {
+                Object credentialArgument;
+                if (listener instanceof SecretHandleableListener) {
+                    credentialArgument = newCredentialObj;
+                } else {
+                    credentialArgument = newCredential;
+                }
+
+                if (!listener.doPostUpdateCredentialByAdmin(userName, credentialArgument, this)) {
+                    return;
+                }
+            }
+        } finally {
+            newCredentialObj.clear();
         }
         // #################### </Listeners> #####################################################
 
@@ -1097,133 +1192,166 @@ public abstract class AbstractUserStoreManager implements UserStoreManager {
             return;
         }
 
-        if (userStore.isSystemStore()) {
-            systemUserRoleManager.addSystemUser(userName, credential, roleList);
-            return;
+        Secret credentialObj;
+        try {
+            credentialObj = Secret.getSecret(credential);
+        } catch (UnsupportedSecretTypeException e) {
+            throw new UserStoreException("Unsupported credential type", e);
         }
 
-        // #################### Domain Name Free Zone Starts Here ################################
-
-        if (isReadOnly()) {
-            throw new UserStoreException("Invalid operation. User store is read only");
-        }
-
-        // This happens only once during first startup - adding administrator user/role.
-        if (userName.indexOf(CarbonConstants.DOMAIN_SEPARATOR) > 0) {
-            userName = userStore.getDomainFreeName();
-            roleList = UserCoreUtil.removeDomainFromNames(roleList);
-        }
-
-        // #################### <Listeners> #####################################################
-        for (UserStoreManagerListener listener : UMListenerServiceComponent
-                .getUserStoreManagerListeners()) {
-            if (!listener.addUser(userName, credential, roleList, claims, profileName, this)) {
+        try {
+            if (userStore.isSystemStore()) {
+                systemUserRoleManager.addSystemUser(userName, credentialObj, roleList);
                 return;
             }
-        }
-        // String buffers are used to let listeners to modify passwords
-        for (UserOperationEventListener listener : UMListenerServiceComponent
-                .getUserOperationEventListeners()) {
-            if (credential == null) { // a default password will be set
-                StringBuffer credBuff = new StringBuffer();
-                if (!listener.doPreAddUser(userName, credBuff, roleList, claims, profileName,
-                        this)) {
-                    return;
-                }
-                credential = credBuff.toString(); // reading the modified value
-            } else if (credential instanceof String) {
-                StringBuffer credBuff = new StringBuffer((String) credential);
-                if (!listener.doPreAddUser(userName, credBuff, roleList, claims, profileName,
-                        this)) {
-                    return;
-                }
-                credential = credBuff.toString(); // reading the modified value
+
+            // #################### Domain Name Free Zone Starts Here ################################
+
+            if (isReadOnly()) {
+                throw new UserStoreException("Invalid operation. User store is read only");
             }
-        }
-        // #################### </Listeners> #####################################################
 
-        if (!checkUserNameValid(userStore.getDomainFreeName())) {
-            String message = "Username " + userStore.getDomainFreeName() + " is not valid. User name must be a non null string with following format, ";
-            String regEx = realmConfig
-                    .getUserStoreProperty(UserCoreConstants.RealmConfig.PROPERTY_USER_NAME_JAVA_REG_EX);
-            throw new UserStoreException(message + regEx);
-        }
+            // This happens only once during first startup - adding administrator user/role.
+            if (userName.indexOf(CarbonConstants.DOMAIN_SEPARATOR) > 0) {
+                userName = userStore.getDomainFreeName();
+                roleList = UserCoreUtil.removeDomainFromNames(roleList);
+            }
 
-        if (!checkUserPasswordValid(credential)) {
-            String message = "Credential not valid. Credential must be a non null string with following format, ";
-            String regEx = realmConfig
-                    .getUserStoreProperty(UserCoreConstants.RealmConfig.PROPERTY_JAVA_REG_EX);
-            throw new UserStoreException(message + regEx);
-        }
+            // #################### <Listeners> #####################################################
+            for (UserStoreManagerListener listener : UMListenerServiceComponent.getUserStoreManagerListeners()) {
+                Object credentialArgument;
+                if (listener instanceof SecretHandleableListener) {
+                    credentialArgument = credentialObj;
+                } else {
+                    credentialArgument = credential;
+                }
 
-        if (doCheckExistingUser(userStore.getDomainFreeName())) {
-            throw new UserStoreException("Username '" + userName
-                    + "' already exists in the system. Please pick another username.");
-        }
+                if (!listener.addUser(userName, credentialArgument, roleList, claims, profileName, this)) {
+                    return;
+                }
+            }
 
+            for (UserOperationEventListener listener : UMListenerServiceComponent.getUserOperationEventListeners()) {
+                if (listener instanceof SecretHandleableListener) {
+                    if (!listener.doPreAddUser(userName, credentialObj, roleList, claims, profileName, this)) {
+                        return;
+                    }
+                } else {
+                    // String buffers are used to let listeners to modify passwords
+                    StringBuffer credBuff = null;
+                    if (credential == null) { // a default password will be set
+                        credBuff = new StringBuffer();
+                    } else if (credential instanceof String) {
+                        credBuff = new StringBuffer((String) credential);
+                    }
 
-        List<String> internalRoles = new ArrayList<String>();
-        List<String> externalRoles = new ArrayList<String>();
-        int index;
-        if (roleList != null) {
-            for (String role : roleList) {
-                if (role != null && role.trim().length() > 0) {
-                    index = role.indexOf(CarbonConstants.DOMAIN_SEPARATOR);
-                    if (index > 0) {
-                        String domain = role.substring(0, index);
-                        if (UserCoreConstants.INTERNAL_DOMAIN.equalsIgnoreCase(domain)) {
-                            internalRoles.add(UserCoreUtil.removeDomainFromName(role));
-                            continue;
+                    if (credBuff != null) {
+                        if (!listener.doPreAddUser(userName, credBuff, roleList, claims, profileName, this)) {
+                            return;
+                        }
+                        // reading the modified value
+                        credential = credBuff.toString();
+                        credentialObj.clear();
+                        try {
+                            credentialObj = Secret.getSecret(credential);
+                        } catch (UnsupportedSecretTypeException e) {
+                            throw new UserStoreException("Unsupported credential type", e);
                         }
                     }
-                    externalRoles.add(UserCoreUtil.removeDomainFromName(role));
                 }
             }
-        }
+            // #################### </Listeners> #####################################################
 
-        // check existance of roles and claims before user is adding
-        for (String internalRole : internalRoles) {
-            if (!hybridRoleManager.isExistingRole(internalRole)) {
-                throw new UserStoreException("Internal role is not exist : " + internalRole);
+            if (!checkUserNameValid(userStore.getDomainFreeName())) {
+                String message = "Username " + userStore.getDomainFreeName() +
+                                 " is not valid. User name must be a non null string with following format, ";
+                String regEx = realmConfig
+                        .getUserStoreProperty(UserCoreConstants.RealmConfig.PROPERTY_USER_NAME_JAVA_REG_EX);
+                throw new UserStoreException(message + regEx);
             }
-        }
 
-        for (String externalRole : externalRoles) {
-            if (!doCheckExistingRole(externalRole)) {
-                throw new UserStoreException("External role is not exist : " + externalRole);
+            if (!checkUserPasswordValid(credentialObj)) {
+                String message = "Credential not valid. Credential must be a non null string with following format, ";
+                String regEx = realmConfig.getUserStoreProperty(UserCoreConstants.RealmConfig.PROPERTY_JAVA_REG_EX);
+                throw new UserStoreException(message + regEx);
             }
-        }
 
-        if (claims != null) {
-            for (Map.Entry<String, String> entry : claims.entrySet()) {
-                ClaimMapping claimMapping = null;
-                try {
-                    claimMapping = (ClaimMapping) claimManager.getClaimMapping(entry.getKey());
-                } catch (org.wso2.carbon.user.api.UserStoreException e) {
-                    String errorMessage = "Error in obtaining claim mapping for persisting user attributes.";
-                    throw new UserStoreException(errorMessage, e);
+            if (doCheckExistingUser(userStore.getDomainFreeName())) {
+                throw new UserStoreException("Username '" + userName
+                                             + "' already exists in the system. Please pick another username.");
+            }
+
+            List<String> internalRoles = new ArrayList<String>();
+            List<String> externalRoles = new ArrayList<String>();
+            int index;
+            if (roleList != null) {
+                for (String role : roleList) {
+                    if (role != null && role.trim().length() > 0) {
+                        index = role.indexOf(CarbonConstants.DOMAIN_SEPARATOR);
+                        if (index > 0) {
+                            String domain = role.substring(0, index);
+                            if (UserCoreConstants.INTERNAL_DOMAIN.equalsIgnoreCase(domain)) {
+                                internalRoles.add(UserCoreUtil.removeDomainFromName(role));
+                                continue;
+                            }
+                        }
+                        externalRoles.add(UserCoreUtil.removeDomainFromName(role));
+                    }
                 }
-                if (claimMapping == null) {
-                    String errorMessage = "Invalid claim uri has been provided.";
-                    throw new UserStoreException(errorMessage);
+            }
+
+            // check existance of roles and claims before user is adding
+            for (String internalRole : internalRoles) {
+                if (!hybridRoleManager.isExistingRole(internalRole)) {
+                    throw new UserStoreException("Internal role is not exist : " + internalRole);
                 }
             }
-        }
 
-        doAddUser(userName, credential, externalRoles.toArray(new String[externalRoles.size()]),
-                claims, profileName, requirePasswordChange);
-
-        if (internalRoles.size() > 0) {
-            hybridRoleManager.updateHybridRoleListOfUser(userName, null,
-                    internalRoles.toArray(new String[internalRoles.size()]));
-        }
-
-        // #################### <Listeners> #####################################################
-        for (UserOperationEventListener listener : UMListenerServiceComponent
-                .getUserOperationEventListeners()) {
-            if (!listener.doPostAddUser(userName, credential, roleList, claims, profileName, this)) {
-                return;
+            for (String externalRole : externalRoles) {
+                if (!doCheckExistingRole(externalRole)) {
+                    throw new UserStoreException("External role is not exist : " + externalRole);
+                }
             }
+
+            if (claims != null) {
+                for (Map.Entry<String, String> entry : claims.entrySet()) {
+                    ClaimMapping claimMapping = null;
+                    try {
+                        claimMapping = (ClaimMapping) claimManager.getClaimMapping(entry.getKey());
+                    } catch (org.wso2.carbon.user.api.UserStoreException e) {
+                        String errorMessage = "Error in obtaining claim mapping for persisting user attributes.";
+                        throw new UserStoreException(errorMessage, e);
+                    }
+                    if (claimMapping == null) {
+                        String errorMessage = "Invalid claim uri has been provided.";
+                        throw new UserStoreException(errorMessage);
+                    }
+                }
+            }
+
+            doAddUser(userName, credentialObj, externalRoles.toArray(new String[externalRoles.size()]),
+                      claims, profileName, requirePasswordChange);
+
+            if (internalRoles.size() > 0) {
+                hybridRoleManager.updateHybridRoleListOfUser(userName, null,
+                                                             internalRoles.toArray(new String[internalRoles.size()]));
+            }
+
+            // #################### <Listeners> #####################################################
+            for (UserOperationEventListener listener : UMListenerServiceComponent.getUserOperationEventListeners()) {
+                Object credentialArgument;
+                if (listener instanceof SecretHandleableListener) {
+                    credentialArgument = credentialObj;
+                } else {
+                    credentialArgument = credential;
+                }
+
+                if (!listener.doPostAddUser(userName, credentialArgument, roleList, claims, profileName, this)) {
+                    return;
+                }
+            }
+        } finally {
+            credentialObj.clear();
         }
         // #################### </Listeners> #####################################################
 
@@ -2807,19 +2935,25 @@ public abstract class AbstractUserStoreManager implements UserStoreManager {
             return false;
         }
 
-        if (!(credential instanceof String)) {
-            throw new UserStoreException("Can handle only string type credentials");
+        Secret credentialObj;
+        try {
+            credentialObj = Secret.getSecret(credential);
+        } catch (UnsupportedSecretTypeException e) {
+            throw new UserStoreException("Unsupported credential type", e);
         }
 
-        String password = ((String) credential).trim();
+        try {
+            if (credentialObj.getChars().length < 1) {
+                return false;
+            }
 
-        if (password.length() < 1) {
-            return false;
+            String regularExpression =
+                    realmConfig.getUserStoreProperty(UserCoreConstants.RealmConfig.PROPERTY_JAVA_REG_EX);
+            return regularExpression == null || isFormatCorrect(regularExpression, credentialObj.getChars());
+        } finally {
+            credentialObj.clear();
         }
 
-        String regularExpression = realmConfig
-                .getUserStoreProperty(UserCoreConstants.RealmConfig.PROPERTY_JAVA_REG_EX);
-        return regularExpression == null || isFormatCorrect(regularExpression, password);
     }
 
     /**
@@ -2981,6 +3115,18 @@ public abstract class AbstractUserStoreManager implements UserStoreManager {
         Pattern p2 = Pattern.compile(regularExpression);
         Matcher m2 = p2.matcher(attribute);
         return m2.matches();
+    }
+
+    private boolean isFormatCorrect(String regularExpression, char[] attribute) {
+
+        boolean matches;
+        CharBuffer charBuffer = CharBuffer.wrap(attribute);
+
+        Pattern p2 = Pattern.compile(regularExpression);
+        Matcher m2 = p2.matcher(charBuffer);
+        matches = m2.matches();
+
+        return matches;
     }
 
     /**

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/ActiveDirectoryUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/ActiveDirectoryUserStoreManager.java
@@ -23,6 +23,7 @@ import org.wso2.carbon.CarbonConstants;
 import org.wso2.carbon.user.api.Properties;
 import org.wso2.carbon.user.api.Property;
 import org.wso2.carbon.user.api.RealmConfiguration;
+import org.wso2.carbon.utils.Secret;
 import org.wso2.carbon.user.core.UserCoreConstants;
 import org.wso2.carbon.user.core.UserRealm;
 import org.wso2.carbon.user.core.UserStoreConfigConstants;
@@ -30,6 +31,7 @@ import org.wso2.carbon.user.core.UserStoreException;
 import org.wso2.carbon.user.core.claim.ClaimManager;
 import org.wso2.carbon.user.core.profile.ProfileConfigurationManager;
 import org.wso2.carbon.user.core.util.JNDIUtil;
+import org.wso2.carbon.utils.UnsupportedSecretTypeException;
 
 import javax.naming.Name;
 import javax.naming.NameParser;
@@ -46,7 +48,7 @@ import javax.naming.directory.ModificationItem;
 import javax.naming.directory.NoSuchAttributeException;
 import javax.naming.directory.SearchControls;
 import javax.naming.directory.SearchResult;
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.StringTokenizer;
 
@@ -136,6 +138,13 @@ public class ActiveDirectoryUserStoreManager extends ReadWriteLDAPUserStoreManag
 		/* setting claims */
         setUserClaims(claims, basicAttributes, userName);
 
+        Secret credentialObj;
+        try {
+            credentialObj = Secret.getSecret(credential);
+        } catch (UnsupportedSecretTypeException e) {
+            throw new UserStoreException("Unsupported credential type", e);
+        }
+
         Name compoundName = null;
         try {
             NameParser ldapParser = dirContext.getNameParser("");
@@ -156,7 +165,8 @@ public class ActiveDirectoryUserStoreManager extends ReadWriteLDAPUserStoreManag
             ModificationItem[] mods = new ModificationItem[2];
             mods[0] = new ModificationItem(DirContext.REPLACE_ATTRIBUTE, new BasicAttribute(
                     LDAPConstants.ACTIVE_DIRECTORY_UNICODE_PASSWORD_ATTRIBUTE,
-                    createUnicodePassword((String) credential)));
+                    createUnicodePassword(credentialObj)));
+
             if (isADLDSRole) {
                 mods[1] = new ModificationItem(DirContext.REPLACE_ATTRIBUTE, new BasicAttribute(
                         LDAPConstants.ACTIVE_DIRECTORY_MSDS_USER_ACCOUNT_DISSABLED, "FALSE"));
@@ -180,6 +190,7 @@ public class ActiveDirectoryUserStoreManager extends ReadWriteLDAPUserStoreManag
             }
             throw new UserStoreException(errorMessage, e);
         } finally {
+            credentialObj.clear();
             JNDIUtil.closeContext(dirContext);
         }
     }
@@ -253,6 +264,14 @@ public class ActiveDirectoryUserStoreManager extends ReadWriteLDAPUserStoreManag
         searchControl.setReturningAttributes(returningAttributes);
         searchControl.setSearchScope(SearchControls.SUBTREE_SCOPE);
         DirContext subDirContext = null;
+
+        Secret credentialObj;
+        try {
+            credentialObj = Secret.getSecret(newCredential);
+        } catch (UnsupportedSecretTypeException e) {
+            throw new UserStoreException("Unsupported credential type", e);
+        }
+
         try {
             // search the user with UserNameAttribute and obtain its CN attribute
             NamingEnumeration<SearchResult> searchResults = dirContext.search(escapeDNForSearch(searchBase),
@@ -283,17 +302,9 @@ public class ActiveDirectoryUserStoreManager extends ReadWriteLDAPUserStoreManag
             // The user tries to change his own password
             if (oldCredential != null && newCredential != null) {
                 mods = new ModificationItem[1];
-                /*
-				 * byte[] oldUnicodePassword = createUnicodePassword((String) oldCredential); byte[]
-				 * newUnicodePassword = createUnicodePassword((String) newCredential);
-				 */
                 mods[0] = new ModificationItem(DirContext.REPLACE_ATTRIBUTE, new BasicAttribute(
                         LDAPConstants.ACTIVE_DIRECTORY_UNICODE_PASSWORD_ATTRIBUTE,
-                        createUnicodePassword((String) newCredential)));
-				/*
-				 * mods[1] = new ModificationItem(DirContext.ADD_ATTRIBUTE, new BasicAttribute(
-				 * LDAPConstants.ACTIVE_DIRECTORY_UNICODE_PASSWORD_ATTRIBUTE, newUnicodePassword));
-				 */
+                        createUnicodePassword(credentialObj)));
             }
             subDirContext = (DirContext) dirContext.lookup(searchBase);
             subDirContext.modifyAttributes("CN" + "=" + escapeSpecialCharactersForDN(userCNValue), mods);
@@ -305,6 +316,7 @@ public class ActiveDirectoryUserStoreManager extends ReadWriteLDAPUserStoreManag
             }
             throw new UserStoreException(error, e);
         } finally {
+            credentialObj.clear();
             JNDIUtil.closeContext(subDirContext);
             JNDIUtil.closeContext(dirContext);
         }
@@ -359,13 +371,24 @@ public class ActiveDirectoryUserStoreManager extends ReadWriteLDAPUserStoreManag
             ModificationItem[] mods = null;
 
             if (newCredential != null) {
-                mods = new ModificationItem[1];
-                mods[0] = new ModificationItem(DirContext.REPLACE_ATTRIBUTE, new BasicAttribute(
-                        LDAPConstants.ACTIVE_DIRECTORY_UNICODE_PASSWORD_ATTRIBUTE,
-                        createUnicodePassword((String) newCredential)));
+                Secret credentialObj;
+                try {
+                    credentialObj = Secret.getSecret(newCredential);
+                } catch (UnsupportedSecretTypeException e) {
+                    throw new UserStoreException("Unsupported credential type", e);
+                }
 
-                subDirContext = (DirContext) dirContext.lookup(searchBase);
-                subDirContext.modifyAttributes("CN" + "=" + escapeSpecialCharactersForDN(userCNValue), mods);
+                try {
+                    mods = new ModificationItem[1];
+                    mods[0] = new ModificationItem(DirContext.REPLACE_ATTRIBUTE, new BasicAttribute(
+                            LDAPConstants.ACTIVE_DIRECTORY_UNICODE_PASSWORD_ATTRIBUTE,
+                            createUnicodePassword(credentialObj)));
+
+                    subDirContext = (DirContext) dirContext.lookup(searchBase);
+                    subDirContext.modifyAttributes("CN" + "=" + escapeSpecialCharactersForDN(userCNValue), mods);
+                } finally {
+                    credentialObj.clear();
+                }
             }
 
         } catch (NamingException e) {
@@ -425,18 +448,26 @@ public class ActiveDirectoryUserStoreManager extends ReadWriteLDAPUserStoreManag
     }
 
     /**
-     * @param password
-     * @return
+     * Returns password as a UTF_16LE encoded bytes array
+     *
+     * @param password password instance of Secret
+     * @return byte[]
      */
-    private byte[] createUnicodePassword(String password) {
-        String newQuotedPassword = "\"" + password + "\"";
-        byte[] encodedPwd = null;
-        try {
-            encodedPwd = newQuotedPassword.getBytes("UTF-16LE");
-        } catch (UnsupportedEncodingException e) {
-            logger.error("Error while encoding the given password", e);
+    private byte[] createUnicodePassword(Secret password) {
+        char[] passwordChars = password.getChars();
+        char[] quotedPasswordChars = new char[passwordChars.length + 2];
+
+        for (int i = 0; i < quotedPasswordChars.length; i++) {
+            if (i == 0 || i == quotedPasswordChars.length - 1) {
+                quotedPasswordChars[i] = '"';
+            } else {
+                quotedPasswordChars[i] = passwordChars[i - 1];
+            }
         }
-        return encodedPwd;
+
+        password.setChars(quotedPasswordChars);
+
+        return password.getBytes(StandardCharsets.UTF_16LE);
     }
 
     /**

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/ReadOnlyLDAPUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/ReadOnlyLDAPUserStoreManager.java
@@ -26,6 +26,7 @@ import org.wso2.carbon.context.CarbonContext;
 import org.wso2.carbon.user.api.Properties;
 import org.wso2.carbon.user.api.Property;
 import org.wso2.carbon.user.api.RealmConfiguration;
+import org.wso2.carbon.utils.Secret;
 import org.wso2.carbon.user.core.UserCoreConstants;
 import org.wso2.carbon.user.core.UserRealm;
 import org.wso2.carbon.user.core.UserStoreException;
@@ -39,6 +40,7 @@ import org.wso2.carbon.user.core.util.DatabaseUtil;
 import org.wso2.carbon.user.core.util.JNDIUtil;
 import org.wso2.carbon.user.core.util.LDAPUtil;
 import org.wso2.carbon.user.core.util.UserCoreUtil;
+import org.wso2.carbon.utils.UnsupportedSecretTypeException;
 
 import javax.naming.AuthenticationException;
 import javax.naming.InvalidNameException;
@@ -323,10 +325,14 @@ public class ReadOnlyLDAPUserStoreManager extends AbstractUserStoreManager {
 
         userName = userName.trim();
 
-        String password = (String) credential;
-        password = password.trim();
+        Secret credentialObj;
+        try {
+            credentialObj = Secret.getSecret(credential);
+        } catch (UnsupportedSecretTypeException e) {
+            throw new UserStoreException("Unsupported credential type", e);
+        }
 
-        if (userName.equals("") || password.equals("")) {
+        if (userName.equals("") || credentialObj.isEmpty()) {
             return false;
         }
 
@@ -334,100 +340,101 @@ public class ReadOnlyLDAPUserStoreManager extends AbstractUserStoreManager {
             log.debug("Authenticating user " + userName);
         }
 
-        boolean bValue = false;
-        // check cached user DN first.
-        String name = null;
-        LdapName ldn = (LdapName)userCache.get(userName);
-        if (ldn != null) {
-            name = ldn.toString();
-            try {
-                if (debug) {
-                    log.debug("Cache hit. Using DN " + name);
-                }
-                bValue = this.bindAsUser(userName,name, (String) credential);
-            } catch (NamingException e) {
-                // do nothing if bind fails since we check for other DN
-                // patterns as well.
-                if (log.isDebugEnabled()) {
-                    log.debug("Checking authentication with UserDN " + name + "failed " +
-                            e.getMessage(), e);
-                }
-            }
-
-            if (bValue) {
-                return bValue;
-            }
-            // we need not check binding for this name again, so store this and check
-            failedUserDN = name;
-
-        }
-        // read DN patterns from user-mgt.xml
-        String patterns = realmConfig.getUserStoreProperty(LDAPConstants.USER_DN_PATTERN);
-
-        if (patterns != null && !patterns.isEmpty()) {
-
-            if (debug) {
-                log.debug("Using UserDNPatterns " + patterns);
-            }
-
-            // if the property is present, split it using # to see if there are
-            // multiple patterns specified.
-            String[] userDNPatternList = patterns.split("#");
-            if (userDNPatternList.length > 0) {
-                for (String userDNPattern : userDNPatternList) {
-                    name = MessageFormat.format(userDNPattern, escapeSpecialCharactersForDN(userName));
-                    // check if the same name is found and checked from cache
-                    if(failedUserDN!=null && failedUserDN.equals(name)){
-                        continue;
-                    }
-
+        try {
+            boolean bValue = false;
+            // check cached user DN first.
+            String name = null;
+            LdapName ldn = (LdapName) userCache.get(userName);
+            if (ldn != null) {
+                name = ldn.toString();
+                try {
                     if (debug) {
-                        log.debug("Authenticating with " + name);
+                        log.debug("Cache hit. Using DN " + name);
                     }
-                    try {
-                        if (name != null) {
-                            bValue = this.bindAsUser(userName, name, (String) credential);
-                            if (bValue) {
-                                LdapName ldapName = new LdapName(name);
-                                userCache.put(userName, ldapName);
-                                break;
+                    bValue = this.bindAsUser(userName, name, credentialObj);
+                } catch (NamingException e) {
+                    // do nothing if bind fails since we check for other DN
+                    // patterns as well.
+                    if (log.isDebugEnabled()) {
+                        log.debug("Checking authentication with UserDN " + name + "failed " + e.getMessage(), e);
+                    }
+                }
+
+                if (bValue) {
+                    return bValue;
+                }
+                // we need not check binding for this name again, so store this and check
+                failedUserDN = name;
+
+            }
+            // read DN patterns from user-mgt.xml
+            String patterns = realmConfig.getUserStoreProperty(LDAPConstants.USER_DN_PATTERN);
+
+            if (patterns != null && !patterns.isEmpty()) {
+
+                if (debug) {
+                    log.debug("Using UserDNPatterns " + patterns);
+                }
+
+                // if the property is present, split it using # to see if there are
+                // multiple patterns specified.
+                String[] userDNPatternList = patterns.split("#");
+                if (userDNPatternList.length > 0) {
+                    for (String userDNPattern : userDNPatternList) {
+                        name = MessageFormat.format(userDNPattern, escapeSpecialCharactersForDN(userName));
+                        // check if the same name is found and checked from cache
+                        if (failedUserDN != null && failedUserDN.equals(name)) {
+                            continue;
+                        }
+
+                        if (debug) {
+                            log.debug("Authenticating with " + name);
+                        }
+                        try {
+                            if (name != null) {
+                                bValue = this.bindAsUser(userName, name, credentialObj);
+                                if (bValue) {
+                                    LdapName ldapName = new LdapName(name);
+                                    userCache.put(userName, ldapName);
+                                    break;
+                                }
+                            }
+                        } catch (NamingException e) {
+                            // do nothing if bind fails since we check for other DN
+                            // patterns as well.
+                            if (log.isDebugEnabled()) {
+                                log.debug("Checking authentication with UserDN " + userDNPattern +
+                                          "failed " + e.getMessage(), e);
                             }
                         }
-                    } catch (NamingException e) {
-                        // do nothing if bind fails since we check for other DN
-                        // patterns as well.
-                        if (log.isDebugEnabled()) {
-                            log.debug("Checking authentication with UserDN " + userDNPattern +
-                                    "failed " + e.getMessage(), e);
+                    }
+                }
+            } else {
+                name = getNameInSpaceForUserName(userName);
+                try {
+                    if (name != null) {
+                        if (debug) {
+                            log.debug("Authenticating with " + name);
+                        }
+                        bValue = this.bindAsUser(userName, name, credentialObj);
+                        if (bValue) {
+                            LdapName ldapName = new LdapName(name);
+                            userCache.put(userName, ldapName);
                         }
                     }
+                } catch (NamingException e) {
+                    String errorMessage = "Cannot bind user : " + userName;
+                    if (log.isDebugEnabled()) {
+                        log.debug(errorMessage, e);
+                    }
+                    throw new UserStoreException(errorMessage, e);
                 }
             }
-        }
-        else
-        {
-            name = getNameInSpaceForUserName(userName);
-            try {
-                if (name != null) {
-                    if (debug) {
-                        log.debug("Authenticating with " + name);
-                    }
-                    bValue = this.bindAsUser(userName, name, (String) credential);
-                    if (bValue) {
-                        LdapName ldapName = new LdapName(name);
-                        userCache.put(userName, ldapName);
-                    }
-                }
-            } catch (NamingException e) {
-                String errorMessage = "Cannot bind user : " + userName;
-                if (log.isDebugEnabled()) {
-                    log.debug(errorMessage, e);
-                }
-                throw new UserStoreException(errorMessage, e);
-            }
-        }
 
-        return bValue;
+            return bValue;
+        } finally {
+            credentialObj.clear();
+        }
     }
 
     /**
@@ -1040,7 +1047,7 @@ public class ReadOnlyLDAPUserStoreManager extends AbstractUserStoreManager {
      * @throws NamingException
      * @throws UserStoreException
      */
-    private boolean bindAsUser(String userName, String dn, String credentials) throws NamingException,
+    private boolean bindAsUser(String userName, String dn, Object credentials) throws NamingException,
             UserStoreException {
         boolean isAuthed = false;
         boolean debug = log.isDebugEnabled();

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/listener/SecretHandleableListener.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/listener/SecretHandleableListener.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.user.core.listener;
+
+/**
+ * This is a marker interface that denotes if the implementation of a specific listener can 
+ * accept org.wso2.carbon.utils.Secret as an argument for a password.
+ */
+public interface SecretHandleableListener {
+
+}

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/util/UserCoreUtil.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/util/UserCoreUtil.java
@@ -18,11 +18,13 @@
 package org.wso2.carbon.user.core.util;
 
 import org.apache.axiom.om.util.Base64;
+import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.CarbonConstants;
 import org.wso2.carbon.context.CarbonContext;
 import org.wso2.carbon.user.api.RealmConfiguration;
+import org.wso2.carbon.utils.Secret;
 import org.wso2.carbon.user.core.UserCoreConstants;
 import org.wso2.carbon.user.core.UserStoreException;
 import org.wso2.carbon.user.core.authorization.DBConstants;
@@ -30,6 +32,7 @@ import org.wso2.carbon.user.core.common.UserStore;
 import org.wso2.carbon.user.core.dto.RoleDTO;
 import org.wso2.carbon.user.core.jdbc.JDBCRealmConstants;
 import org.wso2.carbon.user.core.service.RealmService;
+import org.wso2.carbon.utils.UnsupportedSecretTypeException;
 import org.wso2.carbon.utils.xml.StringUtils;
 
 import javax.sql.DataSource;
@@ -43,7 +46,6 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Random;
 import java.util.Set;
@@ -172,6 +174,7 @@ public final class UserCoreUtil {
      * @return
      * @throws UserStoreException
      */
+    @Deprecated
     public static String getPasswordToStore(String password, String passwordHashMethod,
                                             boolean isKdcEnabled) throws UserStoreException {
 
@@ -201,6 +204,60 @@ public final class UserCoreUtil {
             }
         }
         return passwordToStore;
+    }
+
+    /**
+     * process the original password to be stored as per the given hash method and the status of Kerberos Key
+     * Distribution Center (KDC).
+     * If KDC is enabled plain text password is returned in a byte array since it cannot operate with hashed passwords.
+     * Otherwise if the provided hash method is not null password is hashed and returned in a byte array.
+     *
+     * @param password  original password as an Object
+     * @param passwordHashMethod hash method of the password as a String
+     * @param isKdcEnabled boolean true if KDC is enabled and false if not enabled
+     * @return password to store in a byte array
+     * @throws UserStoreException
+     */
+    public static byte[] getPasswordToStore(Object password, String passwordHashMethod, boolean isKdcEnabled)
+            throws UserStoreException {
+
+        Secret credentialObj;
+        try {
+            credentialObj = Secret.getSecret(password);
+        } catch (UnsupportedSecretTypeException e) {
+            throw new UserStoreException("Unsupported credential type", e);
+        }
+
+        try {
+            byte[] passwordBytes = credentialObj.getBytes();
+            byte[] passwordToStore = Arrays.copyOf(passwordBytes, passwordBytes.length);
+
+            if (isKdcEnabled) {
+                // If KDC is enabled we will always use plain text passwords.
+                // Cause - KDC cannot operate with hashed passwords.
+                return passwordToStore;
+            }
+
+            if (passwordHashMethod != null) {
+
+                if (passwordHashMethod.equals(UserCoreConstants.RealmConfig.PASSWORD_HASH_METHOD_PLAIN_TEXT)) {
+                    return passwordToStore;
+                }
+
+                try {
+                    MessageDigest messageDigest = MessageDigest.getInstance(passwordHashMethod);
+                    byte[] digestValue = messageDigest.digest(passwordBytes);
+                    String saltedPassword = "{" + passwordHashMethod + "}" + Base64.encode(digestValue);
+                    passwordToStore = saltedPassword.getBytes();
+                } catch (NoSuchAlgorithmException e) {
+                    throw new UserStoreException("Invalid hashMethod", e);
+                }
+            }
+
+            return passwordToStore;
+        } finally {
+            credentialObj.clear();
+        }
     }
 
     /**
@@ -256,7 +313,7 @@ public final class UserCoreUtil {
      * @return
      * @throws UserStoreException
      */
-    public static String getPolicyFriendlyRandomPassword(String username) throws UserStoreException {
+    public static char[] getPolicyFriendlyRandomPassword(String username) throws UserStoreException {
         return getPolicyFriendlyRandomPassword(username, 8);
     }
 
@@ -269,7 +326,7 @@ public final class UserCoreUtil {
      * @return password
      * @throws UserStoreException
      */
-    public static String getPolicyFriendlyRandomPassword(String username, int length)
+    public static char[] getPolicyFriendlyRandomPassword(String username, int length)
             throws UserStoreException {
 
         if (length < 8 || length > 50) {
@@ -313,7 +370,7 @@ public final class UserCoreUtil {
             throw new UserStoreException(errorMessage, e);
         }
 
-        return new String(password).concat(randomNum);
+        return ArrayUtils.addAll(password, randomNum.toCharArray());
     }
 
     /**
@@ -961,5 +1018,31 @@ public final class UserCoreUtil {
      */
     public static String getTenantShareGroupBase(String tenantOu) {
         return tenantOu + "=" + CarbonContext.getThreadLocalCarbonContext().getTenantDomain();
+    }
+
+    /**
+     * Clear sensitive char arrays
+     *
+     * @param chars char array to be cleared
+     */
+    public static void clearSensitiveChars(char[] chars) {
+        if (chars == null) {
+            return;
+        }
+
+        Arrays.fill(chars, '\u0000');
+    }
+
+    /**
+     * Clear sensitive byte arrays
+     *
+     * @param bytes byte array to be cleared
+     */
+    public static void clearSensitiveBytes(byte[] bytes) {
+        if (bytes == null) {
+            return;
+        }
+
+        Arrays.fill(bytes, (byte) 0);
     }
 }

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/util/UserCoreUtil.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/util/UserCoreUtil.java
@@ -313,21 +313,47 @@ public final class UserCoreUtil {
      * @return
      * @throws UserStoreException
      */
-    public static char[] getPolicyFriendlyRandomPassword(String username) throws UserStoreException {
+    @Deprecated
+    public static String getPolicyFriendlyRandomPassword(String username) throws UserStoreException {
         return getPolicyFriendlyRandomPassword(username, 8);
+    }
+
+    /**
+     * This method generates a random password that adhere to most of the password policies defined by various LDAPs
+     * such as AD, ApacheDS 2.0 etc.
+     *
+     * @param username username of the end user
+     * @return random password generated as a character array
+     * @throws UserStoreException
+     */
+    public static char[] getPolicyFriendlyRandomPasswordInChars(String username) throws UserStoreException {
+        return getPolicyFriendlyRandomPasswordInChars(username, 8);
     }
 
     /**
      * This method generates a random password that adhere to most of the password policies defined
      * by various LDAPs such as AD, ApacheDS 2.0 etc
      *
-     * @param username
-     * @param length
-     * @return password
+     * @param username username of the end user
+     * @param length   length of the generating password
+     * @return random password as a String
      * @throws UserStoreException
      */
-    public static char[] getPolicyFriendlyRandomPassword(String username, int length)
-            throws UserStoreException {
+    @Deprecated
+    public static String getPolicyFriendlyRandomPassword(String username, int length) throws UserStoreException {
+        return new String(getPolicyFriendlyRandomPasswordInChars(username, length));
+    }
+
+    /**
+     * This method generates a random password that adhere to most of the password policies defined
+     * by various LDAPs such as AD, ApacheDS 2.0 etc
+     *
+     * @param username username of the end user
+     * @param length length of the generating password
+     * @return random password as a character array
+     * @throws UserStoreException
+     */
+    public static char[] getPolicyFriendlyRandomPasswordInChars(String username, int length) throws UserStoreException {
 
         if (length < 8 || length > 50) {
             length = 12;

--- a/core/org.wso2.carbon.utils/pom.xml
+++ b/core/org.wso2.carbon.utils/pom.xml
@@ -92,6 +92,10 @@
             <artifactId>org.wso2.carbon.registry.api</artifactId>
         </dependency>
         <dependency>
+            <groupId>commons-lang.wso2</groupId>
+            <artifactId>commons-lang</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <scope>test</scope>

--- a/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/Secret.java
+++ b/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/Secret.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.utils;
+
+import org.apache.commons.lang.ArrayUtils;
+
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+
+/**
+ * This class wraps a character array to be used to handle sensitive data like passwords.
+ */
+public class Secret {
+    private char[] chars;
+    private byte[] bytes;
+    private int accessCount;
+
+    private Secret(char[] chars) {
+
+        this.chars = chars;
+        this.accessCount = 0;
+    }
+
+    /**
+     * Returns the secret as a character array
+     *
+     * @return char[]
+     */
+    public char[] getChars() {
+
+        if (chars == null) {
+            this.chars = ArrayUtils.EMPTY_CHAR_ARRAY;
+        }
+
+        return chars;
+    }
+
+    /**
+     * Returns the secret as a byte array in UTF-8 format
+     *
+     * @return byte[]
+     */
+    public byte[] getBytes() {
+
+        return getBytes(StandardCharsets.UTF_8);
+    }
+
+    /**
+     * Returns the secret as a byte array for the given encoding format
+     *
+     * @param charset Character encoding format
+     * @return byte[]
+     */
+    public byte[] getBytes(Charset charset) {
+
+        clearBytes(bytes);
+
+        CharBuffer charBuffer = CharBuffer.wrap(getChars());
+        ByteBuffer byteBuffer = charset.encode(charBuffer);
+
+        bytes = Arrays.copyOfRange(byteBuffer.array(), byteBuffer.position(), byteBuffer.limit());
+        Arrays.fill(byteBuffer.array(), (byte) 0); // clear sensitive data
+        return bytes;
+    }
+
+    /**
+     * Check if the character array of the secret is null or empty
+     *
+     * @return true if character array is null or empty, else return false
+     */
+    public boolean isEmpty() {
+
+        return chars == null || chars.length < 1;
+    }
+
+    /**
+     * Sets the given character array as the secret and clears the previous character array
+     *
+     * @param chars character array of the secret
+     */
+    public void setChars(char[] chars) {
+
+        clearChars(this.chars);
+        this.chars = chars;
+    }
+
+    /**
+     * Adds the given character array to the existing character array of the secret
+     *
+     * @param chars character array to be added
+     */
+    public void addChars(char[] chars) {
+
+        char[] previous = getChars();
+        setChars(ArrayUtils.addAll(previous, chars));
+        clearChars(previous);
+    }
+
+    /**
+     * Clears byte and character arrays of the secret.
+     * For each invocation of this method the internal counter which tracks the access count of the instance is
+     * decremented. Byte and character arrays are cleared if and only if the internal counter value is less than 0.
+     *
+     * For proper operation, this method should be invoked once, per each invocation of getSecret factory method.
+     */
+    public void clear() {
+
+        accessCount--;
+        if (accessCount < 0) {
+            clearChars(this.chars);
+            clearBytes(this.bytes);
+        }
+    }
+
+    /**
+     * Returns an instance of a Secret for the given secret type.
+     * Given secret type should be an instance of a Secret, char[] or a String.
+     * If the given secret is of Secret type the internal counter which tracks the access count of the instance is
+     * incremented. Thus, for proper operation once the instance of Secret is retrieved from this method and used,
+     * clear() method should be invoked to clear internal char and byte arrays.
+     *
+     * @param secret given secret. Supports only Secret, char[] or a String types
+     * @return an instance of Secret
+     * @throws UnsupportedSecretTypeException thrown if the given secret is not either a Secret, char[] or String
+     */
+    public static Secret getSecret(Object secret) throws UnsupportedSecretTypeException {
+
+        if (secret != null) {
+            if (secret instanceof Secret) {
+                Secret secretObj = (Secret) secret;
+                secretObj.accessCount++;
+                return secretObj;
+            } else if (secret instanceof char[]) {
+                char[] secretChars = (char[]) secret;
+                return new Secret(Arrays.copyOf(secretChars, secretChars.length));
+            } else if (secret instanceof String) {
+                return new Secret(((String) secret).trim().toCharArray());
+            } else {
+                throw new UnsupportedSecretTypeException(
+                        "Unsupported Secret Type. Can handle only string type or character array type secrets");
+            }
+        }
+
+        return new Secret(ArrayUtils.EMPTY_CHAR_ARRAY);
+    }
+
+    private void clearChars(char[] chars) {
+
+        if (chars != null) {
+            Arrays.fill(chars, '\u0000');
+        }
+    }
+
+    private void clearBytes(byte[] bytes) {
+
+        if (bytes != null) {
+            Arrays.fill(bytes, (byte) 0);
+        }
+    }
+}

--- a/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/UnsupportedSecretTypeException.java
+++ b/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/UnsupportedSecretTypeException.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.utils;
+
+import org.wso2.carbon.CarbonException;
+
+/**
+ * Exception defined to denote that provided secret type is not supported.
+ */
+public class UnsupportedSecretTypeException extends CarbonException {
+
+    private static final long serialVersionUID = 6314854509476176646L;
+
+    public UnsupportedSecretTypeException() {
+    }
+
+    public UnsupportedSecretTypeException(String message) {
+        super(message);
+    }
+
+    public UnsupportedSecretTypeException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public UnsupportedSecretTypeException(Throwable cause) {
+        super(cause);
+    }
+}


### PR DESCRIPTION
JIRA: SECINTDEV-13

We have extensively used String to store user credential across user core, which leaves passwords as string instances in the heap, which are only removed by the garbage collector. Thus, we must make sure that in each and every place passwords are stored in memory as char[] or byte[] and they are cleared as soon as they have been used.

This PR fixes this as below.

A generic class was introduced to carbon utils, that could handle sensitive data like passwords, secrets, tokens etc as a character array internally.
User core implementation was changed to use the introduced instance rather than using String instances for passwords.
A marker interface was introduced to track listeners that supports added instance type in its implementation.
Overloaded existing methods that accept password as a String argument or return password as a String.
