### PR TITLE
Fix for CARBON-16006

### DIFF
--- a/distribution/kernel/carbon-home/repository/conf/tomcat/carbon/WEB-INF/web.xml
+++ b/distribution/kernel/carbon-home/repository/conf/tomcat/carbon/WEB-INF/web.xml
@@ -23,7 +23,7 @@
     <!-- OWASP CSRFGuard per-application configuration property file location-->
     <context-param>
         <param-name>Owasp.CsrfGuard.Config</param-name>
-        <param-value>/repository/conf/security/Owasp.CsrfGuard.Carbon.properties</param-value>
+        <param-value>repository/conf/security/Owasp.CsrfGuard.Carbon.properties</param-value>
     </context-param>
 
     <servlet id="bridge">


### PR DESCRIPTION
Kernel CSRF Guard property file not fetched with IBM JDK and Dev Studio
