### PR TITLE
Add PowerMock, a powerful extension of Mockito

### DIFF
--- a/core/org.wso2.carbon.tomcat.ext/pom.xml
+++ b/core/org.wso2.carbon.tomcat.ext/pom.xml
@@ -91,13 +91,18 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-api-mockito2</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-module-testng</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/distribution/integration/tests-integration/user-core/pom.xml
+++ b/distribution/integration/tests-integration/user-core/pom.xml
@@ -46,8 +46,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
-            <version>${org.mockito.version}</version>
+            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -585,15 +585,15 @@
         <version.com.google.code.gson>2.3.1</version.com.google.code.gson>
 
         <test.framework.version>4.4.3</test.framework.version>
-        <testng.verson>6.1.1</testng.verson>
-        <org.mockito.version>1.9.5</org.mockito.version>
+        <testng.verson>6.10</testng.verson>
         <org.apacheds.version>1.5.5</org.apacheds.version>
 
         <!-- Unit/Integration tests -->
         <jacoco.version>0.7.9</jacoco.version>
         <maven.surefire.plugin.version>2.20.1</maven.surefire.plugin.version>
         <maven.failsafe.plugin.version>2.20.1</maven.failsafe.plugin.version>
-        <mockito.version>2.10.0</mockito.version>
+        <mockito.version>2.8.9</mockito.version>
+        <powermock.version>1.7.3</powermock.version>
 
         <!-- OWASP CSRFGuard Version -->
         <orbit.version.csrfguard>3.1.0.wso2v2</orbit.version.csrfguard>
@@ -1679,6 +1679,16 @@
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-core</artifactId>
                 <version>${mockito.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.powermock</groupId>
+                <artifactId>powermock-api-mockito2</artifactId>
+                <version>${powermock.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.powermock</groupId>
+                <artifactId>powermock-module-testng</artifactId>
+                <version>${powermock.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
## Purpose
PowerMock is a framework that extends other mock libraries such as Mockito with more powerful capabilities. PowerMock uses a custom classloader and bytecode manipulation to enable mocking of static methods, constructors, final classes and methods, private methods, removal of static initializers and more (https://github.com/powermock/powermock). This commit adds PowerMock to carbon-kernel 4.4.x. In addtion, this also involves updating testng version to 6.10 for compatibility reasons. 

This resolves #1580.