### PR TITLE
Replace "$" with "jQuery" in dialog.js

### DIFF
--- a/core/org.wso2.carbon.ui/src/main/resources/web/dialog/js/dialog.js
+++ b/core/org.wso2.carbon.ui/src/main/resources/web/dialog/js/dialog.js
@@ -15,7 +15,7 @@ var pageLoaded = false;
  * @param {String} value html value to be encoded
  */ 
 function htmlEncode(value){
-  return $('<div/>').text(value).html();
+  return jQuery('<div/>').text(value).html();
 }
 
 jQuery(document).ready(function() {


### PR DESCRIPTION
It is recommended to use "jQuery" in case another function is defined with "$"
by some other javascript library.