### PR TITLE
Add option to skip the Startup Order Resolver when registering OSGi services

### DIFF
--- a/core/src/main/java/org/wso2/carbon/kernel/internal/startupresolver/OSGiServiceCapabilityTracker.java
+++ b/core/src/main/java/org/wso2/carbon/kernel/internal/startupresolver/OSGiServiceCapabilityTracker.java
@@ -41,6 +41,7 @@ import java.util.stream.IntStream;
 import static org.wso2.carbon.kernel.internal.startupresolver.StartupResolverConstants.CAPABILITY_NAME;
 import static org.wso2.carbon.kernel.internal.startupresolver.StartupResolverConstants.COMPONENT_NAME;
 import static org.wso2.carbon.kernel.internal.startupresolver.StartupResolverConstants.OBJECT_CLASS;
+import static org.wso2.carbon.kernel.internal.startupresolver.StartupResolverConstants.SKIP_CARBON_STARTUP_RESOLVER;
 import static org.wso2.carbon.utils.StringUtils.getNonEmptyStringAfterTrim;
 
 /**
@@ -170,9 +171,14 @@ class OSGiServiceCapabilityTracker {
                                         bundle,
                                         true)));
             } else {
+                if (Boolean.TRUE.equals(reference.getProperty(SKIP_CARBON_STARTUP_RESOLVER))) {
+                    logger.debug("Skipping tracking of service {} which implements {}.", serviceImplClassName,
+                                 serviceInterfaceClassName);
+                    return null;
+                }
+
                 logger.debug("Updating indirect dependencies in components for interface={} via the implementation={}",
                         serviceInterfaceClassName, serviceImplClassName);
-
                 startupComponentManager.updateCapability(new OSGiServiceCapability(
                         serviceInterfaceClassName,
                         Capability.CapabilityType.OSGi_SERVICE,

--- a/core/src/main/java/org/wso2/carbon/kernel/internal/startupresolver/StartupComponentManager.java
+++ b/core/src/main/java/org/wso2/carbon/kernel/internal/startupresolver/StartupComponentManager.java
@@ -170,8 +170,7 @@ class StartupComponentManager {
                         logger.warn("You are trying to add an {} capability {} from bundle({}:{}) to an already " +
                                         "activated startup listener component {} in bundle({}:{}). Refer the Startup " +
                                         "Order Resolver documentation and verify your configuration",
-                                (capability.getState() == Capability.CapabilityState.AVAILABLE) ?
-                                        "available" : "expected",
+                                capability.getState(),
                                 capability.getName(),
                                 capability.getBundle().getSymbolicName(),
                                 capability.getBundle().getVersion(),
@@ -183,8 +182,7 @@ class StartupComponentManager {
                     if (logger.isDebugEnabled()) {
                         logger.debug("Adding {} required capability {} from bundle({}:{}) to " +
                                         "startup listener component {}.",
-                                (capability.getState() == Capability.CapabilityState.AVAILABLE) ?
-                                        "available" : "expected",
+                                capability.getState(),
                                 capability.getName(),
                                 capability.getBundle().getSymbolicName(),
                                 capability.getBundle().getVersion(),
@@ -211,8 +209,7 @@ class StartupComponentManager {
                                     "Either specify the capability in the " + CARBON_COMPONENT_HEADER +
                                     " manifest header or explicitly skip the Startup Order Resolver. " +
                                     "Refer the Startup Order Resolver documentation for more information.",
-                                    (capability.getState() == Capability.CapabilityState.AVAILABLE) ?
-                                            "available" : "expected",
+                                    capability.getState(),
                                     capability.getName(),
                                     capability.getBundle().getSymbolicName(),
                                     capability.getBundle().getVersion(),

--- a/core/src/main/java/org/wso2/carbon/kernel/internal/startupresolver/StartupResolverConstants.java
+++ b/core/src/main/java/org/wso2/carbon/kernel/internal/startupresolver/StartupResolverConstants.java
@@ -26,6 +26,7 @@ class StartupResolverConstants {
 
     static final String CARBON_COMPONENT_HEADER = "Carbon-Component";
     static final String CAPABILITY_NAME = "capabilityName";
+    static final String SKIP_CARBON_STARTUP_RESOLVER = "skipCarbonStartupResolver";
     static final String COMPONENT_NAME = "componentName";
     static final String STARTUP_LISTENER_COMPONENT = "startup.listener";
     static final String OSGI_SERVICE_COMPONENT = "osgi.service";

--- a/core/src/main/java/org/wso2/carbon/kernel/internal/startupresolver/beans/Capability.java
+++ b/core/src/main/java/org/wso2/carbon/kernel/internal/startupresolver/beans/Capability.java
@@ -19,6 +19,8 @@ package org.wso2.carbon.kernel.internal.startupresolver.beans;
 
 import org.osgi.framework.Bundle;
 
+import java.util.Locale;
+
 /**
  * Represents a generic capability provided by an OSGi bundle.
  *
@@ -47,8 +49,12 @@ public class Capability {
      * It could be in either EXPECTED state or AVAILABLE state
      */
     public enum CapabilityState {
-        EXPECTED,
-        AVAILABLE
+        EXPECTED, AVAILABLE;
+
+        @Override
+        public String toString() {
+            return name().toLowerCase(Locale.ENGLISH);
+        }
     }
 
     /**

--- a/docs/KernelFeatures/ResolvingtheComponentStartupOrder.md
+++ b/docs/KernelFeatures/ResolvingtheComponentStartupOrder.md
@@ -194,3 +194,16 @@ In order to solve this problem, we have introduced an interface called `Capabili
         }
 
 As explained above, the startup order resolver processes the `Carbon-Component` manifest headers, and figures out the components that need to be notified when all requirements are satisfied. Similarly, the startup order resolver figures out the expected number of OSGi services for each startup listener component. The startup order resolver listens to OSGi service events, and notifies startup listener components, as and when their requirements are satisfied.
+
+### Skipping OSGi service registrations from Carbon Startup Order Resolver
+
+There are some usecases where OSGi services will be registered dynamically in the server startup, but those 
+registrations won't affect the services startup order (e.g. starting services per deploying artifact). In those 
+scenarios, developers can skip such OSGi service registrations from the Carbon Startup Order Resolver by setting the 
+`skipCarbonStartupResolver` property to `true` in the associated service registration properties.
+
+```java
+Dictionary<String, Object> properties = new Hashtable<>();
+properties.put("skipCarbonStartupResolver", true);
+bundleContext.registerService(SomeService.class, new SomeServiceImpl(), properties);
+```

--- a/tests/osgi-tests/src/test/java/org/wso2/carbon/osgi/startupresolver/SkipServiceTrackingOSGiTest.java
+++ b/tests/osgi-tests/src/test/java/org/wso2/carbon/osgi/startupresolver/SkipServiceTrackingOSGiTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.osgi.startupresolver;
+
+import org.ops4j.pax.exam.Configuration;
+import org.ops4j.pax.exam.ExamFactory;
+import org.ops4j.pax.exam.Option;
+import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
+import org.ops4j.pax.exam.spi.reactors.PerClass;
+import org.ops4j.pax.exam.testng.listener.PaxExam;
+import org.testng.Assert;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+import org.wso2.carbon.container.CarbonContainerFactory;
+import org.wso2.carbon.kernel.CarbonServerInfo;
+import org.wso2.carbon.sample.transport.mgt.TransportManager;
+
+import javax.inject.Inject;
+
+import static org.ops4j.pax.exam.CoreOptions.maven;
+import static org.wso2.carbon.container.options.CarbonDistributionOption.copyOSGiLibBundle;
+
+/**
+ * This test case will test the skipping of service tracking in the Startup Order Resolver.
+ *
+ * @since 5.2.5
+ */
+@Listeners(PaxExam.class)
+@ExamReactorStrategy(PerClass.class)
+@ExamFactory(CarbonContainerFactory.class)
+public class SkipServiceTrackingOSGiTest {
+
+    @Inject
+    TransportManager transportManager;
+
+    @Inject
+    private CarbonServerInfo carbonServerInfo;
+
+    /**
+     * This configuration registers the capability "org.wso2.carbon.sample.transport.mgt.Transport" statically using
+     * Provider-Capability header with "org.wso2.carbon.sample.transport.http" bundle and also dynamically registers the
+     * same capability with the implementation of @see TransportServiceCapabilityProvider in
+     * "org.wso2.carbon.sample.transport.custom" bundle.
+     *
+     * @return the bundle configurations that will be used for this test case.
+     */
+    @Configuration
+    public Option[] createConfiguration() {
+        return new Option[]{
+                copyOSGiLibBundle(maven().artifactId("org.wso2.carbon.sample.transport.mgt").groupId("org.wso2.carbon")
+                                          .versionAsInProject()),
+                copyOSGiLibBundle(maven().artifactId("org.wso2.carbon.sample.transport.ftp").groupId("org.wso2.carbon")
+                                          .versionAsInProject()),
+                copyOSGiLibBundle(maven().artifactId("org.wso2.carbon.sample.order.resolver").groupId("org.wso2.carbon")
+                                          .versionAsInProject())
+        };
+    }
+
+    @Test
+    public void testSkipServiceTracking() {
+        int expectedTransportCount = 2;
+        int actualTransportCount = transportManager.getTransportCount();
+        Assert.assertEquals(actualTransportCount, expectedTransportCount, "Transport count is not correct.");
+    }
+}

--- a/tests/test-artifacts/startup-coordination/org.wso2.carbon.sample.transport.ftp/pom.xml
+++ b/tests/test-artifacts/startup-coordination/org.wso2.carbon.sample.transport.ftp/pom.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.wso2.carbon</groupId>
+        <artifactId>carbon-kernel-startup-resolver-test-artifacts</artifactId>
+        <version>5.2.5-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>org.wso2.carbon.sample.transport.ftp</artifactId>
+    <packaging>bundle</packaging>
+
+    <name>WSO2 Carbon Kernel - Sample Transport FTP</name>
+    <url>http://wso2.com</url>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.wso2.carbon</groupId>
+            <artifactId>org.wso2.carbon.sample.transport.mgt</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.eclipse.osgi</groupId>
+            <artifactId>org.eclipse.osgi</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.eclipse.osgi</groupId>
+            <artifactId>org.eclipse.osgi.services</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.ops4j.pax.logging</groupId>
+            <artifactId>pax-logging-api</artifactId>
+            <optional>true</optional>
+        </dependency>
+    </dependencies>
+
+    <properties>
+        <export.package>org.wso2.carbon.sample.transport.ftp</export.package>
+        <import.package>*</import.package>
+        <carbon.component>
+            osgi.service; objectClass="org.wso2.carbon.sample.transport.mgt.Transport"; serviceCount="2"
+        </carbon.component>
+    </properties>
+
+</project>

--- a/tests/test-artifacts/startup-coordination/org.wso2.carbon.sample.transport.ftp/src/main/java/org/wso2/carbon/sample/transport/ftp/FtpTransport.java
+++ b/tests/test-artifacts/startup-coordination/org.wso2.carbon.sample.transport.ftp/src/main/java/org/wso2/carbon/sample/transport/ftp/FtpTransport.java
@@ -1,18 +1,21 @@
 /*
- *  Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *  http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
+
 package org.wso2.carbon.sample.transport.ftp;
 
 import org.slf4j.Logger;

--- a/tests/test-artifacts/startup-coordination/org.wso2.carbon.sample.transport.ftp/src/main/java/org/wso2/carbon/sample/transport/ftp/FtpTransport.java
+++ b/tests/test-artifacts/startup-coordination/org.wso2.carbon.sample.transport.ftp/src/main/java/org/wso2/carbon/sample/transport/ftp/FtpTransport.java
@@ -1,0 +1,41 @@
+/*
+ *  Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.wso2.carbon.sample.transport.ftp;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.wso2.carbon.sample.transport.mgt.Transport;
+
+/**
+ * A sample FTP transport implementation which will be used for testing skipping service tracking in the Startup Order
+ * Resolver.
+ *
+ * @since 5.2.5
+ */
+public class FtpTransport implements Transport {
+
+    private static final Logger logger = LoggerFactory.getLogger(FtpTransport.class);
+
+    @Override
+    public void start() {
+        logger.info("Transport service : " + this.getClass().getName());
+    }
+
+    @Override
+    public void stop() {
+
+    }
+}

--- a/tests/test-artifacts/startup-coordination/org.wso2.carbon.sample.transport.ftp/src/main/java/org/wso2/carbon/sample/transport/ftp/FtpTransportServiceComponent.java
+++ b/tests/test-artifacts/startup-coordination/org.wso2.carbon.sample.transport.ftp/src/main/java/org/wso2/carbon/sample/transport/ftp/FtpTransportServiceComponent.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.sample.transport.ftp;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.wso2.carbon.sample.transport.mgt.Transport;
+
+import java.util.Dictionary;
+import java.util.Hashtable;
+import java.util.stream.IntStream;
+
+/**
+ * OSGi service component that will register FTP transports.
+ *
+ * @since 5.2.5
+ */
+@Component(immediate = true)
+public class FtpTransportServiceComponent {
+
+    private static final Logger logger = LoggerFactory.getLogger(FtpTransportServiceComponent.class);
+    private static final int TRACKED_SERVICE_COUNT = 2;
+    private static final int SKIPPED_SERVICE_COUNT = 2;
+
+    @Activate
+    protected void activate(BundleContext bundleContext) {
+        registerTrackedTransports(bundleContext);
+        registerSkippedTransports(bundleContext);
+        logger.debug("FTP transport service component activated.");
+    }
+
+    @Deactivate
+    protected void deactivate(BundleContext bundleContext) {
+        logger.debug("FTP transport service component deactivated.");
+    }
+
+    private void registerTrackedTransports(BundleContext bundleContext) {
+        IntStream.range(0, TRACKED_SERVICE_COUNT)
+                .forEach($ -> {
+                    Dictionary<String, Object> properties = new Hashtable<>();
+                    properties.put("skipCarbonStartupResolver", false);
+                    bundleContext.registerService(Transport.class, new FtpTransport(), properties);
+                });
+    }
+
+    private void registerSkippedTransports(BundleContext bundleContext) {
+        IntStream.range(0, SKIPPED_SERVICE_COUNT)
+                .forEach($ -> {
+                    Dictionary<String, Object> properties = new Hashtable<>();
+                    properties.put("skipCarbonStartupResolver", true);
+                    bundleContext.registerService(Transport.class, new FtpTransport(), properties);
+                });
+    }
+}

--- a/tests/test-artifacts/startup-coordination/pom.xml
+++ b/tests/test-artifacts/startup-coordination/pom.xml
@@ -34,6 +34,7 @@
         <module>org.wso2.carbon.sample.transport.custom</module>
         <module>org.wso2.carbon.sample.transport.custom2</module>
         <module>org.wso2.carbon.sample.transport.file</module>
+        <module>org.wso2.carbon.sample.transport.ftp</module>
         <module>org.wso2.carbon.sample.transport.mgt</module>
         <module>org.wso2.carbon.sample.runtime.mgt</module>
         <module>org.wso2.carbon.sample.runtime.mss</module>


### PR DESCRIPTION
## Purpose
Currently there is no way to skip the Carbon Startup Resolver when registering an OSGi service dynamically (via the `BundleContext`). 
Resolves #1584

## Goals
This PR adds an option to skip the Carbon Startup Resolver when registering an OSGi service via `BundleContext`.

## Approach
In the OSGi service tracking process, we check for the `skipCarbonStartupResolver` property in the associated service registration properties. If `skipCarbonStartupResolver` is set to `true`, then we skip that service.

## Documentation
Docs are updated in `docs/KernelFeatures/ResolvingtheComponentStartupOrder.md` file.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? **yes**
 - Ran FindSecurityBugs plugin and verified report? **yes**
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? **yes**

## Samples
Included in the docs.