### PR TITLE
Update org.wso2.carbon.runtime.feature to org.wso2.carbon.osgi.feature

### DIFF
--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -53,7 +53,7 @@
         </dependency>
         <dependency>
             <groupId>org.wso2.carbon</groupId>
-            <artifactId>org.wso2.carbon.runtime.feature</artifactId>
+            <artifactId>org.wso2.carbon.osgi.feature</artifactId>
             <type>zip</type>
         </dependency>
     </dependencies>
@@ -123,7 +123,7 @@
                                     <version>${carbon.kernel.version}</version>
                                 </feature>
                                 <feature>
-                                    <id>org.wso2.carbon.runtime.feature</id>
+                                    <id>org.wso2.carbon.osgi.feature</id>
                                     <version>${carbon.kernel.version}</version>
                                 </feature>
                             </features>
@@ -172,7 +172,7 @@
                                     <version>${carbon.kernel.version}</version>
                                 </feature>
                                 <feature>
-                                    <id>org.wso2.carbon.runtime.feature.group</id>
+                                    <id>org.wso2.carbon.osgi.feature.group</id>
                                     <version>${carbon.kernel.version}</version>
                                 </feature>
                             </features>

--- a/features/org.wso2.carbon.osgi.feature/pom.xml
+++ b/features/org.wso2.carbon.osgi.feature/pom.xml
@@ -23,13 +23,13 @@
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
-    <artifactId>org.wso2.carbon.runtime.feature</artifactId>
+    <artifactId>org.wso2.carbon.osgi.feature</artifactId>
     <packaging>carbon-feature</packaging>
-    <name>WSO2 Carbon Kernel - Runtime Feature</name>
+    <name>WSO2 Carbon Kernel - OSGi Feature</name>
     <url>http://wso2.com</url>
     <description>
-        This feature contains the carbon core runtime related bundles and their dependencies
-        Eg : (OSGi Runtime, Declarative Service Runtime, Console, etc)
+        This feature contains the core OSGi runtime related bundles and their dependencies
+        Eg : (OSGi Runtime, Declarative Service Runtime, OSGi Console, etc)
     </description>
 
     <dependencies>

--- a/features/pom.xml
+++ b/features/pom.xml
@@ -33,7 +33,7 @@
     <modules>
         <module>org.wso2.carbon.touchpoint.feature</module>
         <module>org.wso2.carbon.kernel.feature</module>
-        <module>org.wso2.carbon.runtime.feature</module>
+        <module>org.wso2.carbon.osgi.feature</module>
     </modules>
 
 </project>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -200,7 +200,7 @@
             </dependency>
             <dependency>
                 <groupId>org.wso2.carbon</groupId>
-                <artifactId>org.wso2.carbon.runtime.feature</artifactId>
+                <artifactId>org.wso2.carbon.osgi.feature</artifactId>
                 <version>${carbon.kernel.version}</version>
                 <type>zip</type>
             </dependency>
@@ -680,7 +680,7 @@
         <geronimo.atinject.spec.version>1.0</geronimo.atinject.spec.version>
 
         <!--Other dependency versions -->
-        <carbon.feature.plugin.version>3.1.0</carbon.feature.plugin.version>
+        <carbon.feature.plugin.version>3.1.1</carbon.feature.plugin.version>
         <org.snakeyaml.version>1.17</org.snakeyaml.version>
         <org.snakeyaml.package.import.version.range>[1.17.0,2.0.0)</org.snakeyaml.package.import.version.range>
         <testng.version>6.9.4</testng.version>


### PR DESCRIPTION
- Changing the name of org.wso2.carbon.runtime.feature to org.wso2.carbon.osgi.feature
- This is required as we are now using the "runtime" team with carbon servers where a single distribution can have multiple runtimes and the above name may conflict and confuse.
- The above feature actually packs all the OSGi related runtime bundles as a single feature and proper name would be "org.wso2.carbon.osgi.feature"
- This support required a new release of carbon-feature-plugin as currently the name "org.wso2.carbon.runtime" was hardcoded in the feature plugin.
- Resolves #1262