### PR TITLE
Add icf-register tool

### DIFF
--- a/docs/DeveloperTools/RegisteringInitialContextFactories.md
+++ b/docs/DeveloperTools/RegisteringInitialContextFactories.md
@@ -1,0 +1,23 @@
+# Registering InitialContextFactory classes to OSGI env
+> The process of registering InitialContextFactory to OSGi env in a WSO2 product is explained below. For the full list of capabilities available in this kernel version, see the **features** section in the [root README.md file](../../README.md#key-features-and-tools). 
+
+ICF Register is a standalone tool that can be used for products that are based on Carbon 5 (WSO2 Carbon 5 platform). The implementation of this tool has been added to the freshly introduced Tools module (Maven module) of the WSO2 Carbon 5 platform.
+
+> Read more about Carbon tools and the instructions for developing new tools from [here](../KernelFeatures/DevelopingaCarbonTool.md). 
+
+The need for this functionality arose due to the OSGi JNDI specification where when you register an InitialContextFactory you need to register it for both the interface and the implementation. The primary purpose of this tool is register InitialContextFactory classes based on the OSGi JNDI spec. 
+From the implementation, we primarily generate a Custom BundleActivator and register the user provided InitialContextFactory implementation of the provided jar, under both interface and the implementation. If the provided file is an Jar file this will wrap that as a Bundle as well. 
+
+## To Run the Tool:
+
+The 'ICF Register' tool that is shipped with Carbon Kernel can be executed to create a bundle which will be responsible of registering the provided ICF based on OSGi JNDI spec.
+You can execute the relevant script using the following steps:
+
+1. Open a terminal.
+2. Navigate to the `<PRODUCT_HOME>/bin` directory. The scripts for executing this tool are stored in this folder.
+3. Execute the relevant script:
+
+  * In a Unix system:  `sh icf-register.sh` [Full qualified name of ICF impl class name] [path to source jar] [destination] 
+  * In the Windows platform: `icf-register.bat` [Full qualified name of ICF impl class name] [path to source jar] [destination] 
+
+> Restrictions: Note that the required file permissions are considered when reading source JARs and the destination directory.

--- a/features/org.wso2.carbon.server.feature/resources/bin/icf-register.bat
+++ b/features/org.wso2.carbon.server.feature/resources/bin/icf-register.bat
@@ -1,0 +1,81 @@
+@echo off
+
+REM ---------------------------------------------------------------------------
+REM   Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+REM
+REM   Licensed under the Apache License, Version 2.0 (the "License");
+REM   you may not use this file except in compliance with the License.
+REM   You may obtain a copy of the License at
+REM
+REM   http://www.apache.org/licenses/LICENSE-2.0
+REM
+REM   Unless required by applicable law or agreed to in writing, software
+REM   distributed under the License is distributed on an "AS IS" BASIS,
+REM   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+REM   See the License for the specific language governing permissions and
+REM   limitations under the License.
+
+rem ----- if JAVA_HOME is not set we're not happy ------------------------------
+:checkJava
+
+if "%JAVA_HOME%" == "" goto noJavaHome
+if not exist "%JAVA_HOME%\bin\java.exe" goto noJavaHome
+goto checkServer
+
+:noJavaHome
+echo "You must set the JAVA_HOME variable before running CARBON."
+goto end
+
+rem ----- Only set CARBON_HOME if not already set ----------------------------
+:checkServer
+rem %~sdp0 is expanded pathname of the current script under NT with spaces in the path removed
+if "%CARBON_HOME%"=="" set CARBON_HOME=%~sdp0..
+SET curDrive=%cd:~0,1%
+SET wsasDrive=%CARBON_HOME:~0,1%
+if not "%curDrive%" == "%wsasDrive%" %wsasDrive%:
+
+rem find CARBON_HOME if it does not exist due to either an invalid value passed
+rem by the user or the %0 problem on Windows 9x
+if not exist "%CARBON_HOME%\bin\kernel-version.txt" goto noServerHome
+
+goto commandLifecycle
+
+:noServerHome
+echo CARBON_HOME is set incorrectly or CARBON could not be located. Please set CARBON_HOME.
+goto end
+
+:commandLifecycle
+goto findJdk
+
+:findJdk
+
+set CMD=RUN %*
+
+:checkJdk16
+"%JAVA_HOME%\bin\java" -version 2>&1 | findstr /r "1.[8]" >NUL
+IF ERRORLEVEL 1 goto unknownJdk
+goto jdk16
+
+:unknownJdk
+echo Starting WSO2 Carbon (in unsupported JDK)
+echo [ERROR] CARBON is supported only on JDK 1.8
+goto jdk16
+
+:jdk16
+goto runTool
+
+:runTool
+
+set CURRENT_DIR=%cd%
+
+cd %CARBON_HOME%\bin
+echo JAVA_HOME environment variable is set to %JAVA_HOME%
+echo CARBON_HOME environment variable is set to %CARBON_HOME%
+java -cp ".\*;..\bin\tools\*" -Dcarbon.home="%CARBON_HOME" -Dwso2.carbon.tool="icf-register" org.wso2.carbon.tools.CarbonToolExecutor "%1" "%2" "%3" "%4"
+
+:end
+goto endlocal
+
+:endlocal
+
+:END

--- a/features/org.wso2.carbon.server.feature/resources/bin/icf-register.sh
+++ b/features/org.wso2.carbon.server.feature/resources/bin/icf-register.sh
@@ -1,0 +1,124 @@
+#!/bin/sh
+# ---------------------------------------------------------------------------
+#  Copyright (c) 2015, WSO7 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+# ----------------------------------------------------------------------------
+
+cygwin=false;
+darwin=false;
+os400=false;
+mingw=false;
+case "`uname`" in
+CYGWIN*) cygwin=true;;
+MINGW*) mingw=true;;
+OS400*) os400=true;;
+Darwin*) darwin=true
+        if [ -z "$JAVA_VERSION" ] ; then
+             JAVA_VERSION="CurrentJDK"
+           else
+             echo "Using Java version: $JAVA_VERSION"
+           fi
+           if [ -z "$JAVA_HOME" ] ; then
+             JAVA_HOME=/System/Library/Frameworks/JavaVM.framework/Versions/${JAVA_VERSION}/Home
+           fi
+           ;;
+esac
+
+# resolve links - $0 may be a softlink
+PRG="$0"
+
+while [ -h "$PRG" ]; do
+  ls=`ls -ld "$PRG"`
+  link=`expr "$ls" : '.*-> \(.*\)$'`
+  if expr "$link" : '.*/.*' > /dev/null; then
+    PRG="$link"
+  else
+    PRG=`dirname "$PRG"`/"$link"
+  fi
+done
+
+# Get standard environment variables
+PRGDIR=`dirname "$PRG"`
+
+# Only set CARBON_HOME if not already set
+[ -z "$CARBON_HOME" ] && CARBON_HOME=`cd "$PRGDIR/.." ; pwd`
+
+# For Cygwin, ensure paths are in UNIX format before anything is touched
+if $cygwin; then
+  [ -n "$JAVA_HOME" ] && JAVA_HOME=`cygpath --unix "$JAVA_HOME"`
+  [ -n "$CARBON_HOME" ] && CARBON_HOME=`cygpath --unix "$CARBON_HOME"`
+fi
+
+# For OS400
+if $os400; then
+  # Set job priority to standard for interactive (interactive - 6) by using
+  # the interactive priority - 6, the helper threads that respond to requests
+  # will be running at the same priority as interactive jobs.
+  COMMAND='chgjob job('$JOBNAME') runpty(6)'
+  system $COMMAND
+
+  # Enable multi threading
+  QIBM_MULTI_THREADED=Y
+  export QIBM_MULTI_THREADED
+fi
+
+# For Migwn, ensure paths are in UNIX format before anything is touched
+if $mingw ; then
+  [ -n "$CARBON_HOME" ] &&
+    CARBON_HOME="`(cd "$CARBON_HOME"; pwd)`"
+  [ -n "$JAVA_HOME" ] &&
+    JAVA_HOME="`(cd "$JAVA_HOME"; pwd)`"
+fi
+
+if [ -z "$JAVACMD" ] ; then
+  if [ -n "$JAVA_HOME"  ] ; then
+    if [ -x "$JAVA_HOME/jre/sh/java" ] ; then
+      # IBM's JDK on AIX uses strange locations for the executables
+      JAVACMD="$JAVA_HOME/jre/sh/java"
+    else
+      JAVACMD="$JAVA_HOME/bin/java"
+    fi
+  else
+    JAVACMD=java
+  fi
+fi
+
+if [ ! -x "$JAVACMD" ] ; then
+  echo "Error: JAVA_HOME is not defined correctly."
+  echo " CARBON cannot execute $JAVACMD"
+  exit 1
+fi
+
+# if JAVA_HOME is not set we're not happy
+if [ -z "$JAVA_HOME" ]; then
+  echo "You must set the JAVA_HOME variable before running CARBON."
+  exit 1
+fi
+
+jdk_18=`$JAVA_HOME/bin/java -version 2>&1 | grep "1.[8]"`
+if [ "$jdk_18" = "" ]; then
+   echo " Starting WSO2 Carbon (in unsupported JDK)"
+   echo " [ERROR] CARBON is supported only on JDK 1.8"
+   exit 1
+fi
+
+echo JAVA_HOME environment variable is set to $JAVA_HOME
+echo CARBON_HOME environment variable is set to $CARBON_HOME
+
+# get the current directory from which the script is executed
+CURRENT_DIR=${PWD};
+
+cd "$CARBON_HOME/bin/";
+java -cp "../bin/tools/*" -Dcarbon.home="$CARBON_HOME" -Dwso2.carbon.tool="icf-register" org.wso2.carbon.tools.CarbonToolExecutor "$1" "$2" "$3" "$4"

--- a/tools/tools-core/src/main/java/org/wso2/carbon/tools/CarbonToolExecutor.java
+++ b/tools/tools-core/src/main/java/org/wso2/carbon/tools/CarbonToolExecutor.java
@@ -18,6 +18,7 @@ package org.wso2.carbon.tools;
 import org.wso2.carbon.tools.converter.BundleGeneratorTool;
 import org.wso2.carbon.tools.exception.CarbonToolException;
 import org.wso2.carbon.tools.osgilib.OSGiLibDeployerTool;
+import org.wso2.carbon.tools.spi.ICFRegisterTool;
 
 import java.util.Optional;
 import java.util.logging.Level;
@@ -72,6 +73,9 @@ public class CarbonToolExecutor {
             break;
         case "osgi-lib-deployer":
             carbonTool = new OSGiLibDeployerTool();
+            break;
+        case "icf-register":
+            carbonTool = new ICFRegisterTool();
             break;
         default:
             carbonTool = null;

--- a/tools/tools-core/src/main/java/org/wso2/carbon/tools/Constants.java
+++ b/tools/tools-core/src/main/java/org/wso2/carbon/tools/Constants.java
@@ -29,6 +29,7 @@ public class Constants {
     public static final String BUNDLE_MANIFEST_VERSION = "Bundle-ManifestVersion";
     public static final String BUNDLE_NAME = "Bundle-Name";
     public static final String BUNDLE_SYMBOLIC_NAME = "Bundle-SymbolicName";
+    public static final String BUNDLE_ACTIVATOR = "Bundle-Activator";
     public static final String BUNDLE_VERSION = "Bundle-Version";
     public static final String EXPORT_PACKAGE = "Export-Package";
     public static final String BUNDLE_CLASSPATH = "Bundle-ClassPath";

--- a/tools/tools-core/src/main/java/org/wso2/carbon/tools/converter/utils/BundleGeneratorUtils.java
+++ b/tools/tools-core/src/main/java/org/wso2/carbon/tools/converter/utils/BundleGeneratorUtils.java
@@ -157,7 +157,7 @@ public class BundleGeneratorUtils {
      * @throws CarbonToolException if {@link Path} {@code zipFilePath} does not refer to a .jar file or if
      *                             {@link Path} {@code zipFilePath} has zero elements
      */
-    private static boolean isOSGiBundle(Path jaFilePath) throws IOException, CarbonToolException {
+    public static boolean isOSGiBundle(Path jaFilePath) throws IOException, CarbonToolException {
         boolean hasSymbolicName, hasVersion;
         try (FileSystem zipFileSystem = BundleGeneratorUtils.createZipFileSystem(jaFilePath, false)) {
             Path manifestPath = zipFileSystem.getPath(Constants.JAR_MANIFEST_FOLDER, Constants.MANIFEST_FILE_NAME);

--- a/tools/tools-core/src/main/java/org/wso2/carbon/tools/spi/ICFRegisterTool.java
+++ b/tools/tools-core/src/main/java/org/wso2/carbon/tools/spi/ICFRegisterTool.java
@@ -1,0 +1,220 @@
+/*
+* Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package org.wso2.carbon.tools.spi;
+
+import org.wso2.carbon.tools.CarbonTool;
+import org.wso2.carbon.tools.converter.utils.BundleGeneratorUtils;
+import org.wso2.carbon.tools.exception.CarbonToolException;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.jar.JarFile;
+import java.util.jar.Manifest;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.naming.spi.InitialContextFactory;
+import javax.tools.JavaCompiler;
+import javax.tools.ToolProvider;
+
+import static org.wso2.carbon.tools.Constants.BUNDLE_ACTIVATOR;
+import static org.wso2.carbon.tools.Constants.JAR_MANIFEST_FOLDER;
+import static org.wso2.carbon.tools.Constants.MANIFEST_FILE_NAME;
+
+/**
+ * This will add a BundleActivator which will register the {@link InitialContextFactory} based on OSGi JNDI spec.
+ *
+ * @since 5.2.1
+ */
+public class ICFRegisterTool implements CarbonTool {
+
+    private static final Logger logger = Logger.getLogger(ICFRegisterTool.class.getName());
+    private static final String ACTIVATOR_CLASS_FILE = "CustomBundleActivator.class";
+    private static final String ACTIVATOR_JAVA_FILE = "CustomBundleActivator.java";
+    private static final String INTERNAL_PKG_NAME = "internal";
+    private static final String ACTIVATOR_FULL_QUALIFIED_NAME = "internal.CustomBundleActivator";
+
+    private static final String CLASS_TEMPLATE =
+            "package internal;\n" +
+            "import org.osgi.framework.BundleActivator;\n" +
+            "import org.osgi.framework.BundleContext;\n" +
+            "import %s;\n" +
+            "\n" +
+            "import javax.naming.spi.InitialContextFactory;\n" +
+            "\n" +
+            "public class CustomBundleActivator implements BundleActivator {\n" +
+            "\n" + "    " +
+            "@Override\n" +
+            "    public void start(BundleContext bundleContext) throws Exception {\n" +
+            "        bundleContext.registerService(new String[] { \"" + InitialContextFactory.class.getName() +
+            "\", \"%s\" }, new %s(), null);\n" +
+            "    }\n" +
+            "\n" +
+            "    @Override\n" +
+            "    public void stop(BundleContext bundleContext) throws Exception {\n" +
+            "\n" +
+            "    " +
+            "}\n" +
+            "}\n";
+
+    @Override
+    public void execute(String... toolArgs) {
+        if (toolArgs.length < 3 || toolArgs.length > 4) {
+            String message = "Improper usage detected. " +
+                             "Usage: icf-register.sh|bat [ICF Impl class] [jar file] [destination] [OSGi jar path]" +
+                             "First 3 arguments are compulsory.";
+            logger.log(Level.INFO, message);
+            return;
+        }
+
+        String spiImpl = toolArgs[0];
+        Path jarFile = Paths.get(toolArgs[1]);
+        Path destination = Paths.get(toolArgs[2]);
+        String osgiJar = (toolArgs.length == 4 && !toolArgs[3].isEmpty()) ? toolArgs[3] :
+                         Paths.get(System.getProperty("carbon.home"), "wso2", "lib", "plugins",
+                                   "org.eclipse.osgi_3.11.0.v20160603-1336.jar").toString();
+
+        Path fileName = jarFile.getFileName();
+        if (fileName == null) {
+            return;
+        }
+        String jarFileName = fileName.toString();
+        Path tmpDir = destination.resolve(jarFileName.substring(0, jarFileName.lastIndexOf(".")));
+
+        Process process = null;
+        if (Files.exists(jarFile) && Files.exists(destination) && Files.isWritable(destination) &&
+            !Files.exists(tmpDir)) {
+            FileOutputStream fileOutputStream = null;
+            try {
+                Files.createDirectory(tmpDir);
+
+                // Prepare source.
+                String source = String.format(CLASS_TEMPLATE, spiImpl, spiImpl, spiImpl);
+
+                // Save source in .java file.
+                Path internal = Files.createDirectory(tmpDir.resolve(INTERNAL_PKG_NAME));
+                File sourceFile = new File(internal.toFile(), ACTIVATOR_JAVA_FILE);
+                Files.write(internal.resolve(ACTIVATOR_JAVA_FILE), source.getBytes(StandardCharsets.UTF_8));
+
+                // Compile source file.
+                JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+
+                List<String> compilerArgs = new ArrayList<>();
+                compilerArgs.add("-cp");
+                String separator =
+                        System.getProperty("os.name").toLowerCase(Locale.ENGLISH).contains("windows") ? ";" : ":";
+                compilerArgs.add(jarFile.toString() + separator + osgiJar);
+                compilerArgs.add(sourceFile.getPath());
+                fileOutputStream = new FileOutputStream(internal.resolve(ACTIVATOR_CLASS_FILE).toFile());
+                compiler.run(null, fileOutputStream, null, compilerArgs.toArray(new String[0]));
+
+                //Copy the original jar file to tmp dir
+                Path finalJarPath = tmpDir.resolve(jarFileName);
+                Files.copy(jarFile, finalJarPath);
+
+                // Add the .class file to jar
+                StringBuilder command = new StringBuilder();
+                command.append("jar uf ")
+                       .append(finalJarPath.toString())
+                       .append(" -C ")
+                       .append(tmpDir.toString())
+                       .append(" ")
+                       .append(internal.resolve(ACTIVATOR_CLASS_FILE).toString().replace(tmpDir.toString(), ""));
+                logger.log(Level.INFO, "Executing '" + command.toString() + "'");
+                process = Runtime.getRuntime().exec(command.toString());
+                process.waitFor(5, TimeUnit.SECONDS);
+                addBundleActivatorHeader(finalJarPath, tmpDir);
+            } catch (IOException e) {
+                logger.log(Level.SEVERE, "Error while running SPI Creator", e);
+            } catch (InterruptedException e) {
+                logger.log(Level.SEVERE, "Error while adding SPI", e);
+            } catch (CarbonToolException e) {
+                logger.log(Level.SEVERE, "Error while converting to bundle", e);
+            } finally {
+                if (process != null) {
+                    process.destroy();
+                }
+                if (fileOutputStream != null) {
+                    try {
+                        fileOutputStream.close();
+                    } catch (IOException e) {
+                        logger.log(Level.WARNING, "Error while closing OutputStream", e);
+                    }
+                }
+            }
+        } else {
+            String message = "The destination location '" + tmpDir.toString() +
+                             "' already exist/does not have write permissions or jar file doesn't exist";
+            logger.log(Level.WARNING, message);
+        }
+    }
+
+    /**
+     * Add 'Bundle-Activator: CustomBundleActivator' to MANIFEST.MF file.
+     *
+     * @param finalJarPath Path of the jar file
+     * @param destination  Destination path where jar get created.
+     * @throws IOException         if an error occur while reading/writing jar file
+     * @throws CarbonToolException if an error occur when converting to bundle
+     */
+    private void addBundleActivatorHeader(Path finalJarPath, Path destination) throws IOException, CarbonToolException {
+        Manifest manifest = new Manifest();
+        manifest.getMainAttributes().putValue(BUNDLE_ACTIVATOR, ACTIVATOR_FULL_QUALIFIED_NAME);
+        if (BundleGeneratorUtils.isOSGiBundle(finalJarPath)) {
+            logger.log(Level.INFO, "Adding '" + BUNDLE_ACTIVATOR + ": CustomBundleActivator' to " + MANIFEST_FILE_NAME);
+            Path manifestmfFile = destination.resolve(MANIFEST_FILE_NAME);
+            try (JarFile jar = new JarFile(finalJarPath.toString()); PrintWriter printWriter = new PrintWriter(
+                    new OutputStreamWriter(new FileOutputStream(manifestmfFile.toFile()),
+                                           "UTF-8")); InputStream inputStream = jar
+                    .getInputStream(jar.getEntry(JAR_MANIFEST_FOLDER + "/" + MANIFEST_FILE_NAME));) {
+                Files.copy(inputStream, destination.resolve(MANIFEST_FILE_NAME + ".tmp"));
+                List<String> existingManifest = Files.readAllLines(destination.resolve(MANIFEST_FILE_NAME + ".tmp"));
+                existingManifest.add(BUNDLE_ACTIVATOR + ": " + ACTIVATOR_FULL_QUALIFIED_NAME);
+                existingManifest.forEach(printWriter::println);
+                printWriter.flush();
+            }
+
+            Map<String, String> env = new HashMap<>();
+            env.put("create", "true");
+            URI uri = URI.create("jar:file:" + finalJarPath.toString());
+            try (FileSystem zipfs = FileSystems.newFileSystem(uri, env)) {
+                Path pathInZipfile = zipfs.getPath(JAR_MANIFEST_FOLDER, MANIFEST_FILE_NAME);
+                Files.copy(manifestmfFile, pathInZipfile, StandardCopyOption.REPLACE_EXISTING);
+            }
+            logger.log(Level.INFO, "Created bundle file: '" + finalJarPath.toString());
+        } else {
+            logger.log(Level.INFO, "Running jar to bundle conversion");
+            BundleGeneratorUtils.convertFromJarToBundle(finalJarPath, destination, manifest, "");
+        }
+    }
+}

--- a/tools/tools-core/src/test/java/org/wso2/carbon/tools/spi/ICFRegisterToolTest.java
+++ b/tools/tools-core/src/test/java/org/wso2/carbon/tools/spi/ICFRegisterToolTest.java
@@ -1,0 +1,68 @@
+/*
+* Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package org.wso2.carbon.tools.spi;
+
+import org.testng.annotations.Test;
+import org.wso2.carbon.tools.Constants;
+import org.wso2.carbon.tools.TestConstants;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.jar.JarFile;
+
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertNotNull;
+import static org.testng.AssertJUnit.assertTrue;
+
+public class ICFRegisterToolTest {
+    private static final Path converterTestResources =
+            Paths.get(TestConstants.TARGET_FOLDER, TestConstants.TEST_RESOURCES,
+                      TestConstants.CONVERTER_TEST_RESOURCES);
+    private static final Path sampleJARFile = Paths.get(converterTestResources.toString(), TestConstants.ARTIFACT_FIVE);
+
+    @Test
+    public void testAddingSPI() throws IOException {
+        ICFRegisterTool icfRegisterTool = new ICFRegisterTool();
+        String spiImpl = "org.wso2.carbon.impl.TestSPIImpl";
+        icfRegisterTool.execute(spiImpl, sampleJARFile.toString(), converterTestResources.toString(),
+                                converterTestResources.getParent().resolve("lib")
+                                                      .resolve("org.eclipse.osgi_3.11.0.v20160603-1336.jar")
+                                                      .toString());
+
+        String jarFileName = sampleJARFile.getFileName().toString();
+        Path tmpDir = converterTestResources.resolve(jarFileName.substring(0, jarFileName.lastIndexOf(".")));
+        int i = jarFileName.lastIndexOf(".");
+        Path finalJarPath = tmpDir.resolve(
+                new StringBuilder(jarFileName.replace("-", "_")).replace(i, i + 1, "_1.0.0.").toString());
+        assertTrue(Files.exists(finalJarPath));
+
+        Path extractPath = tmpDir.resolve("carbon-spi-fly.jar");
+        try (JarFile jarFile = new JarFile(finalJarPath.toFile());
+             InputStream is = jarFile.getInputStream(jarFile.getEntry(jarFileName))) {
+            assertEquals("internal.CustomBundleActivator",
+                         jarFile.getManifest().getMainAttributes().getValue(Constants.BUNDLE_ACTIVATOR));
+            assertNotNull(jarFile.getJarEntry(jarFileName));
+            Files.copy(is, extractPath);
+            assertTrue(Files.exists(extractPath));
+        }
+        try (JarFile jarFile = new JarFile(extractPath.toString())) {
+            assertNotNull(jarFile.getEntry("internal/CustomBundleActivator.class"));
+        }
+    }
+}

--- a/tools/tools-core/src/test/resources/testng.xml
+++ b/tools/tools-core/src/test/resources/testng.xml
@@ -24,6 +24,7 @@ limitations under the License.
             <class name="org.wso2.carbon.tools.converter.ListPackagesTest"/>
             <class name="org.wso2.carbon.tools.converter.ConversionTest"/>
             <class name="org.wso2.carbon.tools.osgilib.OSGiLibDeployerToolTest"/>
+            <class name="org.wso2.carbon.tools.spi.ICFRegisterToolTest"/>
         </classes>
     </test>
 </suite>


### PR DESCRIPTION
## Purpose
This adds ICF Register tool. Resolves #1577 

## Goals
In order to be compatible with OSGi JNDI spec, ICF providers need to register the ICF implementations to OSGi env under both ICF interface and implementation.

## Approach
This will add a BundleActivator to the user provided jar/bundle which will register the user mentioned ICF implementation according to the OSGi JNDI spec.

## User stories
According to OSGi JNDI spec, all the InitialContextFactories should be exposed as OSGi services. But some client jar files don't contain SPI, but rather they set system properties. So we need to make these compatible with OSGi JNDI spec.

## Release note
N/A

## Documentation
How to run spicreator script
```
./icf-register.(sh|bat) <Full qualified name of ICF Ipml> <Jar path> <destination>
```
e.g.
```
./spicreator.sh org.apache.activemq.jndi.ActiveMQInitialContextFactory /tmp/activemq-client-5.9.0.jar /tmp
```
## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
 - Unit tests 
   > Unit Test created
 - Integration tests
   > N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
N/A
 
## Learning
N/A