### PR TITLE
releasing DBConnection references when DB commit fails

### DIFF
--- a/core/org.wso2.carbon.registry.core/src/main/java/org/wso2/carbon/registry/core/jdbc/dataaccess/JDBCDatabaseTransaction.java
+++ b/core/org.wso2.carbon.registry.core/src/main/java/org/wso2/carbon/registry/core/jdbc/dataaccess/JDBCDatabaseTransaction.java
@@ -1210,8 +1210,7 @@ public class JDBCDatabaseTransaction implements DatabaseTransaction {
                     // If this is the outer connection, then commit all inner connections and then
                     // the outer connection.
                     try {
-                        Map<String, ManagedRegistryConnection> connections =
-                                tCommittedAndRollbackedConnectionMap.get();
+                        Map<String, ManagedRegistryConnection> connections = tCommittedAndRollbackedConnectionMap.get();
                         for (Map.Entry<String, ManagedRegistryConnection> e : connections.entrySet()) {
                             if (e.getValue() != null) {
                                 e.getValue().getConnection().commit();
@@ -1220,8 +1219,8 @@ public class JDBCDatabaseTransaction implements DatabaseTransaction {
                         }
                     } finally {
                         // Clean up list of committed and rollbacked connections.
-                        tCommittedAndRollbackedConnectionMap.set(new LinkedHashMap<String,
-                                ManagedRegistryConnection>());
+                        tCommittedAndRollbackedConnectionMap.
+                                set(new LinkedHashMap<String, ManagedRegistryConnection>());
                         connection.commit();
                         log.trace("Committed all transactions.");
                     }

--- a/core/org.wso2.carbon.registry.core/src/main/java/org/wso2/carbon/registry/core/jdbc/dataaccess/JDBCDatabaseTransaction.java
+++ b/core/org.wso2.carbon.registry.core/src/main/java/org/wso2/carbon/registry/core/jdbc/dataaccess/JDBCDatabaseTransaction.java
@@ -1209,19 +1209,22 @@ public class JDBCDatabaseTransaction implements DatabaseTransaction {
                         getConnectionCount(tCommittedAndRollbackedConnectionMap.get()) + 1)) {
                     // If this is the outer connection, then commit all inner connections and then
                     // the outer connection.
-                    Map<String, ManagedRegistryConnection> connections =
-                            tCommittedAndRollbackedConnectionMap.get();
-                    for (Map.Entry<String, ManagedRegistryConnection> e : connections.entrySet()) {
-                        if (e.getValue() != null) {
-                            e.getValue().getConnection().commit();
-                            connections.put(e.getKey(), null);
+                    try {
+                        Map<String, ManagedRegistryConnection> connections =
+                                tCommittedAndRollbackedConnectionMap.get();
+                        for (Map.Entry<String, ManagedRegistryConnection> e : connections.entrySet()) {
+                            if (e.getValue() != null) {
+                                e.getValue().getConnection().commit();
+                                connections.put(e.getKey(), null);
+                            }
                         }
+                    } finally {
+                        // Clean up list of committed and rollbacked connections.
+                        tCommittedAndRollbackedConnectionMap.set(new LinkedHashMap<String,
+                                ManagedRegistryConnection>());
+                        connection.commit();
+                        log.trace("Committed all transactions.");
                     }
-                    // Clean up list of committed and rollbacked connections.
-                    tCommittedAndRollbackedConnectionMap.set(new LinkedHashMap<String,
-                            ManagedRegistryConnection>());
-                    connection.commit();
-                    log.trace("Committed all transactions.");
                 } else if (tManagedConnectionMap.get().size() <
                         getConnectionCount(tCommittedAndRollbackedConnectionMap.get())) {
                     throw new SQLException("Total number of available connections are less than " +


### PR DESCRIPTION
This is an improvement done with respect to the code analysis conducted to fix [1] and [2].
Pull request fixing these issues is 449 [3].

[1] https://wso2.org/jira/browse/REGISTRY-2954
[2] https://wso2.org/jira/browse/CARBON-15410
[3] https://github.com/wso2/carbon4-kernel/pull/449
