### PR TITLE
CARBON-15971: Should be able to enable or disable SAML Assertion Signature validation in the SAML Carbon Authenticator

### DIFF
--- a/distribution/kernel/carbon-home/repository/conf/security/authenticators.xml
+++ b/distribution/kernel/carbon-home/repository/conf/security/authenticators.xml
@@ -39,6 +39,7 @@
 
             <!-- <Parameter name="IdPCertAlias">wso2carbon</Parameter> -->
             <!-- <Parameter name="ResponseSignatureValidationEnabled">false</Parameter> -->
+            <!-- <Parameter name="AssertionSignatureValidationEnabled">false</Parameter> -->
             <!-- <Parameter name="LoginAttributeName"></Parameter> -->
             <!-- <Parameter name="RoleClaimAttribute"></Parameter> -->
             <!-- <Parameter name="AttributeValueSeparator">,</Parameter> -->


### PR DESCRIPTION
SAML Carbon authenticator enforces assertion signature validation by default with [1]. 
This fix adds the respective configuration that provides the ability to disable that if required.

[1] https://wso2.org/jira/browse/IDENTITY-4737
