### PR TITLE
Upgrade archetype plugin and add archetype tests

### DIFF
--- a/archetypes/carbon-bundle-archetype/src/test/resources/projects/bundle/archetype.properties
+++ b/archetypes/carbon-bundle-archetype/src/test/resources/projects/bundle/archetype.properties
@@ -1,0 +1,4 @@
+groupId=org.test
+artifactId=org.test.bundle
+version=1.0.0
+package=org.test.bundle

--- a/archetypes/carbon-bundle-archetype/src/test/resources/projects/bundle/goal.txt
+++ b/archetypes/carbon-bundle-archetype/src/test/resources/projects/bundle/goal.txt
@@ -1,0 +1,1 @@
+clean install verify

--- a/archetypes/carbon-bundle-archetype/src/test/resources/projects/bundle/reference/pom.xml
+++ b/archetypes/carbon-bundle-archetype/src/test/resources/projects/bundle/reference/pom.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.test</groupId>
+    <artifactId>org.test.bundle</artifactId>
+    <version>1.0.0</version>
+    <packaging>bundle</packaging>
+    <name>WSO2 Carbon - Sample OSGi Bundle</name>
+    <url>http://wso2.com</url>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.core</artifactId>
+            <version>^osgi.core.api.version^</version>
+        </dependency>
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <version>^testng.version^</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>^maven.bundle.plugin.version^</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-Activator>org.test.bundle.internal.Activator</Bundle-Activator>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Bundle-Name>${project.artifactId}</Bundle-Name>
+                        <Private-package>org.test.bundle.internal</Private-package>
+                        <Export-package>
+                            !org.test.bundle.internal,
+                            org.test.bundle.*;version="${project.version}"
+                        </Export-package>
+                        <Import-Package>
+                            org.osgi.framework.*;version="^osgi.framework.package.import.version.range^"
+                        </Import-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/archetypes/carbon-bundle-archetype/src/test/resources/projects/bundle/reference/src/main/java/org/test/bundle/Greeter.java
+++ b/archetypes/carbon-bundle-archetype/src/test/resources/projects/bundle/reference/src/main/java/org/test/bundle/Greeter.java
@@ -1,0 +1,47 @@
+/*
+ *  Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.test.bundle;
+
+import java.util.logging.Logger;
+
+/**
+ * This class greets.
+ *
+ * @since 1.0.0
+ */
+public class Greeter {
+    Logger logger = Logger.getLogger(Greeter.class.getName());
+
+    private String name;
+
+    public Greeter(String name) {
+        this.name = name;
+    }
+
+    /**
+     * This method outputs an info log saying Hello.
+     */
+    public void hello() {
+        logger.info("Hello " + name);
+    }
+
+    /**
+     * This method outputs an info log saying bye.
+     */
+    public void bye() {
+        logger.info("Bye " + name);
+    }
+}

--- a/archetypes/carbon-bundle-archetype/src/test/resources/projects/bundle/reference/src/main/java/org/test/bundle/internal/Activator.java
+++ b/archetypes/carbon-bundle-archetype/src/test/resources/projects/bundle/reference/src/main/java/org/test/bundle/internal/Activator.java
@@ -1,0 +1,50 @@
+/*
+ *  Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.test.bundle.internal;
+
+import org.osgi.framework.BundleActivator;
+import org.osgi.framework.BundleContext;
+import org.test.bundle.Greeter;
+
+/**
+ * This is a sample bundle activator class.
+ *
+ * @since 1.0.0
+ */
+public class Activator implements BundleActivator {
+    private Greeter greeter;
+
+    /**
+     * This is called when the bundle is started.
+     *
+     * @param bundleContext BundleContext of this bundle
+     * @throws Exception Could be thrown while bundle starting
+     */
+    public void start(BundleContext bundleContext) throws Exception {
+        greeter =  new Greeter("WSO2");
+        greeter.hello();
+    }
+
+    /**
+     * This is called when the bundle is stopped.
+     *
+     * @param bundleContext BundleContext of this bundle
+     * @throws Exception Could be thrown while bundle stopping
+     */
+    public void stop(BundleContext bundleContext) throws Exception {
+        greeter.bye();
+    }
+}

--- a/archetypes/carbon-bundle-archetype/src/test/resources/projects/bundle/reference/src/test/java/org/test/bundle/GreeterTest.java
+++ b/archetypes/carbon-bundle-archetype/src/test/resources/projects/bundle/reference/src/test/java/org/test/bundle/GreeterTest.java
@@ -1,0 +1,31 @@
+/*
+ *  Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.test.bundle;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * Unit test for Greeter class.
+ *
+ * @since 1.0.0
+ */
+public class GreeterTest {
+    @Test
+    public void shouldAnswerWithTrue() {
+        Assert.assertTrue(true);
+    }
+}

--- a/archetypes/carbon-component-archetype/src/test/resources/projects/component/archetype.properties
+++ b/archetypes/carbon-component-archetype/src/test/resources/projects/component/archetype.properties
@@ -1,0 +1,4 @@
+groupId=org.test
+artifactId=org.test.component
+version=1.0.0
+package=org.test.component

--- a/archetypes/carbon-component-archetype/src/test/resources/projects/component/goal.txt
+++ b/archetypes/carbon-component-archetype/src/test/resources/projects/component/goal.txt
@@ -1,0 +1,1 @@
+clean install verify

--- a/archetypes/carbon-component-archetype/src/test/resources/projects/component/reference/pom.xml
+++ b/archetypes/carbon-component-archetype/src/test/resources/projects/component/reference/pom.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <parent>
+        <groupId>org.wso2.carbon</groupId>
+        <artifactId>carbon-kernel-parent</artifactId>
+        <version>^project.version^</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.test</groupId>
+    <artifactId>org.test.component</artifactId>
+    <version>1.0.0</version>
+    <packaging>bundle</packaging>
+    <name>WSO2 Carbon - Sample Carbon Component</name>
+    <description>
+        This is a sample implementation of a Carbon Component
+        which consumes an OSGi service registered by Carbon Kernel
+        and registers another OSGi service
+    </description>
+    <url>http://wso2.com</url>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon</groupId>
+            <artifactId>org.wso2.carbon.core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.eclipse.osgi</groupId>
+            <artifactId>org.eclipse.osgi.services</artifactId>
+        </dependency>
+    </dependencies>
+
+    <properties>
+        <private.package>org.test.component.internal</private.package>
+        <export.package>
+            !org.test.component.internal,
+            org.test.component.*;version="^project.version^"
+        </export.package>
+        <import.package>
+            org.osgi.framework.*;version="^osgi.framework.package.import.version.range^",
+            org.wso2.carbon.kernel;version="^carbon.kernel.package.import.version.range^"
+        </import.package>
+    </properties>
+
+</project>

--- a/archetypes/carbon-component-archetype/src/test/resources/projects/component/reference/src/main/java/org/test/component/Greeter.java
+++ b/archetypes/carbon-component-archetype/src/test/resources/projects/component/reference/src/main/java/org/test/component/Greeter.java
@@ -1,0 +1,28 @@
+/*
+ *  Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.test.component;
+
+/**
+ * This interface contains methods for greeting.
+ *
+ * @since 1.0.0
+ */
+public interface Greeter {
+
+    void hello();
+
+    void bye();
+}

--- a/archetypes/carbon-component-archetype/src/test/resources/projects/component/reference/src/main/java/org/test/component/GreeterImpl.java
+++ b/archetypes/carbon-component-archetype/src/test/resources/projects/component/reference/src/main/java/org/test/component/GreeterImpl.java
@@ -1,0 +1,47 @@
+/*
+ *  Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.test.component;
+
+import java.util.logging.Logger;
+
+/**
+ * This class implements the Greeter interface.
+ *
+ * @since 1.0.0
+ */
+public class GreeterImpl implements Greeter {
+    Logger logger = Logger.getLogger(GreeterImpl.class.getName());
+
+    private String name;
+
+    public GreeterImpl(String name) {
+        this.name = name;
+    }
+
+    /**
+     * Output an info log saying Hello.
+     */
+    public void hello() {
+        logger.info("Hello" + name);
+    }
+
+    /**
+     * Outputs an info log saying bye.
+     */
+    public void bye() {
+        logger.info("Bye " + name);
+    }
+}

--- a/archetypes/carbon-component-archetype/src/test/resources/projects/component/reference/src/main/java/org/test/component/internal/DataHolder.java
+++ b/archetypes/carbon-component-archetype/src/test/resources/projects/component/reference/src/main/java/org/test/component/internal/DataHolder.java
@@ -1,0 +1,65 @@
+/*
+ *  Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.test.component.internal;
+
+import org.wso2.carbon.kernel.CarbonRuntime;
+
+import java.util.logging.Logger;
+
+/**
+ * DataHolder to hold org.wso2.carbon.kernel.CarbonRuntime instance referenced through
+ * org.wso2.carbon.helloworld.internal.ServiceComponent.
+ *
+ * @since 1.0.0
+ */
+public class DataHolder {
+    Logger logger = Logger.getLogger(DataHolder.class.getName());
+
+    private static DataHolder instance = new DataHolder();
+    private CarbonRuntime carbonRuntime;
+
+    private DataHolder() {
+
+    }
+
+    /**
+     * This returns the DataHolder instance.
+     *
+     * @return The DataHolder instance of this singleton class
+     */
+    public static DataHolder getInstance() {
+        return instance;
+    }
+
+    /**
+     * Returns the CarbonRuntime service which gets set through a service component.
+     *
+     * @return CarbonRuntime Service
+     */
+    public CarbonRuntime getCarbonRuntime() {
+        return carbonRuntime;
+    }
+
+    /**
+     * This method is for setting the CarbonRuntime service. This method is used by
+     * ServiceComponent.
+     *
+     * @param carbonRuntime The reference being passed through ServiceComponent
+     */
+    public void setCarbonRuntime(CarbonRuntime carbonRuntime) {
+        this.carbonRuntime = carbonRuntime;
+    }
+}

--- a/archetypes/carbon-component-archetype/src/test/resources/projects/component/reference/src/main/java/org/test/component/internal/ServiceComponent.java
+++ b/archetypes/carbon-component-archetype/src/test/resources/projects/component/reference/src/main/java/org/test/component/internal/ServiceComponent.java
@@ -1,0 +1,100 @@
+/*
+ *  Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.test.component.internal;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceRegistration;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.test.component.Greeter;
+import org.test.component.GreeterImpl;
+import org.wso2.carbon.kernel.CarbonRuntime;
+
+import java.util.logging.Logger;
+
+/**
+ * Service component to consume CarbonRuntime instance which has been registered as an OSGi service
+ * by Carbon Kernel.
+ *
+ * @since 1.0.0
+ */
+@Component(
+        name = "org.test.component.internal.ServiceComponent",
+        immediate = true
+)
+public class ServiceComponent {
+
+    Logger logger = Logger.getLogger(ServiceComponent.class.getName());
+    private ServiceRegistration serviceRegistration;
+
+    /**
+     * This is the activation method of ServiceComponent. This will be called when its references are
+     * satisfied.
+     *
+     * @param bundleContext the bundle context instance of this bundle.
+     * @throws Exception this will be thrown if an issue occurs while executing the activate method
+     */
+    @Activate
+    protected void start(BundleContext bundleContext) throws Exception {
+        logger.info("Service Component is activated");
+
+        // Register GreeterImpl instance as an OSGi service.
+        serviceRegistration = bundleContext.registerService(Greeter.class.getName(), new GreeterImpl("WSO2"), null);
+    }
+
+    /**
+     * This is the deactivation method of ServiceComponent. This will be called when this component
+     * is being stopped or references are satisfied during runtime.
+     *
+     * @throws Exception this will be thrown if an issue occurs while executing the de-activate method
+     */
+    @Deactivate
+    protected void stop() throws Exception {
+        logger.info("Service Component is deactivated");
+
+        // Unregister Greeter OSGi service
+        serviceRegistration.unregister();
+    }
+
+    /**
+     * This bind method will be called when CarbonRuntime OSGi service is registered.
+     *
+     * @param carbonRuntime The CarbonRuntime instance registered by Carbon Kernel as an OSGi service
+     */
+    @Reference(
+            name = "carbon.runtime.service",
+            service = CarbonRuntime.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetCarbonRuntime"
+    )
+    protected void setCarbonRuntime(CarbonRuntime carbonRuntime) {
+        DataHolder.getInstance().setCarbonRuntime(carbonRuntime);
+    }
+
+    /**
+     * This is the unbind method which gets called at the un-registration of CarbonRuntime OSGi service.
+     *
+     * @param carbonRuntime The CarbonRuntime instance registered by Carbon Kernel as an OSGi service
+     */
+    protected void unsetCarbonRuntime(CarbonRuntime carbonRuntime) {
+        DataHolder.getInstance().setCarbonRuntime(null);
+    }
+}

--- a/archetypes/pom.xml
+++ b/archetypes/pom.xml
@@ -47,6 +47,15 @@
                 </includes>
             </resource>
         </resources>
+        <testResources>
+            <testResource>
+                <directory>${project.basedir}/src/test/resources</directory>
+                <filtering>true</filtering>
+                <includes>
+                    <include>**/*</include>
+                </includes>
+            </testResource>
+        </testResources>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/core/src/main/java/org/wso2/carbon/kernel/internal/startupresolver/StartupServiceCache.java
+++ b/core/src/main/java/org/wso2/carbon/kernel/internal/startupresolver/StartupServiceCache.java
@@ -78,7 +78,7 @@ public class StartupServiceCache {
     }
 
     /**
-     * This method provides a map of OSGi services and service count for the given {@code componentName}
+     * This method provides a map of OSGi services and service count for the given {@code componentName}.
      *
      * @param componentName name of the reporter component
      * @return a list of reported OSGi service names

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -114,6 +114,9 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-archetype-plugin</artifactId>
                     <version>${maven.archetype.version}</version>
+                    <configuration>
+                        <ignoreEOLStyle>true</ignoreEOLStyle>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -699,7 +702,7 @@
         <!--Maven Plugins -->
         <maven.wagon.ssh.version>2.1</maven.wagon.ssh.version>
         <maven.paxexam.plugin.version>1.2.4</maven.paxexam.plugin.version>
-        <maven.archetype.version>2.4</maven.archetype.version>
+        <maven.archetype.version>3.0.0</maven.archetype.version>
         <maven.surefire.plugin.version>2.18.1</maven.surefire.plugin.version>
         <maven-project.version>2.2.1</maven-project.version>
         <maven-plugin-api.version>3.3.9</maven-plugin-api.version>

--- a/pom.xml
+++ b/pom.xml
@@ -42,9 +42,11 @@
             </activation>
             <modules>
                 <module>parent</module>
-                <module>archetypes</module>
                 <module>launcher</module>
                 <module>core</module>
+                <!--Need to place archetypes module after core because tests in
+                org.wso2.carbon.archetypes.component depend on org.wso2.carbon.core-->
+                <module>archetypes</module>
                 <module>extensions</module>
                 <module>tools</module>
                 <module>pax-exam-container-carbon</module>


### PR DESCRIPTION
This PR fixes https://wso2.org/jira/browse/CARBON-15747 and https://wso2.org/jira/browse/CARBON-15883.

Here https://github.com/wso2/carbon-kernel/commit/a2fbb31bd7177515eddca72a5cc5087e0fa59490 has been reverted and archetype plugin version has been upgraded.

Also a minor javadoc issue has been fixed here in StartupServiceCache.java which caused the kernel build to fail in windows.