### PR TITLE
Do not send cache invalidation message if the tenant information cannot be found.

### DIFF
--- a/core/javax.cache/pom.xml
+++ b/core/javax.cache/pom.xml
@@ -50,6 +50,10 @@
             <groupId>org.wso2.carbon</groupId>
             <artifactId>org.wso2.carbon.logging</artifactId>
         </dependency>
+        <dependency>
+            <groupId>commons-lang.wso2</groupId>
+            <artifactId>commons-lang</artifactId>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION

Resolves #1451 