### PR TITLE
 Resources should be closed

### DIFF
--- a/core/src/test/java/org/wso2/carbon/kernel/deployment/deployers/CustomDeployer.java
+++ b/core/src/test/java/org/wso2/carbon/kernel/deployment/deployers/CustomDeployer.java
@@ -71,8 +71,7 @@ public class CustomDeployer implements Deployer {
     public String deploy(Artifact artifact) throws CarbonDeploymentException {
         logger.info("Deploying : " + artifact.getName());
         String key = null;
-        try {
-            FileInputStream fis = new FileInputStream(artifact.getFile());
+        try (FileInputStream fis = new FileInputStream(artifact.getFile())) {
             int x = fis.available();
             byte b[] = new byte[x];
             fis.read(b);
@@ -93,10 +92,9 @@ public class CustomDeployer implements Deployer {
                     "is not a String value");
         }
         logger.info("Undeploying : " + key);
-        try {
-            File fileToUndeploy = new File(testDir + File.separator + key);
-            logger.info("File to undeploy : " + fileToUndeploy.getAbsolutePath());
-            FileInputStream fis = new FileInputStream(fileToUndeploy);
+        File fileToUndeploy = new File(testDir + File.separator + key);
+        logger.info("File to undeploy : " + fileToUndeploy.getAbsolutePath());
+        try (FileInputStream fis = new FileInputStream(fileToUndeploy)) {
             int x = fis.available();
             byte b[] = new byte[x];
             fis.read(b);

--- a/tests/osgi-tests/src/test/java/org/wso2/carbon/osgi/deployment/CustomDeployer.java
+++ b/tests/osgi-tests/src/test/java/org/wso2/carbon/osgi/deployment/CustomDeployer.java
@@ -58,8 +58,7 @@ public class CustomDeployer implements Deployer {
     public String deploy(Artifact artifact) throws CarbonDeploymentException {
         logger.info("Deploying : " + artifact.getName());
         String key = null;
-        try {
-            FileInputStream fis = new FileInputStream(artifact.getFile());
+        try (FileInputStream fis = new FileInputStream(artifact.getFile())) {
             int x = fis.available();
             byte b[] = new byte[x];
             fis.read(b);
@@ -79,10 +78,9 @@ public class CustomDeployer implements Deployer {
                     "is not a String value");
         }
         logger.info("Undeploying : " + key);
-        try {
-            File fileToUndeploy = new File(testDir + File.separator + key);
-            logger.info("File to undeploy : " + fileToUndeploy.getAbsolutePath());
-            FileInputStream fis = new FileInputStream(fileToUndeploy);
+        File fileToUndeploy = new File(testDir + File.separator + key);
+        logger.info("File to undeploy : " + fileToUndeploy.getAbsolutePath());
+        try (FileInputStream fis = new FileInputStream(fileToUndeploy)) {
             int x = fis.available();
             byte b[] = new byte[x];
             fis.read(b);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2095 - “Resources should be closed”. You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S2095
Please let me know if you have any questions.
Ayman Abdelghany.
