### PR TITLE
CARBON-16113: Fix for "transport starts before Carbon apps are deployed"

### DIFF
--- a/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/internal/StartupFinalizerServiceComponent.java
+++ b/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/internal/StartupFinalizerServiceComponent.java
@@ -154,6 +154,8 @@ public class StartupFinalizerServiceComponent implements ServiceListener {
 
     private void completeInitialization(BundleContext bundleContext) {
         //Add CAppDeployer to deployment engine
+        /* notify listeners of server startup before transport starts */
+        CarbonCoreServiceComponent.notifyBefore();
 
         bundleContext.removeServiceListener(this);
         pendingServicesObservationTimer.cancel();
@@ -181,9 +183,6 @@ public class StartupFinalizerServiceComponent implements ServiceListener {
             throw new RuntimeException(msg, e);
         }
 
-        /* notify listeners of server startup before transport starts */
-        CarbonCoreServiceComponent.notifyBefore();
-        
         if (CarbonUtils.isRunningInStandaloneMode()) {
             try {
                 Class<?> transportManagerClass = Class.forName(TRANSPORT_MANAGER);


### PR DESCRIPTION
This PR carries necessary fixes to deploy Carbon apps before starting the transport.
- Public JIRA: [CARBON-16113](https://wso2.org/jira/browse/CARBON-16113)