### PR TITLE
check registry resource permission for a user in tag deletion

### DIFF
--- a/core/org.wso2.carbon.registry.core/src/main/java/org/wso2/carbon/registry/core/jdbc/EmbeddedRegistry.java
+++ b/core/org.wso2.carbon.registry.core/src/main/java/org/wso2/carbon/registry/core/jdbc/EmbeddedRegistry.java
@@ -1662,6 +1662,9 @@ public class EmbeddedRegistry implements Registry {
                         String author = resource.getAuthorUserName();
                         if (user.equals(author)) {
                             tagsDAO.removeTags(resource, tag);
+                        } else if (userRealm.getAuthorizationManager().isUserAuthorized(user, path,
+                                ActionConstants.DELETE)) {
+                            tagsDAO.removeTags(resource, tag);
                         } else {
                             tagsDAO.removeTags(resource, tag, user);
                         }
@@ -1676,6 +1679,11 @@ public class EmbeddedRegistry implements Registry {
                 // transaction succeeded
                 transactionSucceeded = true;
             }
+        } catch (UserStoreException e) {
+            String msg = "Failed to check if the user is Authorized to perform a delete operation on registry path: "
+                    + path;
+            log.error(msg, e);
+            throw new RegistryException(msg, e);
         } finally {
             if (transactionSucceeded) {
                 commitTransaction();

--- a/core/org.wso2.carbon.registry.core/src/test/java/org/wso2/carbon/registry/core/test/jdbc/TagsTest.java
+++ b/core/org.wso2.carbon.registry.core/src/test/java/org/wso2/carbon/registry/core/test/jdbc/TagsTest.java
@@ -163,4 +163,52 @@ public class TagsTest extends BaseTestCase {
         Tag[] tags4 = adminRegistry.getTags("/r1");
         assertEquals("There should be 2 taggings on resource '/r1'", 2, tags4[0].getTagCount());
     }
+
+    public void testDeleteTagCreatedByDifferentUser() throws Exception {
+
+        RealmConfiguration realmConfig = ctx.getRealmService().getBootstrapRealmConfiguration();
+
+        UserRegistry adminRegistry = embeddedRegistryService.
+                getUserRegistry(realmConfig.getAdminUserName(), realmConfig.getAdminPassword());
+        UserRealm adminRealm = adminRegistry.getUserRealm();
+
+        // add first user who can create tag
+        adminRealm.getUserStoreManager().addUser("foo1", "cce123", null, null, null);
+        adminRealm.getAuthorizationManager().
+                authorizeUser("foo1", RegistryConstants.ROOT_PATH, ActionConstants.PUT);
+
+        // user 'foo1' creates tag
+        UserRegistry fooRegistry = embeddedRegistryService.getUserRegistry("foo1", "cce123");
+        String r1Content = "R1";
+        Resource r1 = fooRegistry.newResource();
+        r1.setContent(r1Content.getBytes());
+        fooRegistry.put("/r1", r1);
+        fooRegistry.applyTag("/r1", "java");
+
+        Tag[] tags = fooRegistry.getTags("/r1");
+        assertEquals("There should be 1 tagging on resource '/r1'", 1, tags.length);
+
+        // add second user who can read tags
+        adminRealm.getUserStoreManager().addUser("bar1", "swe123", null, null, null);
+        adminRealm.getAuthorizationManager().
+                authorizeUser("bar1", RegistryConstants.ROOT_PATH + "r1", ActionConstants.GET);
+
+        // second user tries to delete the tag - should be unsuccessful
+        UserRegistry barRegistry = embeddedRegistryService.getUserRegistry("bar1", "swe123");
+        barRegistry.removeTag("/r1", "java");
+        tags = barRegistry.getTags("/r1");
+        // tag should not be deleted, hence still the tag count should be 1
+        assertEquals("There should be 1 tagging on resource '/r1'", 1, tags.length);
+
+        // create third user who can delete tags
+        adminRealm.getUserStoreManager().addUser("foobar", "cce123swe123", null, null, null);
+        adminRealm.getAuthorizationManager().
+                authorizeUser("foobar", RegistryConstants.ROOT_PATH + "r1", ActionConstants.DELETE);
+        // third user deletes tag successfully since he has delete permission
+        UserRegistry fooBarRegistry = embeddedRegistryService.getUserRegistry("foobar", "cce123swe123");
+        fooBarRegistry.removeTag("/r1", "java");
+        tags = fooBarRegistry.getTags("/r1");
+        // tag must be deleted, hence 0 tags
+        assertEquals("There should be 0 tagging on resource '/r1'", 0, tags.length);
+    }
 }


### PR DESCRIPTION
## Purpose
Improve registry tag deletion process so that a user with delete permission for a resource is able to delete a resource tag, without only allowing tag creator or admin to delete the tag. Resolves https://github.com/wso2/carbon-kernel/issues/1611. 

## Goals
Improve registry tag deletion process so that a user with delete permission for a resource is able to delete a resource tag.

## Approach
Add an additional check whether the current user has permission to delete the resource when trying to remove a tag.

## User stories
Registry Tag deletion.

## Release note
N/A

## Documentation
N/A - this is a bug in the existing flow.

## Training
N/A

## Certification
N/A - this is an internal change

## Marketing
N/A

## Automation tests
 - Unit tests 
   > Code coverage information

## Security checks
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
N/A
 
## Learning
N/A