### PR TITLE
Resolve styles from product style bundle instead of registry

### DIFF
--- a/core/org.wso2.carbon.ui/src/main/resources/web/admin/layout/template.jsp
+++ b/core/org.wso2.carbon.ui/src/main/resources/web/admin/layout/template.jsp
@@ -53,11 +53,15 @@
 				.getAttribute(MultitenantConstants.TENANT_DOMAIN);
 	}
 	if (tenantDomain != null && !MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.equals(tenantDomain)) {
-        String themeRoot = "../../../../t/" + tenantDomain
-				+ "/registry/resource"
-				+ RegistryConstants.GOVERNANCE_REGISTRY_BASE_PATH
-				+ "/repository";
-		mainCSS = themeRoot + "/theme/admin/main.css";
+        if ("true".equals(ServerConfiguration.getInstance().getFirstProperty(CarbonConstants.IS_CLOUD_DEPLOYMENT))) {
+            String themeRoot = "../../../../t/" + tenantDomain
+                    + "/registry/resource"
+                    + RegistryConstants.GOVERNANCE_REGISTRY_BASE_PATH
+                    + "/repository";
+            mainCSS = themeRoot + "/theme/admin/main.css";
+        } else {
+            mainCSS = "../styles/css/main.css";
+        }
         if (request.getSession().getAttribute(
                 CarbonConstants.THEME_URL_RANDOM_SUFFIX_SESSION_KEY) != null) {
             // this random string is used to get the effect of the theme change, where-ever the


### PR DESCRIPTION
Currently in template.jsp style sheet is resolved from registry when in tenant mode. This causes style conflicts in shared registry mode. So this fix will resolve styles from product styles bundle instead of registry, based on isCloudDeployment property in carbon.xml.