### PR TITLE
CARBON-14149: Name the Thread Pools in Carbon Platform

### DIFF
--- a/core/org.wso2.carbon.coordination.core/src/main/java/org/wso2/carbon/coordination/core/services/impl/ZKCoordinationService.java
+++ b/core/org.wso2.carbon.coordination.core/src/main/java/org/wso2/carbon/coordination/core/services/impl/ZKCoordinationService.java
@@ -43,6 +43,7 @@ import org.wso2.carbon.coordination.core.sync.impl.ZKIntegerCounter;
 import org.wso2.carbon.coordination.core.sync.impl.ZKLock;
 import org.wso2.carbon.coordination.core.sync.impl.ZKQueue;
 import org.wso2.carbon.coordination.core.utils.CoordinationUtils;
+import org.wso2.carbon.core.CarbonThreadFactory;
 
 /**
  * Coordination service implementation class.
@@ -83,8 +84,9 @@ public class ZKCoordinationService implements CoordinationService, Watcher {
 			    }
 			    if (scheduler == null || scheduler.isShutdown()) {
 			    	znodeTimerDeletionList = new Vector<ZKCoordinationService.ZNodeDeletionEntry>();
-			        scheduler = Executors.newScheduledThreadPool(MAX_SCHEDULER_THREADS);
-			        scheduler.scheduleWithFixedDelay(new ZNodeDeletionTask(), 
+					scheduler = Executors.newScheduledThreadPool(MAX_SCHEDULER_THREADS, new CarbonThreadFactory(
+							new ThreadGroup("CoordinationThread")));
+					scheduler.scheduleWithFixedDelay(new ZNodeDeletionTask(),
 			        		ZNODE_CLEANUP_TASK_INTERVAL, ZNODE_CLEANUP_TASK_INTERVAL,
 			        		TimeUnit.MILLISECONDS);
 			    }

--- a/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/CarbonAxisConfigurator.java
+++ b/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/CarbonAxisConfigurator.java
@@ -462,7 +462,8 @@ public class CarbonAxisConfigurator extends DeploymentEngine implements AxisConf
                                                           axisConfig,
                                                           MultitenantConstants.SUPER_TENANT_ID,
                                                           MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
-        scheduler = Executors.newScheduledThreadPool(1);
+        scheduler = Executors
+                .newScheduledThreadPool(1, new CarbonThreadFactory(new ThreadGroup("CarbonDeploymentSchedulerThread")));
         String deploymentInterval =
                 CarbonCoreDataHolder.getInstance().
                         getServerConfigurationService().getFirstProperty("Axis2Config.DeploymentUpdateInterval");

--- a/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/CarbonThreadFactory.java
+++ b/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/CarbonThreadFactory.java
@@ -1,0 +1,38 @@
+/*
+* Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package org.wso2.carbon.core;
+
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ *  Carbon Thread Factory which can be used to identify thread specific to tasks.
+ */
+public class CarbonThreadFactory implements ThreadFactory {
+
+    private ThreadGroup threadGroup;
+    private AtomicInteger count = new AtomicInteger();
+
+    public CarbonThreadFactory(ThreadGroup threadGroup) {
+        this.threadGroup = threadGroup;
+    }
+
+    @Override
+    public Thread newThread(Runnable r) {
+        String name = threadGroup.getName() + "-" + count.incrementAndGet();
+        return new Thread(threadGroup, r, name);
+    }
+}

--- a/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/clustering/hazelcast/HazelcastClusteringAgent.java
+++ b/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/clustering/hazelcast/HazelcastClusteringAgent.java
@@ -42,6 +42,7 @@ import org.osgi.framework.BundleContext;
 import org.wso2.carbon.base.CarbonBaseConstants;
 import org.wso2.carbon.base.CarbonBaseUtils;
 import org.wso2.carbon.caching.impl.DistributedMapProvider;
+import org.wso2.carbon.core.CarbonThreadFactory;
 import org.wso2.carbon.core.ServerStatus;
 import org.wso2.carbon.core.clustering.api.CarbonCluster;
 import org.wso2.carbon.core.clustering.api.ClusterMessage;
@@ -239,7 +240,8 @@ public class HazelcastClusteringAgent extends ParameterAdapter implements Cluste
         bundleContext.registerService(HazelcastInstance.class, primaryHazelcastInstance, null);
         bundleContext.registerService(CarbonCluster.class,
                                       hazelcastCarbonCluster, null);
-        ScheduledExecutorService msgCleanupScheduler = Executors.newScheduledThreadPool(1);
+        ScheduledExecutorService msgCleanupScheduler = Executors
+                .newScheduledThreadPool(1, new CarbonThreadFactory(new ThreadGroup("ClusterMsgCleanupThread")));
         msgCleanupScheduler.scheduleWithFixedDelay(new ClusterMessageCleanupTask(),
                                                    2, 2, TimeUnit.MINUTES);
 

--- a/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/deployment/RegistryBasedRepositoryUpdater.java
+++ b/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/deployment/RegistryBasedRepositoryUpdater.java
@@ -17,6 +17,7 @@ package org.wso2.carbon.core.deployment;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.core.CarbonThreadFactory;
 import org.wso2.carbon.registry.core.session.UserRegistry;
 
 import java.util.Map;
@@ -32,8 +33,9 @@ import java.util.concurrent.TimeUnit;
 public class RegistryBasedRepositoryUpdater {
     private static final Log log = LogFactory.getLog(RegistryBasedRepositoryUpdater.class);
 
-    private static final ScheduledThreadPoolExecutor exec =
-            (ScheduledThreadPoolExecutor) Executors.newScheduledThreadPool(20);
+    private static final ScheduledThreadPoolExecutor exec = (ScheduledThreadPoolExecutor) Executors
+            .newScheduledThreadPool(20,
+                                    new CarbonThreadFactory(new ThreadGroup("RegistryBasedRepositoryUpdaterThread")));
     private static final Map<String, ScheduledFuture> futures =
             new ConcurrentHashMap<String, ScheduledFuture>();
 

--- a/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/init/CarbonServerManager.java
+++ b/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/init/CarbonServerManager.java
@@ -53,6 +53,7 @@ import org.wso2.carbon.context.CarbonContext;
 import org.wso2.carbon.core.CarbonAxisConfigurator;
 import org.wso2.carbon.core.CarbonConfigurationContextFactory;
 import org.wso2.carbon.core.CarbonThreadCleanup;
+import org.wso2.carbon.core.CarbonThreadFactory;
 import org.wso2.carbon.core.RegistryResources;
 import org.wso2.carbon.core.ServerInitializer;
 import org.wso2.carbon.core.ServerManagement;
@@ -162,8 +163,8 @@ public final class CarbonServerManager implements Controllable {
     private final Object pendingItemsLock = new Object();
 
     private GenericArtifactUnloader genericArtifactUnloader = new GenericArtifactUnloader();
-    private static final ScheduledExecutorService artifactsCleanupExec
-            = Executors.newScheduledThreadPool(1);
+    private static final ScheduledExecutorService artifactsCleanupExec =
+            Executors.newScheduledThreadPool(1, new CarbonThreadFactory(new ThreadGroup("ArtifactCleanupThread")));
 
     public CarbonServerManager() {
     }

--- a/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/internal/permission/update/PermissionUpdateServiceComponent.java
+++ b/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/internal/permission/update/PermissionUpdateServiceComponent.java
@@ -18,6 +18,7 @@ package org.wso2.carbon.core.internal.permission.update;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.osgi.service.component.ComponentContext;
+import org.wso2.carbon.core.CarbonThreadFactory;
 import org.wso2.carbon.core.internal.CarbonCoreDataHolder;
 import org.wso2.carbon.registry.core.service.RegistryService;
 import org.wso2.carbon.user.core.UserCoreConstants;
@@ -46,7 +47,8 @@ public class PermissionUpdateServiceComponent {
     private static Log log = LogFactory.getLog(PermissionUpdateServiceComponent.class);
     private static final long JOB_INTERVAL_SECS = 1 * 60;
 
-    private static final ScheduledExecutorService permUpdater = Executors.newScheduledThreadPool(1);
+    private static final ScheduledExecutorService permUpdater =
+            Executors.newScheduledThreadPool(1, new CarbonThreadFactory(new ThreadGroup("PermissionUpdaterThread")));
     private CarbonCoreDataHolder dataHolder = CarbonCoreDataHolder.getInstance();
 
     static {

--- a/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/multitenancy/MultitenantServerManager.java
+++ b/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/multitenancy/MultitenantServerManager.java
@@ -19,6 +19,7 @@ import org.apache.axis2.AxisFault;
 import org.apache.axis2.context.ConfigurationContext;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.core.CarbonThreadFactory;
 import org.wso2.carbon.core.multitenancy.utils.TenantAxisUtils;
 import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 
@@ -32,7 +33,8 @@ import java.util.concurrent.TimeUnit;
 public class MultitenantServerManager {
 
     private static final Log log = LogFactory.getLog(MultitenantServerManager.class);
-    private static final ScheduledExecutorService tenantCleanupExec = Executors.newScheduledThreadPool(1);
+    private static final ScheduledExecutorService tenantCleanupExec = Executors
+            .newScheduledThreadPool(1, new CarbonThreadFactory(new ThreadGroup("tenantCleanupThread")));
     private static final int TENANT_CLEANUP_PERIOD_SECS = 60;
     private static final int DEFAULT_TENANT_IDLE_MINS = 30;
     private static long tenantIdleTimeMillis;

--- a/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/multitenancy/TenantAxisConfigurator.java
+++ b/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/multitenancy/TenantAxisConfigurator.java
@@ -38,6 +38,7 @@ import org.osgi.util.tracker.ServiceTracker;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.context.RegistryType;
 import org.wso2.carbon.core.CarbonAxisConfigurator;
+import org.wso2.carbon.core.CarbonThreadFactory;
 import org.wso2.carbon.core.deployment.CarbonDeploymentSchedulerTask;
 import org.wso2.carbon.core.deployment.DeploymentInterceptor;
 import org.wso2.carbon.core.deployment.RegistryBasedRepository;
@@ -528,7 +529,8 @@ public class TenantAxisConfigurator extends DeploymentEngine implements AxisConf
     protected void startSearch(RepositoryListener listener) {
         schedulerTask = new CarbonDeploymentSchedulerTask(listener, axisConfig,
                                                           tenantId, tenantDomain);
-        scheduler = Executors.newScheduledThreadPool(1);
+        scheduler = Executors
+                .newScheduledThreadPool(1, new CarbonThreadFactory(new ThreadGroup("TenantDeploymentSchedulerThread")));
         String deploymentInterval =
                 CarbonCoreDataHolder.getInstance().
                         getServerConfigurationService().getFirstProperty("Axis2Config.DeploymentUpdateInterval");

--- a/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/transports/CarbonServlet.java
+++ b/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/transports/CarbonServlet.java
@@ -31,6 +31,7 @@ import org.jaxen.SimpleNamespaceContext;
 import org.jaxen.XPath;
 import org.osgi.util.tracker.ServiceTracker;
 import org.wso2.carbon.base.ServerConfiguration;
+import org.wso2.carbon.core.CarbonThreadFactory;
 import org.wso2.carbon.core.internal.CarbonCoreDataHolder;
 import org.wso2.carbon.core.transports.metering.MeteredServletRequest;
 import org.wso2.carbon.core.transports.metering.MeteredServletResponse;
@@ -63,8 +64,8 @@ public class CarbonServlet extends AxisServlet {
 
     private static final Log log = LogFactory.getLog(CarbonServlet.class);
 
-    private ScheduledExecutorService requestDataPersisterScheduler =
-            Executors.newScheduledThreadPool(25);
+    private ScheduledExecutorService requestDataPersisterScheduler = Executors
+            .newScheduledThreadPool(25, new CarbonThreadFactory(new ThreadGroup("RequestDataPersisterThread")));
 
     private RequestDataPersisterTask requestDataPersister;
     


### PR DESCRIPTION
This will rename the default thread factories in following classes

- CarbonAxisConfigurator
- TenantAxisConfigurator
- PermissionUpdateServiceComponent
- CarbonServerManager
- HazelcastClusteringAgent
- MultitenantServerManager