### PR TITLE
Replace Mockito with PowerMock, a powerful extension to Mockito

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -585,15 +585,13 @@
         <version.com.google.code.gson>2.3.1</version.com.google.code.gson>
 
         <test.framework.version>4.4.3</test.framework.version>
-        <testng.verson>6.1.1</testng.verson>
-        <org.mockito.version>1.9.5</org.mockito.version>
-        <org.apacheds.version>1.5.5</org.apacheds.version>
+        <testng.verson>6.10</testng.verson>
 
         <!-- Unit/Integration tests -->
         <jacoco.version>0.7.9</jacoco.version>
         <maven.surefire.plugin.version>2.20.1</maven.surefire.plugin.version>
         <maven.failsafe.plugin.version>2.20.1</maven.failsafe.plugin.version>
-        <mockito.version>2.10.0</mockito.version>
+        <powermock.version>1.7.3</powermock.version>
 
         <!-- OWASP CSRFGuard Version -->
         <orbit.version.csrfguard>3.1.0.wso2v2</orbit.version.csrfguard>
@@ -1676,9 +1674,14 @@
                 <version>${testng.verson}</version>
             </dependency>
             <dependency>
-                <groupId>org.mockito</groupId>
-                <artifactId>mockito-core</artifactId>
-                <version>${mockito.version}</version>
+                <groupId>org.powermock</groupId>
+                <artifactId>powermock-api-mockito2</artifactId>
+                <version>${powermock.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.powermock</groupId>
+                <artifactId>powermock-module-testng</artifactId>
+                <version>${powermock.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
## Purpose
PowerMock is a framework that extends other mock libraries such as Mockito with more powerful capabilities. PowerMock uses a custom classloader and bytecode manipulation to enable mocking of static methods, constructors, final classes and methods, private methods, removal of static initializers and more (https://github.com/powermock/powermock). Thus, we here replace Mockito with PowerMock. In addtion, this also involves updating testng version to 6.10 for compatibility reasons. This resolves #1580.