### PR TITLE
updating launcher tests

### DIFF
--- a/launcher/pom.xml
+++ b/launcher/pom.xml
@@ -74,6 +74,21 @@
     </dependencies>
 
     <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <configuration>
+                        <systemPropertyVariables>
+                            <java.util.logging.config.file>
+                                ${basedir}/src/test/resources/logging/logging.properties
+                            </java.util.logging.config.file>
+                        </systemPropertyVariables>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
         <plugins>
             <plugin>
                 <groupId>org.jacoco</groupId>

--- a/launcher/src/test/java/org/wso2/carbon/launcher/test/CarbonLoggerTest.java
+++ b/launcher/src/test/java/org/wso2/carbon/launcher/test/CarbonLoggerTest.java
@@ -17,7 +17,7 @@ package org.wso2.carbon.launcher.test;
 
 import org.testng.Assert;
 import org.testng.annotations.AfterTest;
-import org.testng.annotations.BeforeSuite;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.carbon.launcher.Constants;
 import org.wso2.carbon.launcher.utils.Utils;
@@ -29,7 +29,6 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.ArrayList;
-import java.util.logging.LogManager;
 import java.util.logging.LogRecord;
 import java.util.logging.Logger;
 import java.util.logging.SimpleFormatter;
@@ -49,15 +48,11 @@ public class CarbonLoggerTest extends BaseTest {
         super();
     }
 
-    @BeforeSuite
+    @BeforeClass
     public void doBeforeEachTest() throws IOException {
         setupCarbonHome();
         logFile = new File(Paths.get(Utils.getCarbonHomeDirectory().toString(),
                 "logs", Constants.CARBON_LOG_FILE_NAME).toString());
-        String loggingConfigFile = Paths.get("src", "test", "resources", "logging", "logging.properties").toString();
-        System.setProperty("java.util.logging.config.file", loggingConfigFile);
-        //reload configurations of java.util.logging to set the required pattern for formatter.
-        LogManager.getLogManager().readConfiguration();
         logger = Logger.getLogger(CarbonLoggerTest.class.getName());
         carbonLogHandler = new CarbonLogHandler(logFile);
         carbonLogHandler.setFormatter(new SimpleFormatter());

--- a/launcher/src/test/resources/logging/logging.properties
+++ b/launcher/src/test/resources/logging/logging.properties
@@ -18,7 +18,7 @@
 #handlers= java.util.logging.ConsoleHandler,java.util.logging.FileHandler
 
 # To also add the FileHandler, use the following line instead.
-handlers= java.util.logging.FileHandler, java.util.logging.ConsoleHandler
+handlers= java.util.logging.ConsoleHandler
 
 # Default global logging level.
 # This specifies which kinds of events are logged across
@@ -35,7 +35,7 @@ handlers= java.util.logging.FileHandler, java.util.logging.ConsoleHandler
 
 # default file output is in user's home directory.
 java.util.logging.FileHandler.level = INFO
-java.util.logging.FileHandler.pattern = %carbon.home/java%u.log
+java.util.logging.FileHandler.pattern = logs/carbon.log
 java.util.logging.FileHandler.limit = 50000
 java.util.logging.FileHandler.count = 1
 java.util.logging.FileHandler.formatter = java.util.logging.SimpleFormatter


### PR DESCRIPTION
updating launcher tests to load java.util.logging.config.file property via surefire plugin systemPropertyVariables. This commit also removes the FileHandler configuration from logging.properties file used for unit tests. 
