### PR TITLE
Fix DB deadlock error in OIDC flow.

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/JDBCUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/JDBCUserStoreManager.java
@@ -2097,7 +2097,7 @@ public class JDBCUserStoreManager extends AbstractUserStoreManager {
                 Map.Entry<String, String> entry = ite2.next();
                 String claimURI = entry.getKey();
                 String claimValue = claimPropertyMap.get(claimURI);
-                if (availableProperties.containsKey(claimValue)) {
+                if (claimValue != null && availableProperties.containsKey(claimValue)) {
                     String availableValue = availableProperties.get(claimValue);
                     if (availableValue != null && availableValue.equals(entry.getValue())) {
                         continue;

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/JDBCUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/JDBCUserStoreManager.java
@@ -2096,8 +2096,14 @@ public class JDBCUserStoreManager extends AbstractUserStoreManager {
             while (ite2.hasNext()) {
                 Map.Entry<String, String> entry = ite2.next();
                 String claimURI = entry.getKey();
-                if (availableProperties.containsKey(claimPropertyMap.get(claimURI))) {
-                    availableClaims.put(claimURI, entry.getValue());
+                String claimValue = claimPropertyMap.get(claimURI);
+                if (availableProperties.containsKey(claimValue)) {
+                    String availableValue = availableProperties.get(claimValue);
+                    if (availableValue != null && availableValue.equals(entry.getValue())) {
+                        continue;
+                    } else {
+                        availableClaims.put(claimURI, entry.getValue());
+                    }
                 } else {
                     newClaims.put(claimURI, entry.getValue());
                 }


### PR DESCRIPTION
We have fixed DB deadlock error in OIDC flow, by executing update query only if there is a value change for claims. Resolves #1407.