### PR TITLE
Fix Java 8 support in JSP files. Resolves #1617

### DIFF
--- a/distribution/kernel/carbon-home/repository/conf/tomcat/web.xml
+++ b/distribution/kernel/carbon-home/repository/conf/tomcat/web.xml
@@ -242,6 +242,14 @@
             <param-name>xpoweredBy</param-name>
             <param-value>false</param-value>
         </init-param>
+        <init-param>
+            <param-name>compilerSourceVM</param-name>
+            <param-value>1.8</param-value>
+        </init-param>
+        <init-param>
+            <param-name>compilerTargetVM</param-name>
+            <param-value>1.8</param-value>
+        </init-param>
         <load-on-startup>3</load-on-startup>
     </servlet>
 


### PR DESCRIPTION
## Purpose
> Resolves java 8 code compilation failures in JSPs

## Goals
> Provide java 8 support in JSPs

## Approach
> Set compiler source and target versions to java 1.8 for jsps

## User stories
> N/A

## Release note
> N/A

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Unit tests 
   > N/A
 - Integration tests
   > N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> None

## Migrations (if applicable)
> N/A

## Test environment
> JDK 8
 
## Learning
> N/A