### PR TITLE
CARBON-15586: Adding test methods for substituteVars method

### DIFF
--- a/core/src/test/java/org/wso2/carbon/kernel/utils/UtilsTest.java
+++ b/core/src/test/java/org/wso2/carbon/kernel/utils/UtilsTest.java
@@ -75,7 +75,8 @@ public class UtilsTest {
         }
     }
 
-    @Test public void testGetCarbonConfigHomePathNullSystemPropertyScenarioOne() throws Exception {
+    @Test
+    public void testGetCarbonConfigHomePathNullSystemPropertyScenarioOne() throws Exception {
 
         String carbonRepoDirPath = System.getProperty(Constants.CARBON_REPOSITORY);
         Boolean needToSetCarbonRepoDirPathAtTheEnd = false;

--- a/core/src/test/java/org/wso2/carbon/kernel/utils/UtilsTest.java
+++ b/core/src/test/java/org/wso2/carbon/kernel/utils/UtilsTest.java
@@ -75,8 +75,7 @@ public class UtilsTest {
         }
     }
 
-    @Test
-    public void testGetCarbonConfigHomePathNullSystemPropertyScenarioOne() throws Exception {
+    @Test public void testGetCarbonConfigHomePathNullSystemPropertyScenarioOne() throws Exception {
 
         String carbonRepoDirPath = System.getProperty(Constants.CARBON_REPOSITORY);
         Boolean needToSetCarbonRepoDirPathAtTheEnd = false;
@@ -166,5 +165,43 @@ public class UtilsTest {
             System.setProperty(Constants.CARBON_HOME, carbonHome);
         }
         setEnvironmentalVariables(backup);
+    }
+
+    @Test
+    public void testSubstituteVarsSystemPropertyNotNull() {
+        String carbonHome = System.getProperty(Constants.CARBON_HOME);
+        Boolean needToClearCarbonHomeAtTheEnd = false;
+
+        if (carbonHome == null) {
+            carbonHome = "test-carbon-home";
+            System.setProperty(Constants.CARBON_HOME, carbonHome);
+            needToClearCarbonHomeAtTheEnd = true;
+        }
+
+        Assert.assertEquals(Utils.substituteVars("${carbon.home}"), carbonHome);
+
+        if (needToClearCarbonHomeAtTheEnd) {
+            System.clearProperty(Constants.CARBON_HOME);
+        }
+    }
+
+    @Test(expectedExceptions = RuntimeException.class)
+    public void testSubstituteVarsSystemPropertyIsNull() {
+        String carbonHome = System.getProperty(Constants.CARBON_HOME);
+        Boolean needToSetCarbonHomeAtTheEnd = false;
+
+        if (carbonHome != null) {
+            System.clearProperty(Constants.CARBON_HOME);
+            needToSetCarbonHomeAtTheEnd = true;
+        }
+
+        try {
+            Utils.substituteVars("${carbon.home}");
+        } finally {
+            if (needToSetCarbonHomeAtTheEnd) {
+                System.setProperty(Constants.CARBON_HOME, carbonHome);
+            }
+        }
+
     }
 }


### PR DESCRIPTION
This is a method in org.wso2.carbon.kernel.utils.Utils. At the moment the corresponding test class org.wso2.carbon.kernel.utils.UtilsTest has been commented out from testng.xml due to intermittent test failures. 
