### PR TITLE
 Utility classes should not have public constructors

### DIFF
--- a/core/src/main/java/org/wso2/carbon/kernel/internal/CarbonStartupHandler.java
+++ b/core/src/main/java/org/wso2/carbon/kernel/internal/CarbonStartupHandler.java
@@ -30,6 +30,9 @@ import java.text.DecimalFormat;
 public class CarbonStartupHandler {
     private static final Logger logger = LoggerFactory.getLogger(CarbonStartupHandler.class);
 
+    private CarbonStartupHandler() {
+    }
+
     /**
      * Log the server start up time.
      */

--- a/core/src/main/java/org/wso2/carbon/kernel/internal/context/CarbonRuntimeFactory.java
+++ b/core/src/main/java/org/wso2/carbon/kernel/internal/context/CarbonRuntimeFactory.java
@@ -28,6 +28,9 @@ import org.wso2.carbon.kernel.config.model.CarbonConfiguration;
  */
 public class CarbonRuntimeFactory {
 
+    private CarbonRuntimeFactory() {
+    }
+
     public static CarbonRuntime createCarbonRuntime(CarbonConfigProvider carbonConfigProvider) throws Exception {
 
         //TODO Remove hardcoded implementations.

--- a/core/src/main/java/org/wso2/carbon/kernel/internal/deployment/Utils.java
+++ b/core/src/main/java/org/wso2/carbon/kernel/internal/deployment/Utils.java
@@ -26,6 +26,9 @@ import java.io.File;
  */
 public class Utils {
 
+    private Utils() {
+    }
+
     /**
      * Checks if a file has been modified by comparing the last update date of
      * both files and Artifact. If they are different, the file is assumed to have

--- a/core/src/main/java/org/wso2/carbon/kernel/internal/utils/Utils.java
+++ b/core/src/main/java/org/wso2/carbon/kernel/internal/utils/Utils.java
@@ -24,6 +24,9 @@ import org.wso2.carbon.kernel.Constants;
  */
 public class Utils {
 
+    private Utils() {
+    }
+
     /**
      * Returns the carbon.yml location.
      *

--- a/core/src/main/java/org/wso2/carbon/kernel/utils/FileUtils.java
+++ b/core/src/main/java/org/wso2/carbon/kernel/utils/FileUtils.java
@@ -31,6 +31,9 @@ import java.nio.file.StandardCopyOption;
 public class FileUtils {
     private static final Logger logger = LoggerFactory.getLogger(FileUtils.class);
 
+    private FileUtils() {
+    }
+
     /**
      * Deletes all files and subdirectories under dir.
      * Returns true if all deletions were successful.

--- a/launcher/src/main/java/org/wso2/carbon/launcher/utils/FileResolver.java
+++ b/launcher/src/main/java/org/wso2/carbon/launcher/utils/FileResolver.java
@@ -26,6 +26,9 @@ import java.net.URL;
  */
 public class FileResolver {
 
+    private FileResolver() {
+    }
+
     /**
      * Request: file:org.eclipse.osgi_3.9.1.v20130814-1242.jar.
      * Response:

--- a/launcher/src/main/java/org/wso2/carbon/launcher/utils/Utils.java
+++ b/launcher/src/main/java/org/wso2/carbon/launcher/utils/Utils.java
@@ -40,6 +40,9 @@ public class Utils {
     private static final String VAR_REGEXP = "\\$\\{[^}]*}";
     private static final Pattern varPattern = Pattern.compile(VAR_REGEXP);
 
+    private Utils() {
+    }
+
     /**
      * Replace system property holders in the property values.
      * e.g Replace ${carbon.home} with value of the carbon.home system property.

--- a/tests/osgi-test-util/src/main/java/org/wso2/carbon/osgi/test/util/OSGiTestConfigurationUtils.java
+++ b/tests/osgi-test-util/src/main/java/org/wso2/carbon/osgi/test/util/OSGiTestConfigurationUtils.java
@@ -35,6 +35,9 @@ import static org.ops4j.pax.exam.CoreOptions.systemProperty;
  */
 public class OSGiTestConfigurationUtils {
 
+    private OSGiTestConfigurationUtils() {
+    }
+
     /**
      * Returns an array of PAX Exam configuration options which are required to boot up a PAX Exam OSGi environment
      * with Carbon Kernel.

--- a/tests/osgi-tests/src/test/java/org/wso2/carbon/osgi/utils/OSGiTestUtils.java
+++ b/tests/osgi-tests/src/test/java/org/wso2/carbon/osgi/utils/OSGiTestUtils.java
@@ -34,6 +34,9 @@ import static org.ops4j.pax.exam.CoreOptions.repositories;
  */
 public class OSGiTestUtils {
 
+    private OSGiTestUtils() {
+    }
+
     /**
      * Setup the test environment.
      *

--- a/tools/src/main/java/org/wso2/carbon/tools/BundleGenerator.java
+++ b/tools/src/main/java/org/wso2/carbon/tools/BundleGenerator.java
@@ -36,6 +36,9 @@ public class BundleGenerator {
 
     private static final Logger logger = Logger.getLogger(BundleGenerator.class.getName());
 
+    private BundleGenerator() {
+    }
+
     /**
      * Application executor of the JAR to OSGi bundle conversion tool.
      *

--- a/tools/src/main/java/org/wso2/carbon/tools/utils/BundleGeneratorUtils.java
+++ b/tools/src/main/java/org/wso2/carbon/tools/utils/BundleGeneratorUtils.java
@@ -50,6 +50,9 @@ public class BundleGeneratorUtils {
 
     private static final Logger logger = Logger.getLogger(BundleGeneratorUtils.class.getName());
 
+    private BundleGeneratorUtils() {
+    }
+
     /**
      * Converts a specified non-OSGi JAR file to an OSGi bundle at the specified destination.
      *

--- a/tools/src/test/java/org/wso2/carbon/tools/TestUtils.java
+++ b/tools/src/test/java/org/wso2/carbon/tools/TestUtils.java
@@ -29,6 +29,9 @@ import java.util.List;
  */
 public class TestUtils {
 
+    private TestUtils() {
+    }
+
     protected static boolean createDirectory(Path directory) {
         try {
             if (!Files.exists(directory)) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - “Utility classes should not have public constructors ”. You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
Ayman Abdelghany.
