### PR TITLE
Preserve backward compatible behaviour of objectGUID attribute

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/ActiveDirectoryUserStoreConstants.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/ActiveDirectoryUserStoreConstants.java
@@ -43,6 +43,9 @@ public class ActiveDirectoryUserStoreConstants {
     private static final String roleDNPatternDescription = "The patten for role's DN. It can be defined to improve " +
             "the LDAP search";
 
+    public static final String TRANSFORM_OBJECTGUID_TO_UUID = "transformObjectGUIDToUUID";
+    public static final String TRANSFORM_OBJECTGUID_TO_UUID_DESC = "Return objectGUID in UUID Canonical Format";
+
     static {
         //Set mandatory properties
         setMandatoryProperty(UserStoreConfigConstants.connectionURL, "Connection URL",

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/ActiveDirectoryUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/ActiveDirectoryUserStoreManager.java
@@ -937,6 +937,9 @@ public class ActiveDirectoryUserStoreManager extends ReadWriteLDAPUserStoreManag
                 LDAPBinaryAttributesDescription);
         setAdvancedProperty(UserStoreConfigConstants.claimOperationsSupported, UserStoreConfigConstants
                 .getClaimOperationsSupportedDisplayName, "true", UserStoreConfigConstants.claimOperationsSupportedDescription);
+        setAdvancedProperty(ActiveDirectoryUserStoreConstants.TRANSFORM_OBJECTGUID_TO_UUID,
+                ActiveDirectoryUserStoreConstants.TRANSFORM_OBJECTGUID_TO_UUID_DESC , "true",
+                ActiveDirectoryUserStoreConstants.TRANSFORM_OBJECTGUID_TO_UUID_DESC);
 
     }
 


### PR DESCRIPTION
In this fix the backwards compatible behaviour of objectGUID attribute in kernel 4.4.8 and before is preserved by introducing a user store property 'transformObjectGUIDToUUID'. When the property is set to false the behaviour will be similar to kernel 4.4.8. 

The default value of the property is true, to make sure any code that depends on the UUID format of the objectGUID introduced in Kernel 4.4.9 won't break.

Resolves #1439.