### PR TITLE
Fix IDENTITY-6807

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/ReadOnlyLDAPUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/ReadOnlyLDAPUserStoreManager.java
@@ -3634,13 +3634,13 @@ public class ReadOnlyLDAPUserStoreManager extends AbstractUserStoreManager {
      * @param value the LDAP name (DN)
      */
     protected void putToUserCache(String name, LdapName value) {
-        Cache<String, LdapName> userDnCache = createOrGetUserDnCache();
-        if (userDnCache == null) {
-            // User cache may be null while initializing.
-            return;
-        }
         try {
             startTenantFlow();
+            Cache<String, LdapName> userDnCache = createOrGetUserDnCache();
+            if (userDnCache == null) {
+                // User cache may be null while initializing.
+                return;
+            }
             userDnCache.put(name, value);
         } catch (IllegalStateException e) {
             // There is no harm ignoring the put, as the cache(local) is already is of no use. Mis-penalty is low.
@@ -3657,13 +3657,13 @@ public class ReadOnlyLDAPUserStoreManager extends AbstractUserStoreManager {
      * @return cached DN, if exists. null if the cache does not contain the DN for the userName.
      */
     protected LdapName getFromUserCache(String userName) {
-        Cache<String, LdapName> userDnCache = createOrGetUserDnCache();
-        if (userDnCache == null) {
-            // User cache may be null while initializing.
-            return null;
-        }
         try {
             startTenantFlow();
+            Cache<String, LdapName> userDnCache = createOrGetUserDnCache();
+            if (userDnCache == null) {
+                // User cache may be null while initializing.
+                return null;
+            }
             return userDnCache.get(userName);
         } catch (IllegalStateException e) {
             log.error("Error occurred while getting User DN from cache having search base : " + userSearchBase, e);
@@ -3680,14 +3680,14 @@ public class ReadOnlyLDAPUserStoreManager extends AbstractUserStoreManager {
      * @return true if removal was successful.
      */
     protected boolean removeFromUserCache(String userName) {
-        Cache<String, LdapName> userDnCache = createOrGetUserDnCache();
-        if (userDnCache == null) {
-            // User cache may be null while initializing.
-            // Return true as removal result is successful when there is no cache. Nothing was held.
-            return true;
-        }
         try {
             startTenantFlow();
+            Cache<String, LdapName> userDnCache = createOrGetUserDnCache();
+            if (userDnCache == null) {
+                // User cache may be null while initializing.
+                // Return true as removal result is successful when there is no cache. Nothing was held.
+                return true;
+            }
             return userDnCache.remove(userName);
         } catch (IllegalStateException e) {
             // There is no harm ignoring the removal, as the cache(local) is already is of no use.


### PR DESCRIPTION
## Purpose
Tenant flow was started wrongly while fixing IDENTITY-6807.
This commit fixes the wrong start on tenant flow.

## Goals
Adding an expiring cache to LDAP user store, User DN .
https://wso2.org/jira/browse/IDENTITY-6471

## Approach
Stating tenant flow at the correct location on the method call.

## User stories
https://wso2.org/jira/browse/IDENTITY-6471

## Release note
https://wso2.org/jira/browse/IDENTITY-6471?focusedCommentId=138228&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-138228

## Documentation
https://wso2.org/jira/browse/IDENTITY-6471?focusedCommentId=138228&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-138228

## Training
N/A

## Certification
> N/A, as this is a simple bug fix.

## Marketing
> N/A Simple bug fix

## Automation tests
 - Unit tests 
   > org.wso2.carbon.user.core.ldap.ReadOnlyLDAPUserStoreManagerTest
 - Integration tests
   > org.wso2.carbon.user.core.ldap.ReadOnlyLDAPUserStoreManagerTest

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Not Needed


## Migrations (if applicable)
> https://wso2.org/jira/browse/IDENTITY-6471?focusedCommentId=138228&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-138228

## Test environment
> JDK 1.7, JDK 1.8, OSX, Linux.
 
## Learning
> N/A