### PR TITLE
fix for APIMANAGER-5989

### DIFF
--- a/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/multitenancy/MultitenantMessageReceiver.java
+++ b/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/multitenancy/MultitenantMessageReceiver.java
@@ -173,7 +173,10 @@ public class MultitenantMessageReceiver implements MessageReceiver {
                                 mainInMsgContext.getProperty(MultitenantConstants.PASS_THROUGH_SOURCE_CONNECTION));
                     }
 
-                    tenantResponseMsgCtx.setProperty(MultitenantConstants.MESSAGE_BUILDER_INVOKED, Boolean.FALSE);
+                    if (mainInMsgContext.getProperty(MultitenantConstants.MESSAGE_BUILDER_INVOKED) != null) {
+                        tenantResponseMsgCtx.setProperty(MultitenantConstants.MESSAGE_BUILDER_INVOKED,
+                                mainInMsgContext.getProperty(MultitenantConstants.MESSAGE_BUILDER_INVOKED));
+                    }
                     tenantResponseMsgCtx.setProperty(MultitenantConstants.CONTENT_TYPE,
                                 mainInMsgContext.getProperty(MultitenantConstants.CONTENT_TYPE));
                     AxisEngine.receive(tenantResponseMsgCtx);


### PR DESCRIPTION
## Purpose
As stated in [APIMANAGER-5989](https://wso2.org/jira/browse/APIMANAGER-5989)

## Goals
In synapse, a message can go through multiple content aware mediators. 
A mediator can choose to build the message again looking at this property, that means if it is false, it builds.
If that property is set to true in message context already, it skips building.

## Approach
As per the implementation, we have set the MESSAGE_BUILDER_INVOKED property to false without considering the value of the MESSAGE_BUILDER_INVOKED of SuperTenants messageContext[1]. One possible solution is setting the MESSAGE_BUILDER_INVOKED by looking at the SuperTenant messageContext. 

## User stories
N/A

## Release note
N/A

## Documentation
N/A

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
N/A

## Security checks
N/A

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
N/A
 
## Learning
N/A