### PR TITLE
Fix CARBON-16119

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/DefaultRealmService.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/DefaultRealmService.java
@@ -64,7 +64,7 @@ public class DefaultRealmService implements RealmService {
 
     private static final Log log = LogFactory.getLog(DefaultRealmService.class);
     private static final String PRIMARY_TENANT_REALM = "primary";
-    private static final String DB_CHECK_SQL = "select * from UM_USER";
+    private static final String DB_CHECK_SQL = "select * from UM_SYSTEM_USER";
     //to track whether this is the first time initialization of the pack.
     private static boolean isFirstInitialization = true;
     private RealmCache realmCache = RealmCache.getInstance();


### PR DESCRIPTION
"java.lang.OutOfMemoryError: GC overhead limit exceeded" issue observed when the server is started with -Dsetup for UM_USER table containing large data set ~ 1 million.