### PR TITLE
Fixing CARBON-16050

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/authorization/AuthorizationCache.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/authorization/AuthorizationCache.java
@@ -253,17 +253,7 @@ public class AuthorizationCache {
      */
     public void clearCacheByTenant(int tenantId) {
         Cache<AuthorizationKey, AuthorizeCacheEntry> cache = this.getAuthorizationCache();
-        // check for null
-        if (isCacheNull(cache)) {
-            return;
-        }
-
-        for (Cache.Entry<AuthorizationKey, AuthorizeCacheEntry> entry : cache) {
-            AuthorizationKey authorizationKey = entry.getKey();
-            if (tenantId == (authorizationKey.getTenantId())) {
-                cache.remove(authorizationKey);
-            }
-        }
+        cache.removeAll();
     }
 
     /**

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/authorization/AuthorizationCache.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/authorization/AuthorizationCache.java
@@ -253,7 +253,10 @@ public class AuthorizationCache {
      */
     public void clearCacheByTenant(int tenantId) {
         Cache<AuthorizationKey, AuthorizeCacheEntry> cache = this.getAuthorizationCache();
-        cache.removeAll();
+
+        if (!isCacheNull(cache)) {
+            cache.removeAll();
+        }
     }
 
     /**


### PR DESCRIPTION
Qutoting findings of @hevayo,

> The issue exist in "clearCacheByTenant" function in AuthorizationCache.java [1]. Here the function tries to remove tenant specific cache entries from the Authorization cache. 
> 
> To do above function fetch all cache keys and iterate them and if the key belongs to the current tenant call the remove method. But when function fetches the cache keys it only get the keys of local cache entries. Because of the above reason in a distributed setup some of the tenant specific cache entries might not get removed. 
> 
> [1] https://github.com/wso2/carbon-kernel/blob/v4.4.3/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/authorization/AuthorizationCache.java#L254-L268
