### PR TITLE
Read tenant-cache from tenant-based CacheManager

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/tenant/TenantCache.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/tenant/TenantCache.java
@@ -7,7 +7,6 @@ import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 
 import javax.cache.Cache;
-import javax.cache.CacheManager;
 import javax.cache.Caching;
 
 public class TenantCache {
@@ -42,7 +41,8 @@ public class TenantCache {
         Cache<TenantIdKey, T> cache;
 
         if ((tenantId > 0) &&
-                (MultitenantConstants.SUPER_TENANT_ID == PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantId())) {
+                (MultitenantConstants.SUPER_TENANT_ID == PrivilegedCarbonContext.getThreadLocalCarbonContext()
+                        .getTenantId())) {
 
             // As per the CacheManagerFactoryImpl, the CacheManager for each tenant is contained in a hash-map keyed
             // by the tenant domain. Therefore, if the tenant is modified from within the super tenant carbon
@@ -58,8 +58,7 @@ public class TenantCache {
 
                 privilegedCarbonContext.setTenantId(tenantId, true);
 
-                cache = Caching.getCacheManagerFactory().getCacheManager(TENANT_CACHE_MANAGER).getCache
-                        (TENANT_CACHE);
+                cache = Caching.getCacheManagerFactory().getCacheManager(TENANT_CACHE_MANAGER).getCache(TENANT_CACHE);
             } finally {
                 PrivilegedCarbonContext.endTenantFlow();
             }


### PR DESCRIPTION
## Purpose
> As per the CacheManagerFactoryImpl, the CacheManager for each tenant is contained in a hash-map keyed by the tenant domain. Therefore, if the tenant is modified from within the super tenant carbon context, an obsolete CacheManager mapped to the super tenant domain will be updated, causing 2 CacheManagers per tenant.

> Public Issue : wso2/product-ei#1107

## Goals
> Use the correct cache for seperate tenants instead of updating 2 tenant caches. 

## Approach
> As a solution, we are executing a temporary tenant flow to access the correct CacheManager for the tenant, and also avoid the cache lookup during addTenant flow, since the tenantDomain is not yet stored for populating the tenant carbon context. 

## User stories
> Startup of tenants in Integration cloud. Should not get stuck until cache invalidation (15 mins)
> 

## Release note
> Bug : Read tenant-cache from tenant-based CacheManager instead of super tenant context.
> https://github.com/wso2/carbon-kernel/issues/1595

## Documentation
> N/A. This is an internal fix to improve tenant loading time. 

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - N/A - Since this issue can be reproduced in a customized ESB / EI pack which contains a custom carbon app + continuous invocation of a tenant API and a custom cloud component (tenant-mgt). 

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> JDK 1.8, Ubuntu 16.04
 
## Learning
> N/A