### PR TITLE
Fixing case senstivity problem in INTERNAL domain. 

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/authorization/TreeNode.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/authorization/TreeNode.java
@@ -18,6 +18,9 @@
 package org.wso2.carbon.user.core.authorization;
 
 
+import org.wso2.carbon.user.core.UserCoreConstants;
+import org.wso2.carbon.user.core.util.UserCoreUtil;
+
 import java.util.BitSet;
 import java.util.HashMap;
 import java.util.List;
@@ -103,7 +106,7 @@ public class TreeNode {
      * @return Boolean.TRUE if authorized, Boolean.FALSE if not
      */
     public Boolean isRoleAuthorized(String role, Permission permission) {
-        BitSet bsAlow = roleAllowPermissions.get(role);
+        BitSet bsAlow = roleAllowPermissions.get(modify(role));
         BitSet bsDeny = roleDenyPermissions.get(role);
         if (bsAlow == null && bsDeny == null) {
             return null;
@@ -145,11 +148,11 @@ public class TreeNode {
      * @param permission the permission granted
      */
     public void authorizeRole(String role, Permission permission) {
-        BitSet bsAllow = roleAllowPermissions.get(role);
+        BitSet bsAllow = roleAllowPermissions.get(modify(role));
         if (bsAllow == null) {
             bsAllow = new BitSet();
             bsAllow.set(permission.ordinal());
-            roleAllowPermissions.put(role, bsAllow);
+            roleAllowPermissions.put(modify(role), bsAllow);
         } else {
             bsAllow.set(permission.ordinal());
         }
@@ -198,7 +201,7 @@ public class TreeNode {
             bsDeny.set(permission.ordinal());
         }
 
-        BitSet bsAllow = roleAllowPermissions.get(role);
+        BitSet bsAllow = roleAllowPermissions.get(modify(role));
         if (bsAllow != null) {
             bsAllow.clear(permission.ordinal());
         }
@@ -302,4 +305,13 @@ public class TreeNode {
         SQS_SEND_MESSAGE, SQS_RECEIVE_MESSAGE, SQS_DELETE_MESSAGE, SQS_CHANGE_MESSAGE_VISIBILITY, SQS_GET_QUEUE_ATTRIBUTES
     }
 
+    private String modify(String name) {
+        if (!name.contains(UserCoreConstants.DOMAIN_SEPARATOR)) {
+            return name;
+        }
+        String domain = UserCoreUtil.extractDomainFromName(name);
+        String nameWithoutDomain = UserCoreUtil.removeDomainFromName(name);
+        String modifiedName = UserCoreUtil.addDomainToName(nameWithoutDomain, domain.toUpperCase());
+        return modifiedName;
+    }
 }

--- a/core/org.wso2.carbon.user.core/src/test/java/org/wso2/carbon/user/core/authorization/HybridRoleAuthorizationTest.java
+++ b/core/org.wso2.carbon.user.core/src/test/java/org/wso2/carbon/user/core/authorization/HybridRoleAuthorizationTest.java
@@ -1,5 +1,5 @@
 /*
-*  Copyright (c) 2005-2010, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*  Copyright (c) 2005-2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
 *
 *  WSO2 Inc. licenses this file to you under the Apache License,
 *  Version 2.0 (the "License"); you may not use this file except

--- a/core/org.wso2.carbon.user.core/src/test/java/org/wso2/carbon/user/core/authorization/HybridRoleAuthorizationTest.java
+++ b/core/org.wso2.carbon.user.core/src/test/java/org/wso2/carbon/user/core/authorization/HybridRoleAuthorizationTest.java
@@ -1,0 +1,101 @@
+/*
+*  Copyright (c) 2005-2010, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+package org.wso2.carbon.user.core.authorization;
+
+import org.junit.Assert;
+import org.wso2.carbon.user.core.BaseTestCase;
+import org.wso2.carbon.user.core.util.UserCoreUtil;
+
+public class HybridRoleAuthorizationTest extends BaseTestCase {
+
+    public void setUp() throws Exception {
+        super.setUp();
+    }
+
+    public void testAuthorizationForActions() throws Exception {
+        String roleName = "Internal/testRole";
+        String resourceId = "/permission/test/testPermission";
+        String actionConsume = "consume";
+        String actionUIExecute = "ui.execute";
+
+
+        TreeNode treeNode = new TreeNode(resourceId);
+        treeNode.authorizeRole(roleName, PermissionTreeUtil.actionToPermission(actionConsume));
+        Assert.assertTrue(treeNode.isRoleAuthorized(roleName, PermissionTreeUtil.actionToPermission(actionConsume)));
+        Assert.assertNull(treeNode.isRoleAuthorized(roleName, PermissionTreeUtil.actionToPermission(actionUIExecute)));
+    }
+
+
+    public void testLowerCaseDomainName() throws Exception {
+        String roleName = "Internal/testRole";
+        String resourceId = "/permission/test/testPermission";
+        String actionConsume = "consume";
+
+
+        TreeNode treeNode = new TreeNode(resourceId);
+        treeNode.authorizeRole(roleName, PermissionTreeUtil.actionToPermission(actionConsume));
+
+        String modifiedRoleName = UserCoreUtil.addDomainToName(UserCoreUtil.removeDomainFromName(roleName),
+                UserCoreUtil.extractDomainFromName(roleName).toLowerCase());
+
+        Assert.assertTrue(treeNode.isRoleAuthorized(modifiedRoleName, PermissionTreeUtil.actionToPermission(actionConsume)));
+
+    }
+
+    public void testUpperCaseDomainName() throws Exception {
+        String roleName = "Internal/testRole";
+        String resourceId = "/permission/test/testPermission";
+        String actionConsume = "consume";
+
+
+        TreeNode treeNode = new TreeNode(resourceId);
+        treeNode.authorizeRole(roleName, PermissionTreeUtil.actionToPermission(actionConsume));
+
+        String modifiedRoleName = UserCoreUtil.addDomainToName(UserCoreUtil.removeDomainFromName(roleName),
+                UserCoreUtil.extractDomainFromName(roleName).toUpperCase());
+
+        Assert.assertTrue(treeNode.isRoleAuthorized(modifiedRoleName, PermissionTreeUtil.actionToPermission(actionConsume)));
+    }
+
+    public void testLowerCaseRoleName() throws Exception {
+        String roleName = "Internal/testRole";
+        String resourceId = "/permission/test/testPermission";
+        String actionConsume = "consume";
+
+
+        TreeNode treeNode = new TreeNode(resourceId);
+        treeNode.authorizeRole(roleName, PermissionTreeUtil.actionToPermission(actionConsume));
+
+        Assert.assertNull(treeNode.isRoleAuthorized(roleName.toLowerCase(), PermissionTreeUtil.actionToPermission
+                (actionConsume)));
+    }
+
+    public void testUpperCaseRoleName() throws Exception {
+        String roleName = "Internal/testRole";
+        String resourceId = "/permission/test/testPermission";
+        String actionConsume = "consume";
+
+
+        TreeNode treeNode = new TreeNode(resourceId);
+        treeNode.authorizeRole(roleName, PermissionTreeUtil.actionToPermission(actionConsume));
+
+        Assert.assertNull(treeNode.isRoleAuthorized(roleName.toUpperCase(), PermissionTreeUtil.actionToPermission
+                (actionConsume)));
+    }
+
+}


### PR DESCRIPTION
This should be further fixed in a proper way to support case sensitivity role names in future [1]. In master branch it uses "INTERNAL"  in block capital letters in all the places, so it is not required fix this in master branch

[1] https://wso2.org/jira/browse/IDENTITY-3850
