### PR TITLE
Cluster-wide local cache invalidation support

### DIFF
--- a/core/javax.cache/src/main/java/org/wso2/carbon/caching/impl/CacheImpl.java
+++ b/core/javax.cache/src/main/java/org/wso2/carbon/caching/impl/CacheImpl.java
@@ -134,6 +134,9 @@ public class CacheImpl<K, V> implements Cache<K, V> {
                     Util.getDistributedMapNameOfCache(CachingConstants.TIMESTAMP_CACHE_PREFIX +
                             cacheName, ownerTenantDomain, cacheManager.getName()), new TimestampMapEntryListenerImpl());
         }
+
+        cacheEntryListeners.add(clusterCacheInvalidationReqSender);
+
         cacheStatistics = new CacheStatisticsImpl();
         registerMBean();
         CacheManagerFactoryImpl.addCacheForMonitoring(this);
@@ -420,6 +423,10 @@ public class CacheImpl<K, V> implements Cache<K, V> {
         CacheEntryEvent event = createCacheEntryEvent(key, value);
         for (CacheEntryListener cacheEntryListener : cacheEntryListeners) {
             if (cacheEntryListener instanceof CacheEntryRemovedListener) {
+                if (cacheEntryListener instanceof ClusterCacheInvalidationRequestSender) {
+                    //this is handled separately in the #remove method
+                    continue;
+                }
                 if (log.isDebugEnabled()) {
                     log.debug("Notification event trigger for cache entry remove : " + cacheEntryListener.getClass());
                 }

--- a/core/javax.cache/src/main/java/org/wso2/carbon/caching/impl/CacheImpl.java
+++ b/core/javax.cache/src/main/java/org/wso2/carbon/caching/impl/CacheImpl.java
@@ -19,11 +19,29 @@ package org.wso2.carbon.caching.impl;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.caching.impl.clustering.ClusterCacheInvalidationRequestSender;
 import org.wso2.carbon.caching.impl.eviction.EvictionAlgorithm;
 import org.wso2.carbon.context.CarbonContext;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.TimeUnit;
 import javax.cache.Cache;
 import javax.cache.CacheConfiguration;
 import javax.cache.CacheLoader;
@@ -45,16 +63,6 @@ import javax.management.MBeanRegistrationException;
 import javax.management.MBeanServer;
 import javax.management.MBeanServerFactory;
 import javax.management.ObjectName;
-import java.util.*;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
-import java.util.concurrent.FutureTask;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ThreadFactory;
-import java.util.concurrent.TimeUnit;
 
 /**
  * TODO: class description
@@ -80,6 +88,8 @@ public class CacheImpl<K, V> implements Cache<K, V> {
     private CacheConfiguration<K, V> cacheConfiguration;
 
     private List<CacheEntryListener> cacheEntryListeners = new ArrayList<CacheEntryListener>();
+    private ClusterCacheInvalidationRequestSender clusterCacheInvalidationReqSender =
+            new ClusterCacheInvalidationRequestSender();
     private Status status;
     private CacheStatisticsImpl cacheStatistics;
     private ObjectName cacheMXBeanObjName;
@@ -483,6 +493,22 @@ public class CacheImpl<K, V> implements Cache<K, V> {
 
     @Override
     public boolean remove(Object key) {
+        boolean removed = removeLocal(key);
+        if (cacheName.startsWith(CachingConstants.LOCAL_CACHE_PREFIX)) {
+            CacheEntryEvent cacheEntryEvent = createCacheEntryEvent((K) key, null);
+            clusterCacheInvalidationReqSender.send(cacheEntryEvent);
+        }
+
+        return removed;
+    }
+
+    /**
+     * This method is added to only remove the cache locally.
+     * This is required since {@link #remove(Object)} method
+     * notifies the other nodes in a cluster in addition to removing
+     * the local cache.
+     */
+    public boolean removeLocal(Object key) {
         Util.checkAccess(ownerTenantDomain, ownerTenantId);
         checkStatusStarted();
         lastAccessed = System.currentTimeMillis();

--- a/core/javax.cache/src/main/java/org/wso2/carbon/caching/impl/DataHolder.java
+++ b/core/javax.cache/src/main/java/org/wso2/carbon/caching/impl/DataHolder.java
@@ -17,6 +17,7 @@
 */
 package org.wso2.carbon.caching.impl;
 
+import org.apache.axis2.clustering.ClusteringAgent;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.base.api.ServerConfigurationService;
@@ -32,6 +33,7 @@ public class DataHolder {
 
     private DistributedMapProvider distributedMapProvider;
     private ServerConfigurationService serverConfigurationService;
+    private ClusteringAgent clusteringAgent;
     private CachingProviderImpl cachingProvider = new CachingProviderImpl();
     private AnnotationProvider annotationProvider = new AnnotationProviderImpl();
 
@@ -70,11 +72,19 @@ public class DataHolder {
         this.serverConfigurationService = serverConfigurationService;
     }
 
+    public void setClusteringAgent(ClusteringAgent clusteringAgent) {
+        this.clusteringAgent = clusteringAgent;
+    }
+
     public CachingProviderImpl getCachingProvider() {
         return cachingProvider;
     }
 
     public AnnotationProvider getAnnotationProvider() {
         return annotationProvider;
+    }
+
+    public ClusteringAgent getClusteringAgent() {
+        return clusteringAgent;
     }
 }

--- a/core/javax.cache/src/main/java/org/wso2/carbon/caching/impl/clustering/ClusterCacheInvalidationRequest.java
+++ b/core/javax.cache/src/main/java/org/wso2/carbon/caching/impl/clustering/ClusterCacheInvalidationRequest.java
@@ -1,3 +1,20 @@
+/*
+*  Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing,
+*  software distributed under the License is distributed on an
+*  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+*  KIND, either express or implied.  See the License for the
+*  specific language governing permissions and limitations
+*  under the License.
+*/
 package org.wso2.carbon.caching.impl.clustering;
 
 import org.apache.axis2.clustering.ClusteringCommand;

--- a/core/javax.cache/src/main/java/org/wso2/carbon/caching/impl/clustering/ClusterCacheInvalidationRequest.java
+++ b/core/javax.cache/src/main/java/org/wso2/carbon/caching/impl/clustering/ClusterCacheInvalidationRequest.java
@@ -53,9 +53,6 @@ public class ClusterCacheInvalidationRequest extends ClusteringMessage {
         this.tenantId = tenantId;
     }
 
-    public ClusterCacheInvalidationRequest() {
-    }
-
     @Override
     public void execute(ConfigurationContext configurationContext) throws ClusteringFault {
         try {

--- a/core/javax.cache/src/main/java/org/wso2/carbon/caching/impl/clustering/ClusterCacheInvalidationRequest.java
+++ b/core/javax.cache/src/main/java/org/wso2/carbon/caching/impl/clustering/ClusterCacheInvalidationRequest.java
@@ -1,0 +1,93 @@
+package org.wso2.carbon.caching.impl.clustering;
+
+import org.apache.axis2.clustering.ClusteringCommand;
+import org.apache.axis2.clustering.ClusteringFault;
+import org.apache.axis2.clustering.ClusteringMessage;
+import org.apache.axis2.context.ConfigurationContext;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.caching.impl.CacheImpl;
+import org.wso2.carbon.context.PrivilegedCarbonContext;
+
+import java.io.Serializable;
+import javax.cache.Cache;
+import javax.cache.CacheManager;
+import javax.cache.Caching;
+
+/**
+ * This is the cluster-wide local cache invalidation message that is sent
+ * to all the other nodes in a cluster. This invalidates its own cache.
+ *
+ * This is based on Axis2 clustering.
+ *
+ */
+public class ClusterCacheInvalidationRequest extends ClusteringMessage {
+
+    private static final transient Log log = LogFactory.getLog(ClusterCacheInvalidationRequest.class);
+    private static final long serialVersionUID = 94L;
+
+    private CacheInfo cacheInfo;
+    private String tenantDomain;
+    private int tenantId;
+
+    public ClusterCacheInvalidationRequest(CacheInfo cacheInfo, String tenantDomain, int tenantId) {
+        this.cacheInfo = cacheInfo;
+        this.tenantDomain = tenantDomain;
+        this.tenantId = tenantId;
+    }
+
+    public ClusterCacheInvalidationRequest() {
+    }
+
+    @Override
+    public void execute(ConfigurationContext configurationContext) throws ClusteringFault {
+        try {
+            if (log.isDebugEnabled()) {
+                log.debug("Received [" + this + "] ");
+            }
+            PrivilegedCarbonContext.startTenantFlow();
+            PrivilegedCarbonContext carbonContext = PrivilegedCarbonContext.getThreadLocalCarbonContext();
+            carbonContext.setTenantId(tenantId);
+            carbonContext.setTenantDomain(tenantDomain);
+
+            CacheManager cacheManager = Caching.getCacheManagerFactory().getCacheManager(cacheInfo.cacheManagerName);
+            Cache<Object, Object> cache = cacheManager.getCache(cacheInfo.cacheName);
+            if (cache instanceof CacheImpl) {
+                ((CacheImpl) cache).removeLocal(cacheInfo.cacheKey);
+            }
+        } finally {
+            PrivilegedCarbonContext.endTenantFlow();
+        }
+
+    }
+
+    @Override
+    public String toString() {
+        return "ClusterCacheInvalidationRequest{" +
+                "tenantId=" + tenantId +
+                ", tenantDomain='" + tenantDomain + '\'' +
+                ", messageId=" + getUuid() +
+                ", cacheManager=" + cacheInfo.cacheManagerName +
+                ", cache=" + cacheInfo.cacheName +
+                ", cacheKey=" +cacheInfo.cacheKey +
+                '}';
+    }
+
+    @Override
+    public ClusteringCommand getResponse() {
+        return null;
+    }
+
+    public static class CacheInfo implements Serializable {
+        private String cacheManagerName;
+        private String cacheName;
+        private Object cacheKey;
+
+        public CacheInfo(String cacheManagerName, String cacheName, Object cacheKey) {
+            this.cacheManagerName = cacheManagerName;
+            this.cacheName = cacheName;
+            this.cacheKey = cacheKey;
+        }
+    }
+
+}

--- a/core/javax.cache/src/main/java/org/wso2/carbon/caching/impl/clustering/ClusterCacheInvalidationRequestSender.java
+++ b/core/javax.cache/src/main/java/org/wso2/carbon/caching/impl/clustering/ClusterCacheInvalidationRequestSender.java
@@ -1,0 +1,94 @@
+/*
+*  Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing,
+*  software distributed under the License is distributed on an
+*  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+*  KIND, either express or implied.  See the License for the
+*  specific language governing permissions and limitations
+*  under the License.
+*/
+package org.wso2.carbon.caching.impl.clustering;
+
+import org.apache.axis2.clustering.ClusteringAgent;
+import org.apache.axis2.clustering.ClusteringFault;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.caching.impl.DataHolder;
+import org.wso2.carbon.context.PrivilegedCarbonContext;
+
+import javax.cache.event.CacheEntryEvent;
+
+/**
+ * Listens for cache entry removals and updates, and sends a cache invalidation request
+ * to the other members in the cluster.
+ * <p>
+ * This is feature intended only when separate local caches are maintained by each node
+ * in the cluster.
+ */
+public class ClusterCacheInvalidationRequestSender {
+
+    private static final Log log = LogFactory.getLog(ClusterCacheInvalidationRequestSender.class);
+
+    /**
+     * We will invalidate the particular cache in other nodes whenever
+     * there is an remove/update of the local cache in the current node.
+     */
+    public void send(CacheEntryEvent cacheEntryEvent) {
+        if (getClusteringAgent() != null) {
+            int numberOfRetries = 0;
+            if (log.isDebugEnabled()) {
+                log.debug(
+                        "Sending cache invalidation message to other cluster nodes for '" + cacheEntryEvent.getKey()
+                                + "' of the cache '" + cacheEntryEvent.getSource().getName()
+                                + "' of the cache manager " + cacheEntryEvent.getSource().getCacheManager()
+                                .getName() + "'");
+            }
+
+            //Send the cluster message
+            String tenantDomain = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain(true);
+            int tenantId = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantId(true);
+            ClusterCacheInvalidationRequest.CacheInfo cacheInfo = new ClusterCacheInvalidationRequest.CacheInfo(
+                    cacheEntryEvent.getSource().getCacheManager().getName(),
+                    cacheEntryEvent.getSource().getName(),
+                    cacheEntryEvent.getKey());
+
+            ClusterCacheInvalidationRequest clusterCacheInvalidationRequest = new ClusterCacheInvalidationRequest(
+                    cacheInfo, tenantDomain, tenantId);
+
+            while (numberOfRetries < 60) {
+                try {
+                    getClusteringAgent().sendMessage(clusterCacheInvalidationRequest, true);
+                    log.debug("Sent [" + clusterCacheInvalidationRequest + "]");
+                    break;
+                } catch (ClusteringFault e) {
+                    numberOfRetries++;
+                    if (numberOfRetries < 60) {
+                        log.warn("Could not send CacheInvalidationMessage for tenant " +
+                                tenantId + ". Retry will be attempted in 2s. Request: " +
+                                clusterCacheInvalidationRequest, e);
+                    } else {
+                        log.error("Could not send CacheInvalidationMessage for tenant " +
+                                tenantId + ". Several retries failed. Request:" + clusterCacheInvalidationRequest, e);
+                    }
+                    try {
+                        Thread.sleep(2000);
+                    } catch (InterruptedException ignored) {
+                    }
+                }
+            }
+        }
+    }
+
+    private ClusteringAgent getClusteringAgent() {
+        return DataHolder.getInstance().getClusteringAgent();
+    }
+
+}

--- a/core/javax.cache/src/main/java/org/wso2/carbon/caching/impl/internal/CachingServiceComponent.java
+++ b/core/javax.cache/src/main/java/org/wso2/carbon/caching/impl/internal/CachingServiceComponent.java
@@ -17,13 +17,13 @@
 */
 package org.wso2.carbon.caching.impl.internal;
 
-
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.osgi.service.component.ComponentContext;
 import org.wso2.carbon.base.api.ServerConfigurationService;
 import org.wso2.carbon.caching.impl.DataHolder;
 import org.wso2.carbon.caching.impl.DistributedMapProvider;
+import org.wso2.carbon.utils.ConfigurationContextService;
 
 /**
  * @scr.component name="org.wso2.carbon.caching.impl.internal.CachingServiceComponent" immediate="true"
@@ -31,6 +31,8 @@ import org.wso2.carbon.caching.impl.DistributedMapProvider;
  * cardinality="0..1" policy="dynamic"  bind="setDistributedMapProvider" unbind="unsetDistributedMapProvider"
  * @scr.reference name="server.configuration.service" interface="org.wso2.carbon.base.api.ServerConfigurationService"
  * cardinality="1..1" policy="dynamic"  bind="setServerConfigurationService" unbind="unsetServerConfigurationService"
+ * @scr.reference name="config.context.service" interface="org.wso2.carbon.utils.ConfigurationContextService"
+ * cardinality="0..1" policy="dynamic" bind="setClusteringAgent" unbind="unsetClusteringAgent"
  */
 public class CachingServiceComponent {
     private static final Log log = LogFactory.getLog(CachingServiceComponent.class);
@@ -59,5 +61,14 @@ public class CachingServiceComponent {
 
     protected void unsetServerConfigurationService(ServerConfigurationService serverConfigurationService) {
         dataHolder.setServerConfigurationService(null);
+    }
+
+    protected void setClusteringAgent(ConfigurationContextService configurationContextService) {
+        dataHolder.setClusteringAgent(configurationContextService.getServerConfigContext().getAxisConfiguration().
+                getClusteringAgent());
+    }
+
+    protected void unsetClusteringAgent(ConfigurationContextService configurationContextService) {
+        dataHolder.setClusteringAgent(null);
     }
 }


### PR DESCRIPTION
At the moment, there is no way to invalidate the local cache in other cluster nodes. We have to wait till the cache expiry time for that.

This feature provides support for immediate invalidation of the local caches in all the in a cluster when one node removes/modifies a cache entry.

Resolves #1423 