### PR TITLE
Fix  FindBugs-IDEA 1.0.1 scan error

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/util/UserCoreUtil.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/util/UserCoreUtil.java
@@ -91,7 +91,6 @@ public final class UserCoreUtil {
 
         int j = 0;
         for (int i = arr1.length; i < newArray.length; i++) {
-            Arrays.toString(newArray);
             newArray[i] = arr2[j];
             j++;
         }


### PR DESCRIPTION
This should be a bug or limitation in  FindBugs-IDEA 1.0.1, the same code was successfully processed by  FindBugs-IDEA 1.0.0.

Since the complained line was an unused one, it was simply removed.

Resolves #1426