### PR TITLE
Handle SQLRecoverableException. Expose remove abandoned properties

### DIFF
--- a/core/org.wso2.carbon.user.api/src/main/java/org/wso2/carbon/user/api/RealmConfiguration.java
+++ b/core/org.wso2.carbon.user.api/src/main/java/org/wso2/carbon/user/api/RealmConfiguration.java
@@ -46,9 +46,12 @@ public class RealmConfiguration {
     protected Map<String, String> authzProperties = new HashMap<String, String>();
     protected Map<String, String> realmProperties = new HashMap<String, String>();
     protected int tenantId;
+    protected int removeAbandonedTimeout;
     protected Date persistedTimestamp;
     protected boolean passwordsExternallyManaged = false;
     protected boolean isPrimary = false;
+   	protected boolean removeAbandoned;
+    protected boolean logAbandoned; 
     protected RealmConfiguration secondaryRealmConfig;
     protected Map<String, Map<String, String>> multipleCredentialProps = new HashMap<String, Map<String, String>>();
 
@@ -97,7 +100,29 @@ public class RealmConfiguration {
     public void setPasswordsExternallyManaged(boolean passwordsExternallyManaged) {
         this.passwordsExternallyManaged = passwordsExternallyManaged;
     }
-
+    public boolean isRemoveAbandoned(){
+    	return this.removeAbandoned;
+    }
+    
+    public void setRemoveAbandoned(boolean remove){
+    	this.removeAbandoned = remove;
+    }
+    
+    public int getRemoveAbandonedTimeout(){
+    	return this.removeAbandonedTimeout;
+    }
+    
+    public void setRemoveAbandonedTimeout(int timeout){
+    	this.removeAbandonedTimeout = timeout;
+    }
+    
+    public boolean isLogAbandoned(){
+    	return this.logAbandoned;
+    }
+    
+    public void setLogAbandoned(boolean shouldLog){
+    	this.logAbandoned = shouldLog;
+    }
     public RealmConfiguration cloneRealmConfigurationWithoutSecondary() throws Exception {
         return cloneRealmConfiguration(false);
     }

--- a/core/org.wso2.carbon.user.api/src/main/java/org/wso2/carbon/user/api/RealmConfiguration.java
+++ b/core/org.wso2.carbon.user.api/src/main/java/org/wso2/carbon/user/api/RealmConfiguration.java
@@ -41,7 +41,7 @@ public class RealmConfiguration {
     protected String description = null;
     protected List<String> restrictedDomainsForSelfSignUp = new ArrayList<String>();
     protected List<String> reservedRoleNames = new ArrayList<String>();
-    ;
+
     protected Map<String, String> userStoreProperties = new HashMap<String, String>();
     protected Map<String, String> authzProperties = new HashMap<String, String>();
     protected Map<String, String> realmProperties = new HashMap<String, String>();
@@ -50,7 +50,7 @@ public class RealmConfiguration {
     protected Date persistedTimestamp;
     protected boolean passwordsExternallyManaged = false;
     protected boolean isPrimary = false;
-   	protected boolean removeAbandoned;
+    protected boolean removeAbandoned;
     protected boolean logAbandoned; 
     protected RealmConfiguration secondaryRealmConfig;
     protected Map<String, Map<String, String>> multipleCredentialProps = new HashMap<String, Map<String, String>>();

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/JDBCRealmConstants.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/JDBCRealmConstants.java
@@ -145,6 +145,9 @@ public final class JDBCRealmConstants {
     public static final String TIME_BETWEEN_EVICTION_RUNS_MILLIS = "timeBetweenEvictionRunsMillis";
     public static final String MIN_EVIC_TABLE_IDLE_TIME_MILLIS = "minEvictableIdleTimeMillis";
     public static final String NUM_TESTS_PEREVICTION_RUN = "numTestsPerEvictionRun";
+    public static final String REMOVE_ABANDONED = "removeAbandoned";
+    public static final String REMOVE_ABANDNONED_TIMEOUT = "removeAbandonedTimeout";
+    public static final String LOG_ABANDONED = "logAbandoned";
     // mssql
     public static final String ADD_USER_TO_ROLE_MSSQL_SQL = "INSERT INTO UM_USER_ROLE (UM_USER_ID, UM_ROLE_ID, UM_TENANT_ID) SELECT (SELECT UM_ID FROM UM_USER WHERE UM_USER_NAME=? AND UM_TENANT_ID=?),(SELECT UM_ID FROM UM_ROLE WHERE UM_ROLE_NAME=? AND UM_TENANT_ID=?),(?)";
     public static final String ADD_ROLE_TO_USER_MSSQL_SQL = "INSERT INTO UM_USER_ROLE (UM_ROLE_ID, UM_USER_ID, UM_TENANT_ID) SELECT (SELECT UM_ID FROM UM_ROLE WHERE UM_ROLE_NAME=? AND UM_TENANT_ID=?),(SELECT UM_ID FROM UM_USER WHERE UM_USER_NAME=? AND UM_TENANT_ID=?), (?)";

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/util/DatabaseUtil.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/util/DatabaseUtil.java
@@ -168,18 +168,18 @@ public class DatabaseUtil {
         }
 		
         if (realmConfig.getUserStoreProperty(JDBCRealmConstants.REMOVE_ABANDONED) != null && 
-        !realmConfig.getUserStoreProperty(JDBCRealmConstants.REMOVE_ABANDONED).trim().equals("")){
-            poolProperties.setRemoveAbandoned(Boolean.parseBoolean(realmConfig.getUserStoreProperty(JDBCRealmConstants.REMOVE_ABANDONED)));
+        		!realmConfig.getUserStoreProperty(JDBCRealmConstants.REMOVE_ABANDONED).trim().equals("")){
+        	poolProperties.setRemoveAbandoned(Boolean.parseBoolean(realmConfig.getUserStoreProperty(JDBCRealmConstants.REMOVE_ABANDONED)));
         }
         
         if (realmConfig.getUserStoreProperty(JDBCRealmConstants.LOG_ABANDONED) != null && 
-                !realmConfig.getUserStoreProperty(JDBCRealmConstants.LOG_ABANDONED).trim().equals("")){
-                    poolProperties.setLogAbandoned(Boolean.parseBoolean(realmConfig.getUserStoreProperty(JDBCRealmConstants.LOG_ABANDONED)));
-                }
+        		!realmConfig.getUserStoreProperty(JDBCRealmConstants.LOG_ABANDONED).trim().equals("")){
+        	poolProperties.setLogAbandoned(Boolean.parseBoolean(realmConfig.getUserStoreProperty(JDBCRealmConstants.LOG_ABANDONED)));
+        }
 
         if (realmConfig.getUserStoreProperty(JDBCRealmConstants.REMOVE_ABANDNONED_TIMEOUT) != null &&
-        		 !realmConfig.getUserStoreProperty(JDBCRealmConstants.REMOVE_ABANDNONED_TIMEOUT).trim().equals("")) {
-            poolProperties.setRemoveAbandonedTimeout(Integer.parseInt(realmConfig.getUserStoreProperty(JDBCRealmConstants.REMOVE_ABANDNONED_TIMEOUT)));
+        		!realmConfig.getUserStoreProperty(JDBCRealmConstants.REMOVE_ABANDNONED_TIMEOUT).trim().equals("")){
+        	poolProperties.setRemoveAbandonedTimeout(Integer.parseInt(realmConfig.getUserStoreProperty(JDBCRealmConstants.REMOVE_ABANDNONED_TIMEOUT)));
         }
     
         return new org.apache.tomcat.jdbc.pool.DataSource(poolProperties);
@@ -255,16 +255,20 @@ public class DatabaseUtil {
         }
 
         if (realmConfig.getRealmProperty(JDBCRealmConstants.REMOVE_ABANDONED) != null) {
-            poolProperties.setRemoveAbandoned(Boolean.parseBoolean(realmConfig.getRealmProperty(JDBCRealmConstants.REMOVE_ABANDONED)));
+            poolProperties.setRemoveAbandoned(Boolean.parseBoolean(realmConfig.getRealmProperty(
+            		JDBCRealmConstants.REMOVE_ABANDONED)));
         }
 
         if (realmConfig.getRealmProperty(JDBCRealmConstants.LOG_ABANDONED) != null) {
-            poolProperties.setLogAbandoned(Boolean.parseBoolean(realmConfig.getRealmProperty(JDBCRealmConstants.LOG_ABANDONED)));
+            poolProperties.setLogAbandoned(Boolean.parseBoolean(realmConfig.getRealmProperty(
+            		JDBCRealmConstants.LOG_ABANDONED)));
         }
 
         if (realmConfig.getRealmProperty(JDBCRealmConstants.REMOVE_ABANDNONED_TIMEOUT) != null) {
-            poolProperties.setRemoveAbandonedTimeout(Integer.parseInt(realmConfig.getRealmProperty(JDBCRealmConstants.REMOVE_ABANDNONED_TIMEOUT)));
+            poolProperties.setRemoveAbandonedTimeout(Integer.parseInt(realmConfig.getRealmProperty(
+            		JDBCRealmConstants.REMOVE_ABANDNONED_TIMEOUT)));
         }
+        
         dataSource = new org.apache.tomcat.jdbc.pool.DataSource(poolProperties);
         return dataSource;
     }
@@ -603,7 +607,7 @@ public class DatabaseUtil {
         if (dbConnection != null) {
             try {
 				if (dbConnection != null && !dbConnection.isClosed()) {
-                dbConnection.close();
+					dbConnection.close();
 				}
             } catch (SQLRecoverableException ex) {
                 handleSQLRecoverableException(dbConnection, ex);
@@ -649,22 +653,22 @@ public class DatabaseUtil {
 				handleSQLRecoverableException(dbConnection, ex);
 	    	}
     	} catch (SQLException e) {
-            log.error("Error occurred during SQLRecoverableException handling." + e.getMessage());
+            log.error("Error occurred during SQLRecoverableException handling.", e);
     	}
     }
     
-    	private static void handleSQLRecoverableException(Connection dbConnection, SQLRecoverableException ex) {
-        log.warn("Attempting recovery from thrown SQLRecoverableException ..." + ex.getLocalizedMessage(), ex);
+    private static void handleSQLRecoverableException(Connection dbConnection, SQLRecoverableException ex) {
+        log.info("Attempting recovery from thrown SQLRecoverableException ..." + ex.getLocalizedMessage(), ex);
         try {
-        	if(dbConnection != null && !dbConnection.isClosed()){
-        			dbConnection.close();
+        	if(dbConnection != null){
+        		dbConnection.close();
         		
         	}else{
             	String reason = dbConnection == null? "database connection is null" : dbConnection.isClosed()? "database connection is closed": "unknown";
         		log.warn("Couldn't recover from SQLRecoverableException - cause: " + reason);
         	}
         } catch (SQLException e) {
-            log.error("Error occurred during SQLRecoverableException handling." + e.getMessage());
+            log.error("Error occurred during SQLRecoverableException handling." + e.getLocalizedMessage(),e); 
         }
     }
   

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/util/DatabaseUtil.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/util/DatabaseUtil.java
@@ -25,14 +25,10 @@ import org.wso2.carbon.user.api.RealmConfiguration;
 import org.wso2.carbon.user.core.UserStoreException;
 import org.wso2.carbon.user.core.jdbc.JDBCRealmConstants;
 
+import javax.lang.model.type.UnknownTypeException;
 import javax.naming.InitialContext;
 import javax.sql.DataSource;
-import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.sql.SQLRecoverableException;
-import java.sql.Timestamp;
+import java.sql.*;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
@@ -92,64 +88,57 @@ public class DatabaseUtil {
         if (dataSourceName != null) {
             return lookupDataSource(dataSourceName);
         }
+
         PoolProperties poolProperties = new PoolProperties();
         poolProperties.setDriverClassName(realmConfig.getUserStoreProperty(JDBCRealmConstants.DRIVER_NAME));
         if (poolProperties.getDriverClassName() == null) {
             return null;
         }
+
         poolProperties.setUrl(realmConfig.getUserStoreProperty(JDBCRealmConstants.URL));
         poolProperties.setUsername(realmConfig.getUserStoreProperty(JDBCRealmConstants.USER_NAME));
         poolProperties.setPassword(realmConfig.getUserStoreProperty(JDBCRealmConstants.PASSWORD));
 
-        if (realmConfig.getUserStoreProperty(JDBCRealmConstants.MAX_ACTIVE) != null &&
-                !realmConfig.getUserStoreProperty(JDBCRealmConstants.MAX_ACTIVE).trim().equals("")) {
+        if (StringUtils.isNotEmpty(realmConfig.getUserStoreProperty(JDBCRealmConstants.MAX_ACTIVE))) {
             poolProperties.setMaxActive(Integer.parseInt(realmConfig.getUserStoreProperty(
                     JDBCRealmConstants.MAX_ACTIVE)));
         } else {
             poolProperties.setMaxActive(DEFAULT_MAX_ACTIVE);
         }
 
-        if (realmConfig.getUserStoreProperty(JDBCRealmConstants.MIN_IDLE) != null &&
-                !realmConfig.getUserStoreProperty(JDBCRealmConstants.MIN_IDLE).trim().equals("")) {
+        if (StringUtils.isNotEmpty(realmConfig.getUserStoreProperty(JDBCRealmConstants.MIN_IDLE))) {
             poolProperties.setMinIdle(Integer.parseInt(realmConfig.getUserStoreProperty(
                     JDBCRealmConstants.MIN_IDLE)));
         } else {
             poolProperties.setMinIdle(DEFAULT_MIN_IDLE);
         }
 
-        if (realmConfig.getUserStoreProperty(JDBCRealmConstants.MAX_IDLE) != null &&
-                !realmConfig.getUserStoreProperty(JDBCRealmConstants.MAX_IDLE).trim().equals("")) {
+        if (StringUtils.isNotEmpty(realmConfig.getUserStoreProperty(JDBCRealmConstants.MAX_IDLE))) {
             poolProperties.setMinIdle(Integer.parseInt(realmConfig.getUserStoreProperty(
                     JDBCRealmConstants.MAX_IDLE)));
         } else {
             poolProperties.setMinIdle(DEFAULT_MAX_IDLE);
         }
 
-        if (realmConfig.getUserStoreProperty(JDBCRealmConstants.MAX_WAIT) != null &&
-                !realmConfig.getUserStoreProperty(JDBCRealmConstants.MAX_WAIT).trim().equals("")) {
+        if (StringUtils.isNotEmpty(realmConfig.getUserStoreProperty(JDBCRealmConstants.MAX_WAIT))) {
             poolProperties.setMaxWait(Integer.parseInt(realmConfig.getUserStoreProperty(
                     JDBCRealmConstants.MAX_WAIT)));
         } else {
             poolProperties.setMaxWait(DEFAULT_MAX_WAIT);
         }
 
-        if (realmConfig.getUserStoreProperty(JDBCRealmConstants.TEST_WHILE_IDLE) != null &&
-                !realmConfig.getUserStoreProperty(JDBCRealmConstants.TEST_WHILE_IDLE).trim().equals("")) {
+        if (StringUtils.isNotEmpty(realmConfig.getUserStoreProperty(JDBCRealmConstants.TEST_WHILE_IDLE))) {
             poolProperties.setTestWhileIdle(Boolean.parseBoolean(realmConfig.getUserStoreProperty(
                     JDBCRealmConstants.TEST_WHILE_IDLE)));
         }
 
-        if (realmConfig.getUserStoreProperty(JDBCRealmConstants.TIME_BETWEEN_EVICTION_RUNS_MILLIS) != null &&
-                !realmConfig.getUserStoreProperty(
-                        JDBCRealmConstants.TIME_BETWEEN_EVICTION_RUNS_MILLIS).trim().equals("")) {
+        if (StringUtils.isNotEmpty( realmConfig.getUserStoreProperty(JDBCRealmConstants.TIME_BETWEEN_EVICTION_RUNS_MILLIS))) {
             poolProperties.setTimeBetweenEvictionRunsMillis(Integer.parseInt(
                     realmConfig.getUserStoreProperty(
                             JDBCRealmConstants.TIME_BETWEEN_EVICTION_RUNS_MILLIS)));
         }
 
-        if (realmConfig.getUserStoreProperty(JDBCRealmConstants.MIN_EVIC_TABLE_IDLE_TIME_MILLIS) != null &&
-                !realmConfig.getUserStoreProperty(
-                        JDBCRealmConstants.MIN_EVIC_TABLE_IDLE_TIME_MILLIS).trim().equals("")) {
+        if (StringUtils.isNotEmpty( realmConfig.getUserStoreProperty(JDBCRealmConstants.MIN_EVIC_TABLE_IDLE_TIME_MILLIS))) {
             poolProperties.setMinEvictableIdleTimeMillis(Integer.parseInt(realmConfig.getUserStoreProperty(
                     JDBCRealmConstants.MIN_EVIC_TABLE_IDLE_TIME_MILLIS)));
         }
@@ -167,18 +156,15 @@ public class DatabaseUtil {
             poolProperties.setValidationInterval(DEFAULT_VALIDATION_INTERVAL);
         }
 		
-        if (realmConfig.getUserStoreProperty(JDBCRealmConstants.REMOVE_ABANDONED) != null && 
-        		!realmConfig.getUserStoreProperty(JDBCRealmConstants.REMOVE_ABANDONED).trim().equals("")){
+        if (StringUtils.isNotEmpty( realmConfig.getUserStoreProperty(JDBCRealmConstants.REMOVE_ABANDONED))){
         	poolProperties.setRemoveAbandoned(Boolean.parseBoolean(realmConfig.getUserStoreProperty(JDBCRealmConstants.REMOVE_ABANDONED)));
         }
         
-        if (realmConfig.getUserStoreProperty(JDBCRealmConstants.LOG_ABANDONED) != null && 
-        		!realmConfig.getUserStoreProperty(JDBCRealmConstants.LOG_ABANDONED).trim().equals("")){
+        if (StringUtils.isNotEmpty(realmConfig.getUserStoreProperty(JDBCRealmConstants.LOG_ABANDONED))){
         	poolProperties.setLogAbandoned(Boolean.parseBoolean(realmConfig.getUserStoreProperty(JDBCRealmConstants.LOG_ABANDONED)));
         }
 
-        if (realmConfig.getUserStoreProperty(JDBCRealmConstants.REMOVE_ABANDNONED_TIMEOUT) != null &&
-        		!realmConfig.getUserStoreProperty(JDBCRealmConstants.REMOVE_ABANDNONED_TIMEOUT).trim().equals("")){
+        if (StringUtils.isNotEmpty(realmConfig.getUserStoreProperty(JDBCRealmConstants.REMOVE_ABANDNONED_TIMEOUT))){
         	poolProperties.setRemoveAbandonedTimeout(Integer.parseInt(realmConfig.getUserStoreProperty(JDBCRealmConstants.REMOVE_ABANDNONED_TIMEOUT)));
         }
     
@@ -556,40 +542,40 @@ public class DatabaseUtil {
         }
     }
 
-    public static void updateDatabase(Connection dbConnection, String sqlStmt, Object... params)
-            throws UserStoreException {
-        PreparedStatement prepStmt = null;
-        try {
-            prepStmt = dbConnection.prepareStatement(sqlStmt);
-            if (params != null && params.length > 0) {
-                for (int i = 0; i < params.length; i++) {
-                    Object param = params[i];
-                    if (param == null) {
-                        //allow to send null data since null allowed values can be in the table. eg: domain name
-                        prepStmt.setString(i + 1, null);
-                        //throw new UserStoreException("Null data provided.");
-                    } else if (param instanceof String) {
-                        prepStmt.setString(i + 1, (String) param);
-                    } else if (param instanceof Integer) {
-                        prepStmt.setInt(i + 1, (Integer) param);
-                    } else if (param instanceof Short) {
-                        prepStmt.setShort(i + 1, (Short) param);
-                    } else if (param instanceof Date) {
-                        Date date = (Date) param;
-                        Timestamp time = new Timestamp(date.getTime());
-                        prepStmt.setTimestamp(i + 1, time);
-                    }
+    private static PreparedStatement getPreparedStatement(Connection dbConnection, String sqlStmt, Object... params) throws SQLException {
+
+        PreparedStatement preparedStatement = dbConnection.prepareStatement(sqlStmt);
+        if (params != null) {
+
+            int index = 1;
+            for (Object param : params) {
+                if (param == null || param instanceof String){
+                    //allow to send null data since null allowed values can be in the table. eg: domain name
+                    preparedStatement.setString(index++, (String) param);
+                }else if (param instanceof Integer){
+                    preparedStatement.setInt(index++, (Integer) param);
+                }else if (param instanceof Short) {
+                    preparedStatement.setShort(index++, (Short) param);
+                }else if (param instanceof Date) {
+                    Timestamp time = new Timestamp(((Date) param).getTime());
+                    preparedStatement.setTimestamp(index++, time);
                 }
             }
+        }
+        return preparedStatement;
+    }
+
+    public static void updateDatabase(Connection dbConnection, String sqlStmt, Object... params)
+            throws UserStoreException {
+        try ( PreparedStatement prepStmt = getPreparedStatement(dbConnection, sqlStmt,params)) {
             prepStmt.executeUpdate();
+            DatabaseUtil.closeAllConnections(null, prepStmt);
         } catch (SQLException e) {
             String errorMessage = "Using sql : " + sqlStmt + " " + e.getMessage();
             if (log.isDebugEnabled()) {
                 log.debug(errorMessage, e);
             }
             throw new UserStoreException(errorMessage, e);
-        } finally {
-            DatabaseUtil.closeAllConnections(null, prepStmt);
         }
     }
 
@@ -603,14 +589,12 @@ public class DatabaseUtil {
     }
 
     public static void closeConnection(Connection dbConnection) {
-
         if (dbConnection != null) {
+
             try {
-				if (dbConnection != null && !dbConnection.isClosed()) {
-					dbConnection.close();
-				}
+                dbConnection.close();
             } catch (SQLRecoverableException ex) {
-                handleSQLRecoverableException(dbConnection, ex);
+                handleSQLRecoverableException(dbConnection, ex, true);
             } catch (SQLException e) {
                 log.error("Database error. Could not close statement. Continuing with others. - " + e.getMessage(), e);
             }
@@ -618,17 +602,15 @@ public class DatabaseUtil {
     }
 
     private static void closeResultSet(ResultSet rs) {
-
         if (rs != null) {
             try {
                 rs.close();
-				} catch (SQLRecoverableException ex) {
-                handleSQLRecoverableException(ex);
+            } catch (SQLRecoverableException ex) {
+                handleSQLRecoverableException(rs,ex, true);
             } catch (SQLException e) {
                 log.error("Database error. Could not close result set  - " + e.getMessage(), e);
             }
         }
-
     }
 
     private static void closeStatement(PreparedStatement preparedStatement) {
@@ -637,41 +619,39 @@ public class DatabaseUtil {
             try {
                 preparedStatement.close();
             } catch (SQLRecoverableException ex) {
-                handleSQLRecoverableException(ex);
+                handleSQLRecoverableException(preparedStatement, ex, true);
             } catch (SQLException e) {
                 log.error("Database error. Could not close statement. Continuing with others. - " + e.getMessage(), e);
             }
         }
-
     }
 
-    private static void handleSQLRecoverableException(SQLRecoverableException ex){
-		Connection dbConnection;
-    	try {
-	    	if(dataSource != null){
-	    		dbConnection = getDBConnection(dataSource);
-				handleSQLRecoverableException(dbConnection, ex);
-	    	}
-    	} catch (SQLException e) {
-            log.error("Error occurred during SQLRecoverableException handling.", e);
-    	}
-    }
-    
-    private static void handleSQLRecoverableException(Connection dbConnection, SQLRecoverableException ex) {
-        log.info("Attempting recovery from thrown SQLRecoverableException ..." + ex.getLocalizedMessage(), ex);
-        try {
-        	if(dbConnection != null){
-        		dbConnection.close();
-        		
-        	}else{
-            	String reason = dbConnection == null? "database connection is null" : dbConnection.isClosed()? "database connection is closed": "unknown";
-        		log.warn("Couldn't recover from SQLRecoverableException - cause: " + reason);
-        	}
-        } catch (SQLException e) {
-            log.error("Error occurred during SQLRecoverableException handling." + e.getLocalizedMessage(),e); 
+    private static void handleSQLRecoverableException(Object dbObject, SQLRecoverableException ex, boolean retry){
+        log.error("SQLRecoverable exception encountered.  Attempting recovery.", ex);
+
+        try{
+            if (dbObject instanceof ResultSet) {
+                ((ResultSet)dbObject).close();
+            } else if(dbObject instanceof  PreparedStatement) {
+                ((PreparedStatement)dbObject).close();
+            } else if( dbObject instanceof Connection ) {
+                ((Connection)dbObject).close();
+            } else { // wrong caller for method
+                throw new UnknownTypeException(null,dbObject);
+            }
+        } catch (SQLRecoverableException recException){
+            // retry on first failure only
+            if(retry) {
+                handleSQLRecoverableException(dbObject, recException, false);
+            }else{
+                log.error("Recovery failed for SQLRecoverableError - exiting recovery.", recException);
+            }
+        }
+        catch (SQLException sqlEx){
+            log.error("Database error. Could not close result set  - " + sqlEx.getMessage(), sqlEx);
         }
     }
-  
+
     private static void closeStatements(PreparedStatement... prepStmts) {
 
         if (prepStmts != null && prepStmts.length > 0) {
@@ -683,13 +663,11 @@ public class DatabaseUtil {
     }
 
     public static void closeAllConnections(Connection dbConnection, PreparedStatement... prepStmts) {
-
         closeStatements(prepStmts);
         closeConnection(dbConnection);
     }
 
     public static void closeAllConnections(Connection dbConnection, ResultSet rs, PreparedStatement... prepStmts) {
-
         closeResultSet(rs);
         closeStatements(prepStmts);
         closeConnection(dbConnection);

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/util/DatabaseUtil.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/util/DatabaseUtil.java
@@ -40,6 +40,8 @@ public class DatabaseUtil {
     private static final int DEFAULT_MIN_IDLE = 5;
     private static final int DEFAULT_MAX_IDLE = 6;
     private static Log log = LogFactory.getLog(DatabaseUtil.class);
+
+
     private static DataSource dataSource = null;
     private static final String VALIDATION_INTERVAL = "validationInterval";
     private static final long DEFAULT_VALIDATION_INTERVAL = 30000;
@@ -295,6 +297,8 @@ public class DatabaseUtil {
             }
             throw new UserStoreException(errorMessage, e);
 
+        }finally {
+            close(dbConnection);
         }
     }
 
@@ -337,6 +341,8 @@ public class DatabaseUtil {
                 log.debug(errorMessage, e);
             }
             throw new UserStoreException(errorMessage, e);
+        }finally {
+            close(dbConnection);
         }
     }
 
@@ -369,6 +375,8 @@ public class DatabaseUtil {
                 log.debug(errorMessage, e);
             }
             throw new UserStoreException(errorMessage, e);
+        }finally {
+            close(dbConnection);
         }
     }
 
@@ -427,9 +435,7 @@ public class DatabaseUtil {
             }
             throw new UserStoreException(errorMessage, e);
         } finally {  // can remove since this is not needed with try-with-resources -
-            if (localConnection) {
-                DatabaseUtil.closeAllConnections(dbConnection);
-            }
+            close(dbConnection);
         }
     }
 
@@ -470,9 +476,7 @@ public class DatabaseUtil {
             }
             throw new UserStoreException(errorMessage, e);
         } finally {
-            if (localConnection) {
-                DatabaseUtil.closeAllConnections(dbConnection);
-            }
+            close(dbConnection);
         }
     }
 
@@ -519,9 +523,7 @@ public class DatabaseUtil {
             }
             throw new UserStoreException(errorMessage, e);
         } finally {
-            if (localConnection) {
-                DatabaseUtil.closeAllConnections(dbConnection);
-            }
+            close(dbConnection);
         }
     }
 
@@ -557,6 +559,8 @@ public class DatabaseUtil {
                 log.debug(errorMessage, e);
             }
             throw new UserStoreException(errorMessage, e);
+        } finally {
+            close(dbConnection);
         }
     }
 
@@ -588,6 +592,7 @@ public class DatabaseUtil {
 
             try {
                 dbObject.close();
+                dbObject = null;
             } catch (SQLRecoverableException ex) {
                 handleSQLRecoverableException(dbObject, ex, true);
             } catch (SQLException e) {
@@ -610,7 +615,7 @@ public class DatabaseUtil {
                 handleSQLRecoverableException(connection, recException, false);
                 } catch (SQLException | NullPointerException nullOrSqlException){
                     if(dataSource == null)
-                        log.error("Null encountered during recovery", nullOrSqlException);
+                        log.error("Null encountered during sqlrecoverable error recovery", nullOrSqlException);
                     else
                         log.error("Recovery failed for SQLRecoverableError - exiting recovery.", nullOrSqlException);
                 }

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/util/DatabaseUtil.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/util/DatabaseUtil.java
@@ -27,12 +27,7 @@ import org.wso2.carbon.user.core.jdbc.JDBCRealmConstants;
 
 import javax.naming.InitialContext;
 import javax.sql.DataSource;
-import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.sql.SQLRecoverableException;
-import java.sql.Timestamp;
+import java.sql.*;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
@@ -92,64 +87,57 @@ public class DatabaseUtil {
         if (dataSourceName != null) {
             return lookupDataSource(dataSourceName);
         }
+
         PoolProperties poolProperties = new PoolProperties();
         poolProperties.setDriverClassName(realmConfig.getUserStoreProperty(JDBCRealmConstants.DRIVER_NAME));
         if (poolProperties.getDriverClassName() == null) {
             return null;
         }
+
         poolProperties.setUrl(realmConfig.getUserStoreProperty(JDBCRealmConstants.URL));
         poolProperties.setUsername(realmConfig.getUserStoreProperty(JDBCRealmConstants.USER_NAME));
         poolProperties.setPassword(realmConfig.getUserStoreProperty(JDBCRealmConstants.PASSWORD));
 
-        if (realmConfig.getUserStoreProperty(JDBCRealmConstants.MAX_ACTIVE) != null &&
-                !realmConfig.getUserStoreProperty(JDBCRealmConstants.MAX_ACTIVE).trim().equals("")) {
+        if (StringUtils.isNotEmpty(realmConfig.getUserStoreProperty(JDBCRealmConstants.MAX_ACTIVE))) {
             poolProperties.setMaxActive(Integer.parseInt(realmConfig.getUserStoreProperty(
                     JDBCRealmConstants.MAX_ACTIVE)));
         } else {
             poolProperties.setMaxActive(DEFAULT_MAX_ACTIVE);
         }
 
-        if (realmConfig.getUserStoreProperty(JDBCRealmConstants.MIN_IDLE) != null &&
-                !realmConfig.getUserStoreProperty(JDBCRealmConstants.MIN_IDLE).trim().equals("")) {
+        if (StringUtils.isNotEmpty(realmConfig.getUserStoreProperty(JDBCRealmConstants.MIN_IDLE))) {
             poolProperties.setMinIdle(Integer.parseInt(realmConfig.getUserStoreProperty(
                     JDBCRealmConstants.MIN_IDLE)));
         } else {
             poolProperties.setMinIdle(DEFAULT_MIN_IDLE);
         }
 
-        if (realmConfig.getUserStoreProperty(JDBCRealmConstants.MAX_IDLE) != null &&
-                !realmConfig.getUserStoreProperty(JDBCRealmConstants.MAX_IDLE).trim().equals("")) {
+        if (StringUtils.isNotEmpty(realmConfig.getUserStoreProperty(JDBCRealmConstants.MAX_IDLE))) {
             poolProperties.setMinIdle(Integer.parseInt(realmConfig.getUserStoreProperty(
                     JDBCRealmConstants.MAX_IDLE)));
         } else {
             poolProperties.setMinIdle(DEFAULT_MAX_IDLE);
         }
 
-        if (realmConfig.getUserStoreProperty(JDBCRealmConstants.MAX_WAIT) != null &&
-                !realmConfig.getUserStoreProperty(JDBCRealmConstants.MAX_WAIT).trim().equals("")) {
+        if (StringUtils.isNotEmpty(realmConfig.getUserStoreProperty(JDBCRealmConstants.MAX_WAIT))) {
             poolProperties.setMaxWait(Integer.parseInt(realmConfig.getUserStoreProperty(
                     JDBCRealmConstants.MAX_WAIT)));
         } else {
             poolProperties.setMaxWait(DEFAULT_MAX_WAIT);
         }
 
-        if (realmConfig.getUserStoreProperty(JDBCRealmConstants.TEST_WHILE_IDLE) != null &&
-                !realmConfig.getUserStoreProperty(JDBCRealmConstants.TEST_WHILE_IDLE).trim().equals("")) {
+        if (StringUtils.isNotEmpty(realmConfig.getUserStoreProperty(JDBCRealmConstants.TEST_WHILE_IDLE))) {
             poolProperties.setTestWhileIdle(Boolean.parseBoolean(realmConfig.getUserStoreProperty(
                     JDBCRealmConstants.TEST_WHILE_IDLE)));
         }
 
-        if (realmConfig.getUserStoreProperty(JDBCRealmConstants.TIME_BETWEEN_EVICTION_RUNS_MILLIS) != null &&
-                !realmConfig.getUserStoreProperty(
-                        JDBCRealmConstants.TIME_BETWEEN_EVICTION_RUNS_MILLIS).trim().equals("")) {
+        if (StringUtils.isNotEmpty( realmConfig.getUserStoreProperty(JDBCRealmConstants.TIME_BETWEEN_EVICTION_RUNS_MILLIS))) {
             poolProperties.setTimeBetweenEvictionRunsMillis(Integer.parseInt(
                     realmConfig.getUserStoreProperty(
                             JDBCRealmConstants.TIME_BETWEEN_EVICTION_RUNS_MILLIS)));
         }
 
-        if (realmConfig.getUserStoreProperty(JDBCRealmConstants.MIN_EVIC_TABLE_IDLE_TIME_MILLIS) != null &&
-                !realmConfig.getUserStoreProperty(
-                        JDBCRealmConstants.MIN_EVIC_TABLE_IDLE_TIME_MILLIS).trim().equals("")) {
+        if (StringUtils.isNotEmpty( realmConfig.getUserStoreProperty(JDBCRealmConstants.MIN_EVIC_TABLE_IDLE_TIME_MILLIS))) {
             poolProperties.setMinEvictableIdleTimeMillis(Integer.parseInt(realmConfig.getUserStoreProperty(
                     JDBCRealmConstants.MIN_EVIC_TABLE_IDLE_TIME_MILLIS)));
         }
@@ -167,18 +155,15 @@ public class DatabaseUtil {
             poolProperties.setValidationInterval(DEFAULT_VALIDATION_INTERVAL);
         }
 		
-        if (realmConfig.getUserStoreProperty(JDBCRealmConstants.REMOVE_ABANDONED) != null && 
-        		!realmConfig.getUserStoreProperty(JDBCRealmConstants.REMOVE_ABANDONED).trim().equals("")){
+        if (StringUtils.isNotEmpty( realmConfig.getUserStoreProperty(JDBCRealmConstants.REMOVE_ABANDONED))){
         	poolProperties.setRemoveAbandoned(Boolean.parseBoolean(realmConfig.getUserStoreProperty(JDBCRealmConstants.REMOVE_ABANDONED)));
         }
         
-        if (realmConfig.getUserStoreProperty(JDBCRealmConstants.LOG_ABANDONED) != null && 
-        		!realmConfig.getUserStoreProperty(JDBCRealmConstants.LOG_ABANDONED).trim().equals("")){
+        if (StringUtils.isNotEmpty(realmConfig.getUserStoreProperty(JDBCRealmConstants.LOG_ABANDONED))){
         	poolProperties.setLogAbandoned(Boolean.parseBoolean(realmConfig.getUserStoreProperty(JDBCRealmConstants.LOG_ABANDONED)));
         }
 
-        if (realmConfig.getUserStoreProperty(JDBCRealmConstants.REMOVE_ABANDNONED_TIMEOUT) != null &&
-        		!realmConfig.getUserStoreProperty(JDBCRealmConstants.REMOVE_ABANDNONED_TIMEOUT).trim().equals("")){
+        if (StringUtils.isNotEmpty(realmConfig.getUserStoreProperty(JDBCRealmConstants.REMOVE_ABANDNONED_TIMEOUT))){
         	poolProperties.setRemoveAbandonedTimeout(Integer.parseInt(realmConfig.getUserStoreProperty(JDBCRealmConstants.REMOVE_ABANDNONED_TIMEOUT)));
         }
     
@@ -556,40 +541,40 @@ public class DatabaseUtil {
         }
     }
 
-    public static void updateDatabase(Connection dbConnection, String sqlStmt, Object... params)
-            throws UserStoreException {
-        PreparedStatement prepStmt = null;
-        try {
-            prepStmt = dbConnection.prepareStatement(sqlStmt);
-            if (params != null && params.length > 0) {
-                for (int i = 0; i < params.length; i++) {
-                    Object param = params[i];
-                    if (param == null) {
-                        //allow to send null data since null allowed values can be in the table. eg: domain name
-                        prepStmt.setString(i + 1, null);
-                        //throw new UserStoreException("Null data provided.");
-                    } else if (param instanceof String) {
-                        prepStmt.setString(i + 1, (String) param);
-                    } else if (param instanceof Integer) {
-                        prepStmt.setInt(i + 1, (Integer) param);
-                    } else if (param instanceof Short) {
-                        prepStmt.setShort(i + 1, (Short) param);
-                    } else if (param instanceof Date) {
-                        Date date = (Date) param;
-                        Timestamp time = new Timestamp(date.getTime());
-                        prepStmt.setTimestamp(i + 1, time);
-                    }
+    private static PreparedStatement getPreparedStatement(Connection dbConnection, String sqlStmt, Object... params) throws SQLException {
+
+        PreparedStatement preparedStatement = dbConnection.prepareStatement(sqlStmt);
+        if (params != null) {
+
+            int index = 1;
+            for (Object param : params) {
+                if (param == null || param instanceof String){
+                    //allow to send null data since null allowed values can be in the table. eg: domain name
+                    preparedStatement.setString(index++, (String) param);
+                }else if (param instanceof Integer){
+                    preparedStatement.setInt(index++, (Integer) param);
+                }else if (param instanceof Short) {
+                    preparedStatement.setShort(index++, (Short) param);
+                }else if (param instanceof Date) {
+                    Timestamp time = new Timestamp(((Date) param).getTime());
+                    preparedStatement.setTimestamp(index++, time);
                 }
             }
+        }
+        return preparedStatement;
+    }
+
+    public static void updateDatabase(Connection dbConnection, String sqlStmt, Object... params)
+            throws UserStoreException {
+        try ( PreparedStatement prepStmt = getPreparedStatement(dbConnection, sqlStmt,params)) {
             prepStmt.executeUpdate();
+            DatabaseUtil.closeAllConnections(null, prepStmt);
         } catch (SQLException e) {
             String errorMessage = "Using sql : " + sqlStmt + " " + e.getMessage();
             if (log.isDebugEnabled()) {
                 log.debug(errorMessage, e);
             }
             throw new UserStoreException(errorMessage, e);
-        } finally {
-            DatabaseUtil.closeAllConnections(null, prepStmt);
         }
     }
 
@@ -603,14 +588,12 @@ public class DatabaseUtil {
     }
 
     public static void closeConnection(Connection dbConnection) {
-
         if (dbConnection != null) {
+
             try {
-				if (dbConnection != null && !dbConnection.isClosed()) {
-					dbConnection.close();
-				}
+                dbConnection.close();
             } catch (SQLRecoverableException ex) {
-                handleSQLRecoverableException(dbConnection, ex);
+                handleSQLRecoverableException(dbConnection, ex, true);
             } catch (SQLException e) {
                 log.error("Database error. Could not close statement. Continuing with others. - " + e.getMessage(), e);
             }
@@ -618,17 +601,15 @@ public class DatabaseUtil {
     }
 
     private static void closeResultSet(ResultSet rs) {
-
         if (rs != null) {
             try {
                 rs.close();
-				} catch (SQLRecoverableException ex) {
-                handleSQLRecoverableException(ex);
+            } catch (SQLRecoverableException ex) {
+                handleSQLRecoverableException(rs,ex, true);
             } catch (SQLException e) {
                 log.error("Database error. Could not close result set  - " + e.getMessage(), e);
             }
         }
-
     }
 
     private static void closeStatement(PreparedStatement preparedStatement) {
@@ -637,41 +618,37 @@ public class DatabaseUtil {
             try {
                 preparedStatement.close();
             } catch (SQLRecoverableException ex) {
-                handleSQLRecoverableException(ex);
+                handleSQLRecoverableException(preparedStatement, ex, true);
             } catch (SQLException e) {
                 log.error("Database error. Could not close statement. Continuing with others. - " + e.getMessage(), e);
             }
         }
-
     }
 
-    private static void handleSQLRecoverableException(SQLRecoverableException ex){
-		Connection dbConnection;
-    	try {
-	    	if(dataSource != null){
-	    		dbConnection = getDBConnection(dataSource);
-				handleSQLRecoverableException(dbConnection, ex);
-	    	}
-    	} catch (SQLException e) {
-            log.error("Error occurred during SQLRecoverableException handling.", e);
-    	}
-    }
-    
-    private static void handleSQLRecoverableException(Connection dbConnection, SQLRecoverableException ex) {
-        log.info("Attempting recovery from thrown SQLRecoverableException ..." + ex.getLocalizedMessage(), ex);
-        try {
-        	if(dbConnection != null){
-        		dbConnection.close();
-        		
-        	}else{
-            	String reason = dbConnection == null? "database connection is null" : dbConnection.isClosed()? "database connection is closed": "unknown";
-        		log.warn("Couldn't recover from SQLRecoverableException - cause: " + reason);
-        	}
-        } catch (SQLException e) {
-            log.error("Error occurred during SQLRecoverableException handling." + e.getLocalizedMessage(),e); 
+    private static void handleSQLRecoverableException(Object dbObject, SQLRecoverableException ex, boolean retry){
+        log.error("SQLRecoverable exception encountered.  Attempting recovery.", ex);
+
+        try{
+            if (dbObject instanceof ResultSet) {
+                ((ResultSet)dbObject).close();
+            } else if(dbObject instanceof  PreparedStatement) {
+                ((PreparedStatement)dbObject).close();
+            } else if( dbObject instanceof Connection ) {
+                ((Connection)dbObject).close();
+            }
+        } catch (SQLRecoverableException recException){
+            // retry on first failure only
+            if(retry) {
+                handleSQLRecoverableException(dbObject, recException, false);
+            }else{
+                log.error("Recovery failed for SQLRecoverableError - exiting recovery.", recException);
+            }
+        }
+        catch (SQLException sqlEx){
+            log.error("Database error. Could not close result set  - " + sqlEx.getMessage(), sqlEx);
         }
     }
-  
+
     private static void closeStatements(PreparedStatement... prepStmts) {
 
         if (prepStmts != null && prepStmts.length > 0) {
@@ -683,13 +660,11 @@ public class DatabaseUtil {
     }
 
     public static void closeAllConnections(Connection dbConnection, PreparedStatement... prepStmts) {
-
         closeStatements(prepStmts);
         closeConnection(dbConnection);
     }
 
     public static void closeAllConnections(Connection dbConnection, ResultSet rs, PreparedStatement... prepStmts) {
-
         closeResultSet(rs);
         closeStatements(prepStmts);
         closeConnection(dbConnection);

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/util/DatabaseUtil.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/util/DatabaseUtil.java
@@ -27,12 +27,7 @@ import org.wso2.carbon.user.core.jdbc.JDBCRealmConstants;
 
 import javax.naming.InitialContext;
 import javax.sql.DataSource;
-import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.sql.SQLRecoverableException;
-import java.sql.Timestamp;
+import java.sql.*;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
@@ -575,42 +570,32 @@ public class DatabaseUtil {
     }
 
     public static void closeConnection(Connection dbConnection) {
-
-        if (dbConnection != null) {
-            try {
-                dbConnection.close();
-            } catch (SQLRecoverableException ex) {
-                handleSQLRecoverableException(dbConnection, ex, true);
-            } catch (SQLException e) {
-                log.error("Database error. Could not close statement. Continuing with others. - " + e.getMessage(), e);
-            }
-        }
+        close(dbConnection);
     }
 
-    private static void closeResultSet(ResultSet rs) {
-        if (rs != null) {
-            try {
-                rs.close();
-            } catch (SQLRecoverableException ex) {
-                handleSQLRecoverableException(rs,ex, true);
-            } catch (SQLException e) {
-                log.error("Database error. Could not close result set  - " + e.getMessage(), e);
-            }
-        }
+    // Although using generics is a bit more cryptic to the uninitiated, this method ensures type safety
+    // and flexibility without the horrible cast conversions in
+    // favor of the usage of interfaces.
+    // Only java.sql types can be used as parameters.
+    //
+    // Only  java.sql object types intersect both Wrapper and AutoCloseable interfaces
+    // Types that are allowed as arguments: CachedRowSet, CallableStatement, Connection, DatabaseMetaData, DataSource,
+    // FilteredRowSet, JdbcRowSet, JoinRowSet, ParameterMetaData,
+    // PreparedStatement, ResultSet, ResultSetMetaData, RowSet, RowSetMetaData, Statement, SyncResolver, WebRowSet
+    private static <AutoClosableWrapper extends AutoCloseable & Wrapper> void close(AutoClosableWrapper dbObject) {
 
-    }
+        if (dbObject != null) {
 
-    private static void closeStatement(PreparedStatement preparedStatement) {
-        if (preparedStatement != null) {
             try {
-                preparedStatement.close();
+                dbObject.close();
             } catch (SQLRecoverableException ex) {
-                handleSQLRecoverableException(preparedStatement, ex, true);
+                handleSQLRecoverableException(dbObject, ex, true);
             } catch (SQLException e) {
                 log.error("Database error. Could not close statement. Continuing with others. - " + e.getMessage(), e);
+            } catch (Exception e) {
+                log.error("Generic error occurred during close operation" + e.getMessage(), e);
             }
         }
-
     }
 
     private static void handleSQLRecoverableException(AutoCloseable dbObject, SQLRecoverableException ex, boolean retry){
@@ -623,11 +608,11 @@ public class DatabaseUtil {
             if(retry) {
                 try (Connection connection = getDBConnection(dataSource)){
                 handleSQLRecoverableException(connection, recException, false);
-                } catch (SQLException salException){
-                    log.error("Recovery failed for SQLRecoverableError - exiting recovery.", salException);
-                }catch (NullPointerException nullException){
-                    if(dataSource == null) log.error("DataSource is null", nullException);
-                    else log.error("Null encountered during recovery", nullException);
+                } catch (SQLException | NullPointerException nullOrSqlException){
+                    if(dataSource == null)
+                        log.error("Null encountered during recovery", nullOrSqlException);
+                    else
+                        log.error("Recovery failed for SQLRecoverableError - exiting recovery.", nullOrSqlException);
                 }
             }else{
                 dbObject = null;
@@ -642,35 +627,58 @@ public class DatabaseUtil {
     }
 
     private static void closeStatements(PreparedStatement... prepStmts) {
-
         if (prepStmts != null && prepStmts.length > 0) {
             for (PreparedStatement stmt : prepStmts) {
-                closeStatement(stmt);
+                close(stmt);
             }
         }
+    }
+
+    public static void close(Connection dbConnection, PreparedStatement... prepStmts) {
+        closeStatements(prepStmts);
+        close(dbConnection);
+    }
+
+    public static void close(Connection dbConnection, ResultSet rs, PreparedStatement... prepStmts) {
+        close(rs);
+        closeStatements(prepStmts);
+        close(dbConnection);
 
     }
 
+    public static void close(Connection dbConnection, ResultSet rs1, ResultSet rs2,
+                                           PreparedStatement... prepStmts) {
+        close(rs1);
+        close(rs2);
+        closeStatements(prepStmts);
+        close(dbConnection);
+    }
+
+    /**
+     * Recommend:
+     * @deprecated Should discontinue use in favor of the parametrized close method.
+     */
     public static void closeAllConnections(Connection dbConnection, PreparedStatement... prepStmts) {
-
-        closeStatements(prepStmts);
-        closeConnection(dbConnection);
+        close(dbConnection, prepStmts);
     }
 
+    /**
+     * Recommend:
+     * @deprecated Should discontinue use in favor of the parametrized close method.
+     */
     public static void closeAllConnections(Connection dbConnection, ResultSet rs, PreparedStatement... prepStmts) {
-
-        closeResultSet(rs);
-        closeStatements(prepStmts);
-        closeConnection(dbConnection);
+        close(dbConnection,rs,prepStmts);
     }
 
+    /**
+     * Recommend:
+     * @deprecated Should discontinue use in favor of the parametrized close method.
+     */
     public static void closeAllConnections(Connection dbConnection, ResultSet rs1, ResultSet rs2,
                                            PreparedStatement... prepStmts) {
-        closeResultSet(rs1);
-        closeResultSet(rs2);
-        closeStatements(prepStmts);
-        closeConnection(dbConnection);
+        close(dbConnection, rs1, rs2, prepStmts);
     }
+
 
     public static void rollBack(Connection dbConnection) {
         try {

--- a/core/org.wso2.carbon.user.core/src/test/java/org/wso2/carbon/user/core/util/DatabaseUtilTest.java
+++ b/core/org.wso2.carbon.user.core/src/test/java/org/wso2/carbon/user/core/util/DatabaseUtilTest.java
@@ -1,0 +1,130 @@
+package org.wso2.carbon.user.core.util;
+
+import org.apache.tomcat.jdbc.pool.PoolProperties;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.wso2.carbon.user.api.RealmConfiguration;
+
+import javax.sql.DataSource;
+import java.sql.*;
+
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.*;
+
+public class DatabaseUtilTest {
+
+
+    @Mock DataSource datasource;
+    @Mock Connection conn;
+    @Mock PreparedStatement preparedStatement;
+    @Mock Statement statement;
+    @Mock ResultSet results;
+    @Mock RealmConfiguration realmConfig;
+    @Mock PoolProperties poolProperties;
+
+    @Before
+    public void setUp() throws Exception {
+        MockitoAnnotations.initMocks(this);
+        when(datasource.getConnection()).thenReturn(conn);
+        when(conn.prepareStatement(any(String.class))).thenReturn(preparedStatement);
+        when(statement.getResultSet()).thenReturn(results);
+    }
+
+    @Test
+    public void getDBConnection() throws Exception {
+        // not a true unit test.
+        String url = "jdbc:h2:target/ReadOnlyTest/CARBON_TEST";
+        String driverName = "org.h2.Driver";
+        PoolProperties poolProperties = new PoolProperties();
+        poolProperties.setUrl(url);
+        poolProperties.setDriverClassName(driverName);
+        DataSource fake = new org.apache.tomcat.jdbc.pool.DataSource(poolProperties);
+
+        Assert.assertNotNull(DatabaseUtil.getDBConnection(fake));
+    }
+
+    @Test
+    public void testCloseConnection() throws SQLException {
+        Mockito.doAnswer(RETURNS_MOCKS).when(datasource).getConnection();
+        DatabaseUtil.closeConnection(conn);
+        assertNotNull(conn);
+    }
+
+    @Test
+    public void testCloseConnectionHandlesSQLRecoverableException() throws Exception {
+        try {
+            Mockito.doThrow(new SQLRecoverableException("throw SQLRecoverableException")).when(conn).close();
+            DatabaseUtil.closeConnection(conn);
+        } catch (SQLRecoverableException e) {
+            Assert.assertNull(conn);
+            Assert.assertEquals(SQLRecoverableException.class, e.getClass());
+        }
+    }
+
+    @Test
+    public void testCloseStatements() throws SQLException {
+        when(conn.isClosed()).thenReturn(false);
+        DatabaseUtil.closeAllConnections(conn, preparedStatement);
+    }
+
+    @Test
+    public void testClosePreparedStatementHandlesSQLRecoverableException() {
+        boolean isThrown = false;
+        try {
+            Mockito.doThrow(new SQLRecoverableException("throw SQLRecoverableException")).when(preparedStatement).close();
+            DatabaseUtil.closeAllConnections(conn, preparedStatement);
+        } catch (SQLRecoverableException e) {
+            // this is expected
+            e.printStackTrace();
+            isThrown = true;
+           Assert.assertTrue(isThrown);
+        } catch (SQLException e) {
+            e.printStackTrace();
+            // this shouldn't happen
+            Assert.assertTrue(false);
+        }
+       Assert.assertNotNull(preparedStatement);
+    }
+
+    @Test
+    public void testCloseResultSetHandlesSQLRecoverableException() {
+        try {
+            Mockito.doThrow(new SQLRecoverableException("throw SQLRecoverableException")).when(results).close();
+            DatabaseUtil.closeAllConnections(conn, results, preparedStatement);
+
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+    }
+    @Test
+    public void testCreateUserStoreDataSource() throws Exception {
+        when(realmConfig.isLogAbandoned()).thenReturn(true);
+        when(realmConfig.isRemoveAbandoned()).thenReturn(true);
+        when(realmConfig.getRemoveAbandonedTimeout()).thenReturn(100);
+        DatabaseUtil.createUserStoreDataSource(realmConfig);
+
+        Assert.assertTrue(realmConfig.isLogAbandoned());
+        Assert.assertTrue(realmConfig.isRemoveAbandoned());
+        Assert.assertEquals(100, realmConfig.getRemoveAbandonedTimeout());
+        Assert.assertNotNull(datasource.getConnection());
+    }
+
+    @Test
+    public void testNullCreateUserStoreDataSource() throws Exception {
+
+        DatabaseUtil.createUserStoreDataSource(realmConfig);
+
+        Assert.assertFalse(realmConfig.isLogAbandoned());
+        Assert.assertFalse(realmConfig.isRemoveAbandoned());
+        Assert.assertEquals(0, realmConfig.getRemoveAbandonedTimeout());
+
+        Assert.assertEquals(realmConfig.isLogAbandoned(), poolProperties.isLogAbandoned());
+        Assert.assertEquals(realmConfig.isRemoveAbandoned(), poolProperties.isRemoveAbandoned());
+        Assert.assertEquals(realmConfig.getRemoveAbandonedTimeout(), poolProperties.getRemoveAbandonedTimeout());
+    }
+
+}

--- a/core/org.wso2.carbon.user.core/src/test/java/org/wso2/carbon/user/core/util/DatabaseUtilTest.java
+++ b/core/org.wso2.carbon.user.core/src/test/java/org/wso2/carbon/user/core/util/DatabaseUtilTest.java
@@ -41,17 +41,6 @@ public class DatabaseUtilTest {
         when(statement.getResultSet()).thenReturn(resultSetMock);
     }
 
-    //for testing
-    public DataSource getDBConnection() throws Exception {
-        // not a true unit test.
-        String url = "jdbc:h2:target/ReadOnlyTest/CARBON_TEST";
-        String driverName = "org.h2.Driver";
-        PoolProperties poolProperties = new PoolProperties();
-        poolProperties.setUrl(url);
-        poolProperties.setDriverClassName(driverName);
-        return new org.apache.tomcat.jdbc.pool.DataSource(poolProperties);
-    }
-
     @Test
     public void getDBConnectionShouldNotBeNull() throws Exception {
         // not a true unit test.
@@ -67,6 +56,7 @@ public class DatabaseUtilTest {
 
     @Test
     public void closeConnectionShouldNotBeNull() throws SQLException {
+
         Mockito.doAnswer(RETURNS_MOCKS).when(datasource).getConnection();
         DatabaseUtil.closeConnection(conn);
         assertNotNull(conn);
@@ -74,10 +64,10 @@ public class DatabaseUtilTest {
 
     @Test
     public void closeConnectionShouldHandlesSQLRecoverableException() throws Exception {
-        //try {
+
             Mockito.doThrow(new SQLRecoverableException("throw SQLRecoverableException")).when(conn).close();
             DatabaseUtil.closeConnection(conn);
-            System.out.println("Expected error thrown in sqlerecoverable handler");// +  e.getMessage());
+            System.out.println("Expected error thrown in sqlerecoverable handler");
             Assert.assertNotNull(conn);
     }
 
@@ -89,6 +79,7 @@ public class DatabaseUtilTest {
 
     @Test
     public void newClosePreparedStatementShouldHandlesSQLRecoverableException() {
+
         boolean isThrown = false;
         try {
             Mockito.doThrow(new SQLRecoverableException("throw SQLRecoverableException")).when(preparedStatement).close();
@@ -102,8 +93,10 @@ public class DatabaseUtilTest {
         }
         Assert.assertNotNull(preparedStatement);
     }
+
     @Test
     public void testNewCloseResultSetHandlesSQLRecoverableException() {
+
         try {
             Mockito.doThrow(new SQLRecoverableException("throw SQLRecoverableException")).when(resultSetMock).close();
             DatabaseUtil.close(conn, resultSetMock, preparedStatement);
@@ -112,15 +105,16 @@ public class DatabaseUtilTest {
             log.error("Unexpected error thrown in sqlerecoverable handler" +  e.getMessage(), e);
         }
     }
-
     @Test
     public void testCloseStatements() throws SQLException {
+
         when(conn.isClosed()).thenReturn(false);
         DatabaseUtil.closeAllConnections(conn, preparedStatement);
     }
 
     @Test
     public void testClosePreparedStatementHandlesSQLRecoverableException() {
+
         boolean isThrown = false;
         try {
             Mockito.doThrow(new SQLRecoverableException("throw SQLRecoverableException")).when(preparedStatement).close();
@@ -140,6 +134,7 @@ public class DatabaseUtilTest {
 
     @Test
     public void testCloseResultSetHandlesSQLRecoverableException() {
+
         try {
             Mockito.doThrow(new SQLRecoverableException("throw SQLRecoverableException")).when(resultSetMock).close();
             DatabaseUtil.closeAllConnections(conn, resultSetMock, preparedStatement);
@@ -148,6 +143,7 @@ public class DatabaseUtilTest {
             log.error("Unexpected error thrown in sqlerecoverable handler" +  e.getMessage(), e);
         }
     }
+
     @Test
     public void testCreateUserStoreDataSource() throws Exception {
 
@@ -161,7 +157,6 @@ public class DatabaseUtilTest {
         Assert.assertEquals(100, realmConfig.getRemoveAbandonedTimeout());
         Assert.assertNotNull(datasource.getConnection());
     }
-
     @Test
     public void testNullCreateUserStoreDataSource() throws Exception {
 
@@ -176,28 +171,8 @@ public class DatabaseUtilTest {
         Assert.assertEquals(realmConfig.getRemoveAbandonedTimeout(), poolProperties.getRemoveAbandonedTimeout());
     }
 
-
     @Test
     public void getStringValuesFromDatabaseShouldReturnValues() throws Exception{
-
-//        String sqlStmt = "update people set firstname=? , lastname=? where id=?";
-//
-//        List<Object> params = new ArrayList<>();
-//        params.add("Jack");
-//        params.add("Smith");
-//        params.add(100);
-//
-//        List<Object> resultSetAnswers = new ArrayList<>();
-//        resultSetAnswers.add("Value1");
-//        resultSetAnswers.add("Value2");
-//        resultSetAnswers.add("100");
-//
-//        when(conn.prepareStatement(sqlStmt)).thenReturn(preparedStatement);
-//        when(preparedStatement.executeQuery()).thenReturn(resultSetMock);
-//        when(resultSetMock.getString(1)).thenReturn( (String) resultSetAnswers.get(0), (String) resultSetAnswers.get(1), (String) resultSetAnswers.get(2));
-//
-//        Mockito.when(resultSetMock.next()).thenReturn(true).thenReturn(true).thenReturn(true).thenReturn(false);
-//        Mockito.doReturn(resultSetMock).when(callableStatementMock).getResultSet();
 
         ResultSetMocker resultSetMocker = new ResultSetMocker().invoke();
         String sqlStmt = resultSetMocker.getSqlStmt();
@@ -211,8 +186,10 @@ public class DatabaseUtilTest {
         Assert.assertEquals(resultSetAnswers.get(2), results[2]);
     }
 
+
     @Test (expected = UserStoreException.class)
     public void getStringValuesFromDatabaseShouldHandleSQLRecoverableException() throws Exception{
+
         // cannot handle sqlerecoverable for resultsets
         ResultSetMocker resultSetMocker = new ResultSetMocker().invoke();
         String sqlStmt = resultSetMocker.getSqlStmt();
@@ -225,10 +202,23 @@ public class DatabaseUtilTest {
 
     @Test
     public void getCurrentRuntime(){
+
         Assert.assertTrue(System.getProperties().getProperty("java.version").contains("1.7"));
     }
 
+    public DataSource getDBConnection() throws Exception {
+
+        // not a true unit test.
+        String url = "jdbc:h2:target/ReadOnlyTest/CARBON_TEST";
+        String driverName = "org.h2.Driver";
+        PoolProperties poolProperties = new PoolProperties();
+        poolProperties.setUrl(url);
+        poolProperties.setDriverClassName(driverName);
+        return new org.apache.tomcat.jdbc.pool.DataSource(poolProperties);
+    }
+
     private class ResultSetMocker {
+
         private String sqlStmt;
         private List<Object> params;
         private List<Object> resultSetAnswers;
@@ -250,7 +240,7 @@ public class DatabaseUtilTest {
         }
 
         public ResultSetMocker invoke() throws SQLException {
-//            sqlStmt = "update people set firstname=? , lastname=? where id=?";
+
             sqlStmt = "SELECT  * FROM people WHHERE firstname=? AND lastname=? AND id=?";
 
             params = new ArrayList<>();

--- a/core/org.wso2.carbon.user.core/src/test/java/org/wso2/carbon/user/core/util/DatabaseUtilTest.java
+++ b/core/org.wso2.carbon.user.core/src/test/java/org/wso2/carbon/user/core/util/DatabaseUtilTest.java
@@ -66,6 +66,41 @@ public class DatabaseUtilTest {
     }
 
     @Test
+    public void testNewCloseStatements() throws SQLException {
+        when(conn.isClosed()).thenReturn(false);
+        DatabaseUtil.close(conn, preparedStatement);
+    }
+
+    @Test
+    public void testNewClosePreparedStatementHandlesSQLRecoverableException() {
+        boolean isThrown = false;
+        try {
+            Mockito.doThrow(new SQLRecoverableException("throw SQLRecoverableException")).when(preparedStatement).close();
+            DatabaseUtil.close(conn, preparedStatement);
+        } catch (SQLRecoverableException e) {
+            // this is expected
+            e.printStackTrace();
+            isThrown = true;
+            Assert.assertTrue(isThrown);
+        } catch (SQLException e) {
+            e.printStackTrace();
+            // this shouldn't happen
+            Assert.assertTrue(false);
+        }
+        Assert.assertNotNull(preparedStatement);
+    }
+    @Test
+    public void testNewCloseResultSetHandlesSQLRecoverableException() {
+        try {
+            Mockito.doThrow(new SQLRecoverableException("throw SQLRecoverableException")).when(results).close();
+            DatabaseUtil.close(conn, results, preparedStatement);
+
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Test
     public void testCloseStatements() throws SQLException {
         when(conn.isClosed()).thenReturn(false);
         DatabaseUtil.closeAllConnections(conn, preparedStatement);
@@ -127,4 +162,8 @@ public class DatabaseUtilTest {
         Assert.assertEquals(realmConfig.getRemoveAbandonedTimeout(), poolProperties.getRemoveAbandonedTimeout());
     }
 
+    @Test
+    public void getCurrentRuntime(){
+        Assert.assertTrue(System.getProperties().getProperty("java.version").contains("1.7"));
+    }
 }

--- a/core/org.wso2.carbon.user.core/src/test/java/org/wso2/carbon/user/core/util/DatabaseUtilTest.java
+++ b/core/org.wso2.carbon.user.core/src/test/java/org/wso2/carbon/user/core/util/DatabaseUtilTest.java
@@ -1,5 +1,7 @@
 package org.wso2.carbon.user.core.util;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.apache.tomcat.jdbc.pool.PoolProperties;
 import org.junit.Assert;
 import org.junit.Before;
@@ -8,34 +10,50 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.wso2.carbon.user.api.RealmConfiguration;
+import org.wso2.carbon.user.api.UserStoreException;
 
 import javax.sql.DataSource;
 import java.sql.*;
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.*;
 
 public class DatabaseUtilTest {
 
+    private static Log log = LogFactory.getLog(DatabaseUtil.class);
 
     @Mock DataSource datasource;
     @Mock Connection conn;
     @Mock PreparedStatement preparedStatement;
     @Mock Statement statement;
-    @Mock ResultSet results;
+    @Mock ResultSet resultSetMock;
     @Mock RealmConfiguration realmConfig;
     @Mock PoolProperties poolProperties;
+    @Mock CallableStatement callableStatementMock;
 
     @Before
     public void setUp() throws Exception {
         MockitoAnnotations.initMocks(this);
         when(datasource.getConnection()).thenReturn(conn);
         when(conn.prepareStatement(any(String.class))).thenReturn(preparedStatement);
-        when(statement.getResultSet()).thenReturn(results);
+        when(statement.getResultSet()).thenReturn(resultSetMock);
+    }
+
+    //for testing
+    public DataSource getDBConnection() throws Exception {
+        // not a true unit test.
+        String url = "jdbc:h2:target/ReadOnlyTest/CARBON_TEST";
+        String driverName = "org.h2.Driver";
+        PoolProperties poolProperties = new PoolProperties();
+        poolProperties.setUrl(url);
+        poolProperties.setDriverClassName(driverName);
+        return new org.apache.tomcat.jdbc.pool.DataSource(poolProperties);
     }
 
     @Test
-    public void getDBConnection() throws Exception {
+    public void getDBConnectionShouldNotBeNull() throws Exception {
         // not a true unit test.
         String url = "jdbc:h2:target/ReadOnlyTest/CARBON_TEST";
         String driverName = "org.h2.Driver";
@@ -48,42 +66,37 @@ public class DatabaseUtilTest {
     }
 
     @Test
-    public void testCloseConnection() throws SQLException {
+    public void closeConnectionShouldNotBeNull() throws SQLException {
         Mockito.doAnswer(RETURNS_MOCKS).when(datasource).getConnection();
         DatabaseUtil.closeConnection(conn);
         assertNotNull(conn);
     }
 
     @Test
-    public void testCloseConnectionHandlesSQLRecoverableException() throws Exception {
-        try {
+    public void closeConnectionShouldHandlesSQLRecoverableException() throws Exception {
+        //try {
             Mockito.doThrow(new SQLRecoverableException("throw SQLRecoverableException")).when(conn).close();
             DatabaseUtil.closeConnection(conn);
-        } catch (SQLRecoverableException e) {
-            Assert.assertNull(conn);
-            Assert.assertEquals(SQLRecoverableException.class, e.getClass());
-        }
+            System.out.println("Expected error thrown in sqlerecoverable handler");// +  e.getMessage());
+            Assert.assertNotNull(conn);
     }
 
     @Test
-    public void testNewCloseStatements() throws SQLException {
+    public void newCloseStatementsShouldBBeSameResult() throws SQLException {
         when(conn.isClosed()).thenReturn(false);
         DatabaseUtil.close(conn, preparedStatement);
     }
 
     @Test
-    public void testNewClosePreparedStatementHandlesSQLRecoverableException() {
+    public void newClosePreparedStatementShouldHandlesSQLRecoverableException() {
         boolean isThrown = false;
         try {
             Mockito.doThrow(new SQLRecoverableException("throw SQLRecoverableException")).when(preparedStatement).close();
             DatabaseUtil.close(conn, preparedStatement);
         } catch (SQLRecoverableException e) {
-            // this is expected
-            e.printStackTrace();
             isThrown = true;
             Assert.assertTrue(isThrown);
         } catch (SQLException e) {
-            e.printStackTrace();
             // this shouldn't happen
             Assert.assertTrue(false);
         }
@@ -92,11 +105,11 @@ public class DatabaseUtilTest {
     @Test
     public void testNewCloseResultSetHandlesSQLRecoverableException() {
         try {
-            Mockito.doThrow(new SQLRecoverableException("throw SQLRecoverableException")).when(results).close();
-            DatabaseUtil.close(conn, results, preparedStatement);
+            Mockito.doThrow(new SQLRecoverableException("throw SQLRecoverableException")).when(resultSetMock).close();
+            DatabaseUtil.close(conn, resultSetMock, preparedStatement);
 
         } catch (SQLException e) {
-            e.printStackTrace();
+            log.error("Unexpected error thrown in sqlerecoverable handler" +  e.getMessage(), e);
         }
     }
 
@@ -114,9 +127,9 @@ public class DatabaseUtilTest {
             DatabaseUtil.closeAllConnections(conn, preparedStatement);
         } catch (SQLRecoverableException e) {
             // this is expected
-            e.printStackTrace();
             isThrown = true;
            Assert.assertTrue(isThrown);
+
         } catch (SQLException e) {
             e.printStackTrace();
             // this shouldn't happen
@@ -128,15 +141,16 @@ public class DatabaseUtilTest {
     @Test
     public void testCloseResultSetHandlesSQLRecoverableException() {
         try {
-            Mockito.doThrow(new SQLRecoverableException("throw SQLRecoverableException")).when(results).close();
-            DatabaseUtil.closeAllConnections(conn, results, preparedStatement);
+            Mockito.doThrow(new SQLRecoverableException("throw SQLRecoverableException")).when(resultSetMock).close();
+            DatabaseUtil.closeAllConnections(conn, resultSetMock, preparedStatement);
 
         } catch (SQLException e) {
-            e.printStackTrace();
+            log.error("Unexpected error thrown in sqlerecoverable handler" +  e.getMessage(), e);
         }
     }
     @Test
     public void testCreateUserStoreDataSource() throws Exception {
+
         when(realmConfig.isLogAbandoned()).thenReturn(true);
         when(realmConfig.isRemoveAbandoned()).thenReturn(true);
         when(realmConfig.getRemoveAbandonedTimeout()).thenReturn(100);
@@ -162,8 +176,100 @@ public class DatabaseUtilTest {
         Assert.assertEquals(realmConfig.getRemoveAbandonedTimeout(), poolProperties.getRemoveAbandonedTimeout());
     }
 
+
+    @Test
+    public void getStringValuesFromDatabaseShouldReturnValues() throws Exception{
+
+//        String sqlStmt = "update people set firstname=? , lastname=? where id=?";
+//
+//        List<Object> params = new ArrayList<>();
+//        params.add("Jack");
+//        params.add("Smith");
+//        params.add(100);
+//
+//        List<Object> resultSetAnswers = new ArrayList<>();
+//        resultSetAnswers.add("Value1");
+//        resultSetAnswers.add("Value2");
+//        resultSetAnswers.add("100");
+//
+//        when(conn.prepareStatement(sqlStmt)).thenReturn(preparedStatement);
+//        when(preparedStatement.executeQuery()).thenReturn(resultSetMock);
+//        when(resultSetMock.getString(1)).thenReturn( (String) resultSetAnswers.get(0), (String) resultSetAnswers.get(1), (String) resultSetAnswers.get(2));
+//
+//        Mockito.when(resultSetMock.next()).thenReturn(true).thenReturn(true).thenReturn(true).thenReturn(false);
+//        Mockito.doReturn(resultSetMock).when(callableStatementMock).getResultSet();
+
+        ResultSetMocker resultSetMocker = new ResultSetMocker().invoke();
+        String sqlStmt = resultSetMocker.getSqlStmt();
+        List<Object> params = resultSetMocker.getParams();
+        List<Object> resultSetAnswers = resultSetMocker.getResultSetAnswers();
+
+        String[] results =   DatabaseUtil.getStringValuesFromDatabase(conn, sqlStmt, params.get(0), params.get(1), params.get(2));
+
+        Assert.assertEquals( resultSetAnswers.get(0), results[0]);
+        Assert.assertEquals(resultSetAnswers.get(1), results[1]);
+        Assert.assertEquals(resultSetAnswers.get(2), results[2]);
+    }
+
+    @Test (expected = UserStoreException.class)
+    public void getStringValuesFromDatabaseShouldHandleSQLRecoverableException() throws Exception{
+        // cannot handle sqlerecoverable for resultsets
+        ResultSetMocker resultSetMocker = new ResultSetMocker().invoke();
+        String sqlStmt = resultSetMocker.getSqlStmt();
+        List<Object> params = resultSetMocker.getParams();
+        Mockito.doThrow(new SQLRecoverableException("throw SQLRecoverableException")).when(resultSetMocker.get()).next();
+
+        String[] results =   DatabaseUtil.getStringValuesFromDatabase(conn, sqlStmt, params.get(0), params.get(1), params.get(2));
+        Assert.fail("Can not handle SQLRecoverableError" );
+    }
+
     @Test
     public void getCurrentRuntime(){
         Assert.assertTrue(System.getProperties().getProperty("java.version").contains("1.7"));
+    }
+
+    private class ResultSetMocker {
+        private String sqlStmt;
+        private List<Object> params;
+        private List<Object> resultSetAnswers;
+
+        public String getSqlStmt() {
+            return sqlStmt;
+        }
+
+        public List<Object> getParams() {
+            return params;
+        }
+
+        public List<Object> getResultSetAnswers() {
+            return resultSetAnswers;
+        }
+
+        public ResultSet get(){
+            return resultSetMock;
+        }
+
+        public ResultSetMocker invoke() throws SQLException {
+//            sqlStmt = "update people set firstname=? , lastname=? where id=?";
+            sqlStmt = "SELECT  * FROM people WHHERE firstname=? AND lastname=? AND id=?";
+
+            params = new ArrayList<>();
+            params.add("Jack");
+            params.add("Smith");
+            params.add(100);
+
+            resultSetAnswers = new ArrayList<>();
+            resultSetAnswers.add("Value1");
+            resultSetAnswers.add("Value2");
+            resultSetAnswers.add("100");
+
+            when(conn.prepareStatement(sqlStmt)).thenReturn(preparedStatement);
+            when(preparedStatement.executeQuery()).thenReturn(resultSetMock);
+            when(resultSetMock.getString(1)).thenReturn( (String) resultSetAnswers.get(0), (String) resultSetAnswers.get(1), (String) resultSetAnswers.get(2));
+
+            Mockito.when(resultSetMock.next()).thenReturn(true).thenReturn(true).thenReturn(true).thenReturn(false);
+            Mockito.doReturn(resultSetMock).when(callableStatementMock).getResultSet();
+            return this;
+        }
     }
 }


### PR DESCRIPTION
Minor code changes to handle the sqlrecoverableexception in databaseutils, and expose properties on the realm configuration to periodically test and recover abandoned connections in the pool.
