### PR TITLE
Add units-tests for core/org.wso2.carbon.tomcat.ext

### DIFF
--- a/core/org.wso2.carbon.tomcat.ext/pom.xml
+++ b/core/org.wso2.carbon.tomcat.ext/pom.xml
@@ -91,17 +91,16 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-api-mockito2</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-module-testng</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>
-
     <build>
         <plugins>
             <plugin>

--- a/core/org.wso2.carbon.tomcat.ext/src/main/java/org/wso2/carbon/tomcat/ext/internal/Utils.java
+++ b/core/org.wso2.carbon.tomcat.ext/src/main/java/org/wso2/carbon/tomcat/ext/internal/Utils.java
@@ -161,8 +161,8 @@ public class Utils {
         String uri = URLMappingHolder.getInstance().getApplicationFromUrlMapping(hostName);
         if (uri != null) {
             //setting application id for the webapps which has deployed in a virtual host
-            if(uri.startsWith("/services/")) {
-                appName = getServiceName(uri);
+            if (uri.startsWith("/services/")) {
+                temp = getServiceName(uri);
             } else if (uri.contains(WEB_APP_PATTERN)) {
                 //if the request from webapps, getting appName from uri
                 temp = uri.substring(uri.indexOf(WEB_APP_PATTERN) + 9);

--- a/core/org.wso2.carbon.tomcat.ext/src/test/java/org/wso2/carbon/tomcat/ext/internal/CarbonRealmServiceComponentTest.java
+++ b/core/org.wso2.carbon.tomcat.ext/src/test/java/org/wso2/carbon/tomcat/ext/internal/CarbonRealmServiceComponentTest.java
@@ -1,0 +1,81 @@
+/*
+ *  Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.wso2.carbon.tomcat.ext.internal;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import org.wso2.carbon.registry.core.service.RegistryService;
+import org.wso2.carbon.user.core.service.RealmService;
+
+import java.util.logging.Logger;
+
+import static org.mockito.Mockito.mock;
+
+/**
+ * CarbonRealmServiceComponentTest includes test scenarios for
+ * [1] functions, setRealmService (), unsetRealmService (), setRegistryService () and
+ * unsetRegistryService () of CarbonRealmServiceComponent.
+ * @since 4.4.19
+ */
+public class CarbonRealmServiceComponentTest {
+
+    private static final Logger log = Logger.getLogger("UtilsTest");
+
+    /**
+     * Checks setRealmService () and unsetRealmService () functionality.
+     */
+    @Test(groups = {"org.wso2.carbon.tomcat.ext.internal"})
+    public void testRealmService () {
+        // mocking inputs
+        RealmService realmService = mock(RealmService.class);
+        // calling setRealmService () functionality
+        CarbonRealmServiceComponent carbonRealmServiceComponent = new CarbonRealmServiceComponent();
+        carbonRealmServiceComponent.setRealmService(realmService);
+        log.info("Testing if mocked realm service instance was set to Carbon realm service holder");
+        Assert.assertEquals(CarbonRealmServiceHolder.getRealmService(), realmService,
+                "Carbon realm service holder does not carry the correct realm service instance set by " +
+                        "Carbon realm service component");
+        // calling unsetRealmService () functionality
+        carbonRealmServiceComponent.unsetRealmService(realmService);
+        log.info("Testing if mocked realm service instance was unset from Carbon realm service holder");
+        Assert.assertEquals(CarbonRealmServiceHolder.getRealmService(), null,
+                "Carbon realm service holder does not correctly unset the realm service instance set by " +
+                        "Carbon realm service component");
+    }
+
+    /**
+     * Checks setRegistryService () and unsetRegistryService () functionality.
+     */
+    @Test(groups = {"org.wso2.carbon.tomcat.ext.internal"})
+    public void testRegistryService () {
+        // mocking inputs
+        RegistryService registryService = mock(RegistryService.class);
+        // calling setRegistryService () functionality
+        CarbonRealmServiceComponent carbonRealmServiceComponent = new CarbonRealmServiceComponent();
+        carbonRealmServiceComponent.setRegistryService(registryService);
+        log.info("Testing if mocked registry service instance was set to Carbon realm service holder");
+        Assert.assertEquals(CarbonRealmServiceHolder.getRegistryService(), registryService,
+                "Carbon realm service holder does not carry the correct registry service instance set by " +
+                        "Carbon realm service component");
+        // calling unsetRegistryService () functionality
+        carbonRealmServiceComponent.unsetRegistryService(registryService);
+        log.info("Testing if mocked registry service instance was unset from Carbon realm service holder");
+        Assert.assertEquals(CarbonRealmServiceHolder.getRegistryService(), null,
+                "Carbon realm service holder does not correctly unset the registry service instance set by " +
+                        "Carbon realm service component");
+    }
+}

--- a/core/org.wso2.carbon.tomcat.ext/src/test/java/org/wso2/carbon/tomcat/ext/internal/TestHttpSession.java
+++ b/core/org.wso2.carbon.tomcat.ext/src/test/java/org/wso2/carbon/tomcat/ext/internal/TestHttpSession.java
@@ -1,3 +1,19 @@
+/*
+ *  Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 package org.wso2.carbon.tomcat.ext.internal;
 
 import javax.servlet.ServletContext;

--- a/core/org.wso2.carbon.tomcat.ext/src/test/java/org/wso2/carbon/tomcat/ext/internal/TestHttpSession.java
+++ b/core/org.wso2.carbon.tomcat.ext/src/test/java/org/wso2/carbon/tomcat/ext/internal/TestHttpSession.java
@@ -1,0 +1,98 @@
+package org.wso2.carbon.tomcat.ext.internal;
+
+import javax.servlet.ServletContext;
+import javax.servlet.http.HttpSession;
+import javax.servlet.http.HttpSessionContext;
+import java.util.Enumeration;
+
+/**
+ * TestHttpSession is an implementation of HttpSession
+ * made to test out Utils test scenarios.
+ * @since 4.4.19
+ */
+public class TestHttpSession implements HttpSession {
+    @Override
+    public long getCreationTime() {
+        return 0;
+    }
+
+    @Override
+    public String getId() {
+        return null;
+    }
+
+    @Override
+    public long getLastAccessedTime() {
+        return 0;
+    }
+
+    @Override
+    public ServletContext getServletContext() {
+        return null;
+    }
+
+    @Override
+    public void setMaxInactiveInterval(int i) {
+
+    }
+
+    @Override
+    public int getMaxInactiveInterval() {
+        return 0;
+    }
+
+    @Override
+    public HttpSessionContext getSessionContext() {
+        return null;
+    }
+
+    @Override
+    public Object getAttribute(String s) {
+        return null;
+    }
+
+    @Override
+    public Object getValue(String s) {
+        return null;
+    }
+
+    @Override
+    public Enumeration<String> getAttributeNames() {
+        return null;
+    }
+
+    @Override
+    public String[] getValueNames() {
+        return new String[0];
+    }
+
+    @Override
+    public void setAttribute(String s, Object o) {
+
+    }
+
+    @Override
+    public void putValue(String s, Object o) {
+
+    }
+
+    @Override
+    public void removeAttribute(String s) {
+
+    }
+
+    @Override
+    public void removeValue(String s) {
+
+    }
+
+    @Override
+    public void invalidate() {
+
+    }
+
+    @Override
+    public boolean isNew() {
+        return false;
+    }
+}

--- a/core/org.wso2.carbon.tomcat.ext/src/test/java/org/wso2/carbon/tomcat/ext/realms/CarbonTomcatRealmTest.java
+++ b/core/org.wso2.carbon.tomcat.ext/src/test/java/org/wso2/carbon/tomcat/ext/realms/CarbonTomcatRealmTest.java
@@ -18,7 +18,9 @@ package org.wso2.carbon.tomcat.ext.realms;
 
 import org.testng.Assert;
 import org.testng.annotations.Test;
+import org.wso2.carbon.tomcat.ext.saas.TenantSaaSRules;
 
+import java.util.Map;
 import java.util.logging.Logger;
 
 /**
@@ -45,7 +47,7 @@ public class CarbonTomcatRealmTest {
     }
 
     /**
-     * Testing getName() for its expected behaviour.
+     * Checks getName() for its expected behaviour.
      */
     @Test(groups = {"org.wso2.carbon.tomcat.ext.realms"})
     public void testGetName () throws Exception {
@@ -77,4 +79,85 @@ public class CarbonTomcatRealmTest {
                 "md5-string");
     }
 
+    /**
+     * Checks for correct tenantSaaSRulesMap value with its setters and getters for Case 1.
+     * Case 1 : SaasRules contain one tenant and its two users.
+     * @throws Exception An exception is thrown according to CarbonTomcatRealm constructor definition.
+     */
+    @Test(groups = {"org.wso2.carbon.tomcat.ext.realms"})
+    public void testTenantSaaSRulesMapWithCase1 () throws Exception {
+        CarbonTomcatRealm carbonTomcatRealm = new CarbonTomcatRealm();
+        log.info("Testing getters and setters for tenantSaaSRulesMap with users");
+        carbonTomcatRealm.setSaasRules("carbon.super:users=admin,bob");
+        Map saasRules = carbonTomcatRealm.getSaasRules();
+        // Testing tenantSaaSRulesMap for correct number of tenants
+        Assert.assertEquals(saasRules.size(), 1,
+                "Received number of tenants does not match expected size");
+        // Testing tenantSaaSRulesMap for correct number of tenant users
+        Assert.assertEquals(((TenantSaaSRules)saasRules.get("carbon.super")).getUsers().size(), 2,
+                "Received number of tenant users does not match expected size");
+    }
+
+    /**
+     * Checks for correct tenantSaaSRulesMap value with its setters and getters for Case 2.
+     * Case 2 : SaasRules contain two tenants and their roles.
+     * @throws Exception An exception is thrown according to CarbonTomcatRealm constructor definition.
+     */
+    @Test(groups = {"org.wso2.carbon.tomcat.ext.realms"})
+    public void testTenantSaaSRulesMapWithCase2 () throws Exception {
+        CarbonTomcatRealm carbonTomcatRealm = new CarbonTomcatRealm();
+        log.info("Testing getters and setters for tenantSaaSRulesMap with roles");
+        carbonTomcatRealm.setSaasRules("carbon.super:roles=admin;abc.com:roles=admin,manager,clerk");
+        Map saasRules = carbonTomcatRealm.getSaasRules();
+        // Testing tenantSaaSRulesMap for correct number of tenants
+        Assert.assertEquals(saasRules.size(), 2,
+                "Received number of tenants does not match expected size");
+        // Testing tenantSaaSRulesMap for correct number of tenant users
+        Assert.assertEquals(((TenantSaaSRules)saasRules.get("abc.com")).getRoles().size(), 3,
+                "Received number of tenant users does not match expected size");
+    }
+
+    /**
+     * Checks for correct tenantSaaSRulesMap value with its setters and getters for Case 3.
+     * Case 3 : SaasRules contain two tenants, their roles and users.
+     * @throws Exception An exception is thrown according to CarbonTomcatRealm constructor definition.
+     */
+    @Test(groups = {"org.wso2.carbon.tomcat.ext.realms"})
+    public void testTenantSaaSRulesMapWithCase3 () throws Exception {
+        CarbonTomcatRealm carbonTomcatRealm = new CarbonTomcatRealm();
+        log.info("Testing getters and setters for tenantSaaSRulesMap with roles and users");
+        carbonTomcatRealm.setSaasRules("carbon.super:roles=admin;abc.com:users=admin,bob,smith");
+        Map saasRules = carbonTomcatRealm.getSaasRules();
+        // Testing tenantSaaSRulesMap for correct number of tenants
+        Assert.assertEquals(saasRules.size(), 2,
+                "Received number of tenants does not match expected size");
+        // Testing tenantSaaSRulesMap for correct number of tenant roles
+        Assert.assertEquals(((TenantSaaSRules)saasRules.get("carbon.super")).getRoles().size(), 1,
+                "Received number of tenant roles does not match expected size");
+        // Testing tenantSaaSRulesMap for correct number of tenant users
+        Assert.assertEquals(((TenantSaaSRules)saasRules.get("abc.com")).getUsers().size(), 3,
+                "Received number of tenant users does not match expected size");
+    }
+
+    /**
+     * Checks for correct tenantSaaSRulesMap value with its setters and getters for Case 4.
+     * Case 4 : SaasRules contain only tenants, but no roles or users.
+     * @throws Exception An exception is thrown according to CarbonTomcatRealm constructor definition.
+     */
+    @Test(groups = {"org.wso2.carbon.tomcat.ext.realms"})
+    public void testTenantSaaSRulesMapWithCase4 () throws Exception {
+        CarbonTomcatRealm carbonTomcatRealm = new CarbonTomcatRealm();
+        log.info("Testing getters and setters for tenantSaaSRulesMap with no roles and users");
+        carbonTomcatRealm.setSaasRules("carbon.super;abc.com;xyz.com");
+        Map saasRules = carbonTomcatRealm.getSaasRules();
+        // Testing tenantSaaSRulesMap for correct number of tenants
+        Assert.assertEquals(saasRules.size(), 3,
+                "Received number of tenants does not match expected size");
+        // Testing tenantSaaSRulesMap for correct number of tenant roles
+        Assert.assertEquals(((TenantSaaSRules)saasRules.get("carbon.super")).getRoles(), null,
+                "Received number of tenant roles does not match expected size");
+        // Testing tenantSaaSRulesMap for correct number of tenant users
+        Assert.assertEquals(((TenantSaaSRules)saasRules.get("abc.com")).getUsers(), null,
+                "Received number of tenant users does not match expected size");
+    }
 }

--- a/core/org.wso2.carbon.tomcat.ext/src/test/java/org/wso2/carbon/tomcat/ext/transport/ServletTransportManagerTest.java
+++ b/core/org.wso2.carbon.tomcat.ext/src/test/java/org/wso2/carbon/tomcat/ext/transport/ServletTransportManagerTest.java
@@ -1,0 +1,175 @@
+/*
+ *  Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.wso2.carbon.tomcat.ext.transport;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import org.wso2.carbon.base.api.ServerConfigurationService;
+import org.wso2.carbon.tomcat.api.CarbonTomcatService;
+import org.wso2.carbon.tomcat.ext.internal.CarbonTomcatServiceHolder;
+
+import java.util.logging.Logger;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * ServletTransportManagerTest includes test scenarios for
+ * [1] functions, getContext () and getTenantName () of TransportStatisticsEntry.
+ * [2] properties, requestSize, responseSize and requestUrl of TransportStatisticsEntry.
+ * @since 4.4.19
+ */
+public class ServletTransportManagerTest {
+
+    private static final Logger log = Logger.getLogger("ServletTransportManagerTest");
+
+    /**
+     * Checks init () functionality with for Case 1.
+     * Case 1: Running servlet transport manager init () with proxy ports, disabled and checking
+     * if system properties are appropriately set for mgt.transport.http.port and mgt.transport.https.port.
+     */
+    @Test(groups = {"org.wso2.carbon.tomcat.ext.transport"})
+    public void testInitWithCase1 () {
+        // mocking internally used service instances by CarbonTomcatServiceHolder
+        ServerConfigurationService serverConfigurationService = mock(ServerConfigurationService.class);
+        CarbonTomcatService carbonTomcatService = mock(CarbonTomcatService.class);
+        // set mocked instances to CarbonTomcatServiceHolder
+        CarbonTomcatServiceHolder.setServerConfigurationService(serverConfigurationService);
+        CarbonTomcatServiceHolder.setCarbonTomcatService(carbonTomcatService);
+        // set return values for mocked instances
+        when(serverConfigurationService.getFirstProperty("Ports.Offset")).thenReturn("0");
+        when(carbonTomcatService.getPort("http")).thenReturn(9673);
+        when(carbonTomcatService.getPort("https")).thenReturn(9443);
+        when(carbonTomcatService.getProxyPort("http")).thenReturn(0);
+        when(carbonTomcatService.getProxyPort("https")).thenReturn(0);
+        // clear system properties if set
+        clearTestedSystemPropertiesIfAlreadySet();
+        // calling init ()
+        ServletTransportManager.init();
+        log.info("Testing init () functionality for case 1");
+        Assert.assertTrue("9673".equals(System.getProperty("mgt.transport.http.port")),
+                "Retrieved value for system property 'mgt.transport.http.port' is not equal to '9673'");
+        Assert.assertTrue("9443".equals(System.getProperty("mgt.transport.https.port")),
+                "Retrieved value for system property 'mgt.transport.https.port' is not equal to '9443'");
+        Assert.assertTrue(System.getProperty("mgt.transport.http.proxyPort") == null,
+                "Retrieved value for system property 'mgt.transport.http.proxyPort' is not equal to null");
+        Assert.assertTrue(System.getProperty("mgt.transport.https.proxyPort") == null,
+                "Retrieved value for system property 'mgt.transport.https.proxyPort' is not equal to null");
+    }
+
+    /**
+     * Checks init () functionality with for Case 2.
+     * Case 2: Running servlet transport manager init () with offset and proxy ports enabled, and
+     * checking if system properties are appropriately set for mgt.transport.http.port, mgt.transport.https.port,
+     * mgt.transport.http.proxyPort and mgt.transport.https.proxyPort.
+     */
+    @Test(groups = {"org.wso2.carbon.tomcat.ext.transport"})
+    public void testInitWithCase2 () {
+        // mocking internally used service instances by CarbonTomcatServiceHolder
+        ServerConfigurationService serverConfigurationService = mock(ServerConfigurationService.class);
+        CarbonTomcatService carbonTomcatService = mock(CarbonTomcatService.class);
+        // set mocked instances to CarbonTomcatServiceHolder
+        CarbonTomcatServiceHolder.setServerConfigurationService(serverConfigurationService);
+        CarbonTomcatServiceHolder.setCarbonTomcatService(carbonTomcatService);
+        // set return values for mocked instances
+        when(serverConfigurationService.getFirstProperty("Ports.Offset")).thenReturn("1");
+        when(carbonTomcatService.getPort("http")).thenReturn(9673);
+        when(carbonTomcatService.getPort("https")).thenReturn(9443);
+        when(carbonTomcatService.getProxyPort("http")).thenReturn(80);
+        when(carbonTomcatService.getProxyPort("https")).thenReturn(443);
+        // clear system properties if set
+        clearTestedSystemPropertiesIfAlreadySet();
+        // calling init ()
+        ServletTransportManager.init();
+        log.info("Testing init () functionality for case 1");
+        Assert.assertTrue("9674".equals(System.getProperty("mgt.transport.http.port")),
+                "Retrieved value for system property 'mgt.transport.http.port' is not equal to '9674'");
+        Assert.assertTrue("9444".equals(System.getProperty("mgt.transport.https.port")),
+                "Retrieved value for system property 'mgt.transport.http.port' is not equal to '9444'");
+        Assert.assertTrue("80".equals(System.getProperty("mgt.transport.http.proxyPort")),
+                "Retrieved value for system property 'mgt.transport.http.proxyPort' is not equal to '80'");
+        Assert.assertTrue("443".equals(System.getProperty("mgt.transport.https.proxyPort")),
+                "Retrieved value for system property 'mgt.transport.https.proxyPort' is not equal to '443'");
+    }
+
+    /**
+     * Checks getPort () functionality for valid and invalid inputs.
+     */
+    @Test(groups = {"org.wso2.carbon.tomcat.ext.transport"})
+    public void testGetPort () {
+        // mocking internally used service instances by CarbonTomcatServiceHolder
+        ServerConfigurationService serverConfigurationService = mock(ServerConfigurationService.class);
+        CarbonTomcatService carbonTomcatService = mock(CarbonTomcatService.class);
+        // set mocked instances to CarbonTomcatServiceHolder
+        CarbonTomcatServiceHolder.setServerConfigurationService(serverConfigurationService);
+        CarbonTomcatServiceHolder.setCarbonTomcatService(carbonTomcatService);
+        // set return values for mocked instances
+        when(serverConfigurationService.getFirstProperty("Ports.Offset")).thenReturn("0");
+        when(carbonTomcatService.getPort("http")).thenReturn(9673);
+        when(carbonTomcatService.getPort("https")).thenReturn(9443);
+        when(carbonTomcatService.getProxyPort("http")).thenReturn(0);
+        when(carbonTomcatService.getProxyPort("https")).thenReturn(0);
+        // clear system properties if set
+        clearTestedSystemPropertiesIfAlreadySet();
+        // calling init () and getPort ()
+        ServletTransportManager.init();
+        log.info("Testing getPort () functionality");
+        Assert.assertTrue(ServletTransportManager.getPort("http") == 9673,
+                "Retrieved value for http port is not equal to set value, '9763'");
+        Assert.assertTrue(ServletTransportManager.getPort("https") == 9443,
+                "Retrieved value for https port is not equal to set value, '9443'");
+        Assert.assertTrue(ServletTransportManager.getPort("jmx") == -1,
+                "Unrecognized transport scheme did not return -1");
+    }
+
+    /**
+     * Checks getProxyPort () functionality for valid and invalid inputs.
+     */
+    @Test(groups = {"org.wso2.carbon.tomcat.ext.transport"})
+    public void testGetProxyPort () {
+        // mocking internally used service instances by CarbonTomcatServiceHolder
+        ServerConfigurationService serverConfigurationService = mock(ServerConfigurationService.class);
+        CarbonTomcatService carbonTomcatService = mock(CarbonTomcatService.class);
+        // set mocked instances to CarbonTomcatServiceHolder
+        CarbonTomcatServiceHolder.setServerConfigurationService(serverConfigurationService);
+        CarbonTomcatServiceHolder.setCarbonTomcatService(carbonTomcatService);
+        // set return values for mocked instances
+        when(serverConfigurationService.getFirstProperty("Ports.Offset")).thenReturn("0");
+        when(carbonTomcatService.getPort("http")).thenReturn(9673);
+        when(carbonTomcatService.getPort("https")).thenReturn(9443);
+        when(carbonTomcatService.getProxyPort("http")).thenReturn(80);
+        when(carbonTomcatService.getProxyPort("https")).thenReturn(443);
+        // clear system properties if set
+        clearTestedSystemPropertiesIfAlreadySet();
+        // calling init () and getProxyPort ()
+        ServletTransportManager.init();
+        log.info("Testing getProxyPort () functionality");
+        Assert.assertTrue(ServletTransportManager.getProxyPort("http") == 80,
+                "Retrieved value for http port is not equal to set value, '80'");
+        Assert.assertTrue(ServletTransportManager.getProxyPort("https") == 443,
+                "Retrieved value for http port is not equal to set value, '443'");
+        Assert.assertTrue(ServletTransportManager.getProxyPort("jmx") == -1,
+                "Unrecognized transport scheme did not return -1");
+    }
+
+    private void clearTestedSystemPropertiesIfAlreadySet() {
+        System.clearProperty("mgt.transport.http.port");
+        System.clearProperty("mgt.transport.https.port");
+        System.clearProperty("mgt.transport.http.proxyPort");
+        System.clearProperty("mgt.transport.https.proxyPort");
+    }
+}

--- a/core/org.wso2.carbon.tomcat.ext/src/test/java/org/wso2/carbon/tomcat/ext/transport/statistics/TransportStatisticsEntryTest.java
+++ b/core/org.wso2.carbon.tomcat.ext/src/test/java/org/wso2/carbon/tomcat/ext/transport/statistics/TransportStatisticsEntryTest.java
@@ -52,7 +52,7 @@ public class TransportStatisticsEntryTest {
     }
 
     /**
-     * Checks getTenantName functionality for services.
+     * Checks getTenantName functionality for service, webapp and other app requests.
      */
     @Test(groups = {"org.wso2.carbon.tomcat.ext.transport.statistics"})
     public void testGetTenantName () {
@@ -61,10 +61,20 @@ public class TransportStatisticsEntryTest {
                 (146515L, 162315L, "http://example.com/services/t/abc.com/echo");
         Assert.assertTrue("abc.com".equals(transportStatisticsEntry.getTenantName()),
                 "Returned tenant domain does not match with expected");
+        log.info("Testing getTenantName () functionality for webapps");
+        transportStatisticsEntry = new TransportStatisticsEntry
+                (146515L, 162315L, "http://example.com/t/foo.com/webapps/echo");
+        Assert.assertTrue("foo.com".equals(transportStatisticsEntry.getTenantName()),
+                "Returned tenant domain does not match with expected");
+        log.info("Testing getTenantName () functionality for other app contexts ");
+        transportStatisticsEntry = new TransportStatisticsEntry
+                (146515L, 162315L, "http://example.com/t/foo.com/jaggeryapps/echo");
+        Assert.assertTrue(transportStatisticsEntry.getTenantName() == null,
+                "Returned value for tenant domain does not match with expected");
     }
 
     /**
-     * Checks getContext functionality for services.
+     * Checks getContext functionality for service, webapp and other app requests.
      */
     @Test(groups = {"org.wso2.carbon.tomcat.ext.transport.statistics"})
     public void testGetContext () {
@@ -73,5 +83,15 @@ public class TransportStatisticsEntryTest {
                 (146515L, 162315L, "http://example.com/services/t/abc.com/echo");
         Assert.assertTrue("services".equals(transportStatisticsEntry.getContext()),
                 "Returned application context does not match with expected");
+        log.info("Testing getContext () functionality for webapps");
+        transportStatisticsEntry = new TransportStatisticsEntry
+                (146515L, 162315L, "http://example.com/t/foo.com/webapps/echo");
+        Assert.assertTrue("webapps".equals(transportStatisticsEntry.getContext()),
+                "Returned application context does not match with expected");
+        log.info("Testing getContext () functionality for other app contexts");
+        transportStatisticsEntry = new TransportStatisticsEntry
+                (146515L, 162315L, "http://example.com/t/foo.com/jaggeryapps/echo");
+        Assert.assertTrue(transportStatisticsEntry.getContext() == null,
+                "Returned value for application context does not match with expected");
     }
 }


### PR DESCRIPTION
## Purpose
Adding more units-tests for core/org.wso2.carbon.tomcat.ext

## Goals
Expected test coverage increase - 12% to 22%
This resolves #1570. Additionally, this also resolves #1582, a minor bug in the code.