### PR TITLE
CARBON-16062: Fixing the issue of primaryHazelcastConfig being null 

### DIFF
--- a/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/clustering/hazelcast/HazelcastClusteringAgent.java
+++ b/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/clustering/hazelcast/HazelcastClusteringAgent.java
@@ -483,7 +483,7 @@ public class HazelcastClusteringAgent extends ParameterAdapter implements Cluste
         } else {
             Parameter classNameParameter = parameters.get(MEMBERSHIP_SCHEME_CLASS_NAME);
             if(classNameParameter != null) {
-                initiateCustomMembershipScheme(classNameParameter);
+                initiateCustomMembershipScheme(classNameParameter, primaryHazelcastConfig);
             } else {
                 String msg = "Invalid membership scheme '" + scheme +
                         "'. Supported schemes are multicast & wka";
@@ -493,14 +493,14 @@ public class HazelcastClusteringAgent extends ParameterAdapter implements Cluste
         } //TODO: AWS membership scheme support
     }
 
-    private void initiateCustomMembershipScheme(Parameter classNameParameter) throws ClusteringFault {
+    private void initiateCustomMembershipScheme(Parameter classNameParameter, Config primaryHazelcastConfig) throws ClusteringFault {
         String className = (String) classNameParameter.getValue();
         try {
             Class membershipSchemeClass = Class.forName(className);
             try {
                 membershipScheme = (HazelcastMembershipScheme) membershipSchemeClass.getConstructor(
                         Map.class, String.class, Config.class, HazelcastInstance.class, List.class).newInstance(
-                        parameters, primaryDomain, primaryHazelcastConfig, primaryHazelcastInstance,
+                        parameters, primaryDomain, this.primaryHazelcastConfig, primaryHazelcastInstance,
                         sentMsgsBuffer);
                 membershipScheme.init();
             } catch (InstantiationException e) {

--- a/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/clustering/hazelcast/HazelcastClusteringAgent.java
+++ b/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/clustering/hazelcast/HazelcastClusteringAgent.java
@@ -500,7 +500,7 @@ public class HazelcastClusteringAgent extends ParameterAdapter implements Cluste
             try {
                 membershipScheme = (HazelcastMembershipScheme) membershipSchemeClass.getConstructor(
                         Map.class, String.class, Config.class, HazelcastInstance.class, List.class).newInstance(
-                        parameters, primaryDomain, this.primaryHazelcastConfig, primaryHazelcastInstance,
+                        parameters, primaryDomain, primaryHazelcastConfig, primaryHazelcastInstance,
                         sentMsgsBuffer);
                 membershipScheme.init();
             } catch (InstantiationException e) {


### PR DESCRIPTION
It looks like HazelcastClusteringAgent class has slightly changed recently and as a result primaryHazelcastConfig class variable is not initialized at the time initiateCustomMembershipScheme() method is invoked.

This pull request fixes that by passing method local primaryHazelcastConfig object to initiateCustomMembershipScheme() method.
