### PR TITLE
Fix adding mapped attributes

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/claim/builder/ClaimBuilder.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/claim/builder/ClaimBuilder.java
@@ -202,7 +202,10 @@ public class ClaimBuilder {
                 attributeId = claimElement.getFirstChildWithName(new QName(LOCAL_NAME_ATTR_ID))
                         .getText();
 
-                claimMapping = new ClaimMapping(claim, attributeId);
+                claimMapping = new ClaimMapping();
+                claimMapping.setClaim(claim);
+                setMappedAttributes(claimMapping, attributeId);
+
                 claims.put(claimUri, claimMapping);
             }
         }
@@ -303,5 +306,38 @@ public class ClaimBuilder {
         OMElement documentElement = builder.getDocumentElement();
 
         return documentElement;
+    }
+
+    /**
+     * Set mapped attributes to claim mapping
+     *
+     * @param claimMapping claim mappings
+     * @param mappedAttribute mapped attributes
+     */
+    private void setMappedAttributes(ClaimMapping claimMapping, String mappedAttribute) {
+        if (mappedAttribute != null) {
+            String[] attributes = mappedAttribute.split(";");
+            Map<String, String> attrMap = new HashMap<>();
+
+            for (int i = 0; i < attributes.length; i++) {
+                int index;
+                if ((index = attributes[i].indexOf("/")) > 1 && attributes[i].indexOf("/") == attributes[i]
+                        .lastIndexOf("/")) {
+                    String domain = attributes[i].substring(0, index);
+                    String attrName = attributes[i].substring(index + 1);
+                    if (domain != null) {
+                        attrMap.put(domain.toUpperCase(), attrName);
+                    } else {
+                        claimMapping.setMappedAttribute(attributes[i]);
+                    }
+                } else {
+                    claimMapping.setMappedAttribute(attributes[i]);
+                }
+            }
+
+            if (attrMap.size() > 0) {
+                claimMapping.setMappedAttributes(attrMap);
+            }
+        }
     }
 }

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/claim/inmemory/FileBasedClaimBuilder.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/claim/inmemory/FileBasedClaimBuilder.java
@@ -130,7 +130,10 @@ public class FileBasedClaimBuilder {
                     }
 
                     propertyHolder.put(claimUri, properties);
-                    claimMapping = new ClaimMapping(claim, attributeId);
+                    claimMapping = new ClaimMapping();
+                    claimMapping.setClaim(claim);
+                    setMappedAttributes(claimMapping, attributeId);
+
                     claims.put(claimUri, claimMapping);
                 }
             }
@@ -215,5 +218,38 @@ public class FileBasedClaimBuilder {
         OMElement documentElement = builder.getDocumentElement();
 
         return documentElement;
+    }
+
+    /**
+     * Set mapped attributes to claim mapping
+     *
+     * @param claimMapping claim mappings
+     * @param mappedAttribute mapped attributes
+     */
+    private static void setMappedAttributes(ClaimMapping claimMapping, String mappedAttribute) {
+        if (mappedAttribute != null) {
+            String[] attributes = mappedAttribute.split(";");
+            Map<String, String> attrMap = new HashMap<>();
+
+            for (int i = 0; i < attributes.length; i++) {
+                int index;
+                if ((index = attributes[i].indexOf("/")) > 1 && attributes[i].indexOf("/") == attributes[i]
+                        .lastIndexOf("/")) {
+                    String domain = attributes[i].substring(0, index);
+                    String attrName = attributes[i].substring(index + 1);
+                    if (domain != null) {
+                        attrMap.put(domain.toUpperCase(), attrName);
+                    } else {
+                        claimMapping.setMappedAttribute(attributes[i]);
+                    }
+                } else {
+                    claimMapping.setMappedAttribute(attributes[i]);
+                }
+            }
+
+            if (attrMap.size() > 0) {
+                claimMapping.setMappedAttributes(attrMap);
+            }
+        }
     }
 }


### PR DESCRIPTION
According to the previous implementation, we were able to add the mapped attributes only from the UI. But it should allow adding the mapped attributes for a claim from the claim-config.xml configuration file.
So this PR includes the fix for add the secondary user store attributes as mapped attributes from the claim-mapping.xml configuration file.
Resolves #1416