### PR TITLE
Fixing CARBON-15748

### DIFF
--- a/archetypes/carbon-bundle-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/archetypes/carbon-bundle-archetype/src/main/resources/archetype-resources/pom.xml
@@ -44,7 +44,7 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <version>^maven.bundleplugin.version^</version>
+                <version>^maven.bundle.plugin.version^</version>
                 <extensions>true</extensions>
                 <configuration>
                     <instructions>

--- a/archetypes/carbon-component-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/archetypes/carbon-component-archetype/src/main/resources/archetype-resources/pom.xml
@@ -21,7 +21,7 @@
 
     <parent>
         <groupId>org.wso2.carbon</groupId>
-        <artifactId>carbon-kernel</artifactId>
+        <artifactId>carbon-kernel-parent</artifactId>
         <version>^project.version^</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION
Changing property name maven.bundleplugin.version to maven.bundle.plugin.version in carbon-bundle-archetype and using carbon-kernel-parent as the parent of carbon-component-archetype instead of carbon-kernel.

https://wso2.org/jira/browse/CARBON-15748
