### PR TITLE
Fix Hazelcast custom topic message de-serialization issue

### DIFF
--- a/modules/carbon-hazelcast/component/pom.xml
+++ b/modules/carbon-hazelcast/component/pom.xml
@@ -84,6 +84,7 @@
             org.slf4j.*;version="[1.7,2)",
             com.hazelcast.*;version="[3.6,4)",
         </import.package>
+        <dynamic.import.package>*</dynamic.import.package>
         <provide.capability>
 
         </provide.capability>

--- a/modules/carbon-hazelcast/component/src/main/java/org/wso2/carbon/hazelcast/internal/CarbonHazelcastComponent.java
+++ b/modules/carbon-hazelcast/component/src/main/java/org/wso2/carbon/hazelcast/internal/CarbonHazelcastComponent.java
@@ -58,6 +58,10 @@ public class CarbonHazelcastComponent {
                     "conf", "hazelcast", "hazelcast.xml").toString();
 
             Config config = new XmlConfigBuilder(hazelcastFilePath).build();
+            // Set class loader of this class as the Hazelcast class loader
+            // Internally used by Hazelcast for de-serialization and as context class-loader of Hazelcast
+            // internal threads.
+            config.setClassLoader(this.getClass().getClassLoader());
 
             hazelcastInstance = DataHolder.getInstance().getHazelcastOSGiService()
                     .newHazelcastInstance(config);


### PR DESCRIPTION
Set the class loader of carbon Hazelcast bundle as class loader of Hazelcast for de-serialisation of custom objects.

Make custom objects, created by the users of carbon Hazelcast bundle, visible to the class loader of
carbon Hazelcast bundle by adding dynamic imports \* property.

Issue: https://github.com/hazelcast/hazelcast/issues/8139
JIRA: https://wso2.org/jira/browse/CARBON-15892
