### PR TITLE
Avoid removing history preserved service resources from registry

### DIFF
--- a/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/deployment/DeploymentInterceptor.java
+++ b/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/deployment/DeploymentInterceptor.java
@@ -209,7 +209,9 @@ public class DeploymentInterceptor implements AxisObserver {
 
                     log.info("Removing Axis2 Service: " + axisService.getName() +
                              getTenantIdAndDomainString());
-                    deleteServiceResource(axisService);
+                    if (!keepHistory(axisService)) {
+                        deleteServiceResource(axisService);
+                    }
                 }
             } catch (Exception e) {
                 String msg = "Exception occurred while handling service update event." +
@@ -550,6 +552,15 @@ public class DeploymentInterceptor implements AxisObserver {
         }
 
         return false;
+    }
+
+    private boolean keepHistory(AxisService axisService) {
+        Parameter keepHistoryParam = axisService.getParameter(CarbonConstants.KEEP_SERVICE_HISTORY_PARAM);
+        if (keepHistoryParam == null) {
+            return false;
+        }
+        Object value = keepHistoryParam.getValue();
+        return (value instanceof String && Boolean.valueOf((String) value));
     }
 
 

--- a/core/org.wso2.carbon.ui/src/main/java/org/wso2/carbon/ui/CarbonUILoginUtil.java
+++ b/core/org.wso2.carbon.ui/src/main/java/org/wso2/carbon/ui/CarbonUILoginUtil.java
@@ -207,13 +207,13 @@ public final class CarbonUILoginUtil {
      * @return
      */
     protected static boolean letRequestedUrlIn(String requestedURI, String tempUrl) {
-        return ((isEndsWithValidExtensionInUrl(requestedURI) && !requestedURI.contains(";"))
+        return ((validExtensionInUrl(requestedURI) && !requestedURI.contains(";"))
                 || requestedURI.contains("/registry") || requestedURI.contains("/openid/")
                 || requestedURI.contains("/openidserver") || requestedURI.contains("/gadgets")
                 || requestedURI.contains("/samlsso"));
     }
 
-    private static boolean isEndsWithValidExtensionInUrl(String requestedURI) {
+    private static boolean validExtensionInUrl(String requestedURI) {
         return requestedURI.endsWith(".css") || requestedURI.endsWith(".gif")
                 || requestedURI.endsWith(".GIF") || requestedURI.endsWith(".jpg")
                 || requestedURI.endsWith(".JPG") || requestedURI.endsWith(".png")

--- a/core/org.wso2.carbon.ui/src/main/java/org/wso2/carbon/ui/CarbonUILoginUtil.java
+++ b/core/org.wso2.carbon.ui/src/main/java/org/wso2/carbon/ui/CarbonUILoginUtil.java
@@ -207,19 +207,19 @@ public final class CarbonUILoginUtil {
      * @return
      */
     protected static boolean letRequestedUrlIn(String requestedURI, String tempUrl) {
-        if (requestedURI.endsWith(".css") || requestedURI.endsWith(".gif")
+        return ((isEndsWithValidExtensionInUrl(requestedURI) && !requestedURI.contains(";"))
+                || requestedURI.contains("/registry") || requestedURI.contains("/openid/")
+                || requestedURI.contains("/openidserver") || requestedURI.contains("/gadgets")
+                || requestedURI.contains("/samlsso"));
+    }
+
+    private static boolean isEndsWithValidExtensionInUrl(String requestedURI) {
+        return requestedURI.endsWith(".css") || requestedURI.endsWith(".gif")
                 || requestedURI.endsWith(".GIF") || requestedURI.endsWith(".jpg")
                 || requestedURI.endsWith(".JPG") || requestedURI.endsWith(".png")
                 || requestedURI.endsWith(".PNG") || requestedURI.endsWith(".xsl")
                 || requestedURI.endsWith(".xslt") || requestedURI.endsWith(".js")
-                || requestedURI.startsWith("/registry") || requestedURI.endsWith(".html")
-                || requestedURI.endsWith(".ico") || requestedURI.startsWith("/openid/")
-                || requestedURI.indexOf("/openid/") > -1
-                || requestedURI.indexOf("/openidserver") > -1
-                || requestedURI.indexOf("/gadgets") > -1 || requestedURI.indexOf("/samlsso") > -1) {
-            return true;
-        }
-        return false;
+                || requestedURI.endsWith(".html") || requestedURI.endsWith(".ico");
     }
 
     /**

--- a/core/org.wso2.carbon.ui/src/main/java/org/wso2/carbon/ui/filters/cache/AbstractCachePreventionFilter.java
+++ b/core/org.wso2.carbon.ui/src/main/java/org/wso2/carbon/ui/filters/cache/AbstractCachePreventionFilter.java
@@ -53,7 +53,7 @@ public abstract class AbstractCachePreventionFilter implements Filter {
 
     // Headers to be sent in the response
     private static final String HEADER_NAME_CACHE_CONTROL = "Cache-Control";
-    private static final String HEADER_VALUE_CACHE_CONTROL = "no-store, no-cache, must-revalidate";
+    private static final String HEADER_VALUE_CACHE_CONTROL = "no-store, no-cache, must-revalidate, private";
     private static final String HEADER_NAME_EXPIRES = "Expires";
     private static final String HEADER_VALUE_EXPIRES = "0";
     private static final String HEADER_NAME_PRAGMA = "Pragma";


### PR DESCRIPTION
Resolves #1420 
Fix removing history preserved service resources from registry - Avoid removal of registry resources for services that has the axis service parameter "keepServiceHistory" set to "true"
Related JIRA: https://wso2.org/jira/browse/ESBJAVA-5105 