### PR TITLE
CARBON-16067: Changed Maven Assembly Plugin goal to single

### DIFF
--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -228,7 +228,7 @@
                         <id>distribution</id>
                         <phase>package</phase>
                         <goals>
-                            <goal>attached</goal>
+                            <goal>single</goal>
                         </goals>
                         <configuration>
                             <filters>

--- a/tests/test-distribution/pom.xml
+++ b/tests/test-distribution/pom.xml
@@ -138,7 +138,7 @@
                         <id>make-assembly</id>
                         <phase>package</phase>
                         <goals>
-                            <goal>attached</goal>
+                            <goal>single</goal>
                         </goals>
                     </execution>
                 </executions>


### PR DESCRIPTION
Maven Assembly Plugin goal:attached is deprecated and it is recommended to use the goal:single