### PR TITLE
Fixing issue #1545 : Add property to Change the server runtime from OSGi tests.

### DIFF
--- a/pax-exam-container-carbon/org.wso2.carbon.container/src/main/java/org/wso2/carbon/container/CarbonTestContainer.java
+++ b/pax-exam-container-carbon/org.wso2.carbon.container/src/main/java/org/wso2/carbon/container/CarbonTestContainer.java
@@ -138,7 +138,13 @@ public class CarbonTestContainer implements TestContainer {
             //copy files to the distributions if there are any
             copyFiles(targetDirectory);
             Path carbonBin = targetDirectory.resolve("bin");
-            Path runtimeBin = targetDirectory.resolve("wso2").resolve("default").resolve("bin");
+            Path runtimeBin;
+            if (carbonHomeDirectoryOption.getCarbonRuntimeName() != null) {
+                runtimeBin = targetDirectory.resolve("wso2").resolve(carbonHomeDirectoryOption.getCarbonRuntimeName())
+                        .resolve("bin");
+            } else {
+                runtimeBin = targetDirectory.resolve("wso2").resolve("default").resolve("bin");
+            }
 
             //make the files in the bin directory to be executable
             makeFilesInBinExec(carbonBin.toFile());
@@ -154,7 +160,12 @@ public class CarbonTestContainer implements TestContainer {
             if (debugOption != null) {
                 options.add(debugOption.getDebugConfiguration());
             }
-            runner.exec(environment, targetDirectory.resolve("wso2").resolve("default"), options);
+            if (carbonHomeDirectoryOption.getCarbonRuntimeName() != null) {
+                runner.exec(environment, targetDirectory.resolve("wso2").resolve(carbonHomeDirectoryOption
+                        .getCarbonRuntimeName()), options);
+            } else {
+                runner.exec(environment, targetDirectory.resolve("wso2").resolve("default"), options);
+            }
             logger.debug("Wait for test container to finish its initialization " + subsystem.getTimeout());
 
             //wait for the osgi environment to be active

--- a/pax-exam-container-carbon/org.wso2.carbon.container/src/main/java/org/wso2/carbon/container/options/CarbonDistributionBaseOption.java
+++ b/pax-exam-container-carbon/org.wso2.carbon.container/src/main/java/org/wso2/carbon/container/options/CarbonDistributionBaseOption.java
@@ -33,11 +33,13 @@ public class CarbonDistributionBaseOption implements Option {
     private MavenUrlReference distributionMavenURL;
     private String name;
     private Path unpackDirectory;
+    private String carbonRuntimeName;
 
     public CarbonDistributionBaseOption() {
         distributionDirectoryPath = null;
         distributionMavenURL = null;
         name = null;
+        carbonRuntimeName = null;
     }
 
     /**
@@ -88,6 +90,18 @@ public class CarbonDistributionBaseOption implements Option {
     }
 
     /**
+     * Sets the carbon runtime name of the Distribution.
+     *
+     * @param carbonRuntimeName runtime name
+     * @return this
+     */
+    public CarbonDistributionBaseOption carbonRuntimeName(String carbonRuntimeName) {
+        NullArgumentException.validateNotNull(carbonRuntimeName, "Distribution Carbon Runtime Name");
+        this.carbonRuntimeName = carbonRuntimeName;
+        return this;
+    }
+
+    /**
      * Define the unpack directory for the carbon distribution. In this directory a UUID named
      * directory will be created for each environment.
      *
@@ -117,6 +131,10 @@ public class CarbonDistributionBaseOption implements Option {
 
     public Path getUnpackDirectory() {
         return unpackDirectory;
+    }
+
+    public String getCarbonRuntimeName() {
+        return carbonRuntimeName;
     }
 
 }

--- a/pax-exam-container-carbon/org.wso2.carbon.container/src/main/java/org/wso2/carbon/container/options/CarbonDistributionOption.java
+++ b/pax-exam-container-carbon/org.wso2.carbon.container/src/main/java/org/wso2/carbon/container/options/CarbonDistributionOption.java
@@ -44,6 +44,17 @@ public class CarbonDistributionOption {
     }
 
     /**
+     * Set the carbon distribution maven url and carbon runtime name options.
+     *
+     * @return an option to set the path to distribution.
+     */
+    public static CarbonDistributionBaseOption carbonDistribution(MavenUrlReference mavenUrlReference,
+                                                                  String runtimeName) {
+        return new CarbonDistributionBaseOption().distributionMavenURL(mavenUrlReference)
+                .carbonRuntimeName(runtimeName);
+    }
+
+    /**
      * Set the carbon distribution path option.
      *
      * @return an option to set the path to distribution.
@@ -53,6 +64,19 @@ public class CarbonDistributionOption {
             return new CarbonDistributionBaseOption().distributionZipPath(path);
         } else {
             return new CarbonDistributionBaseOption().distributionDirectoryPath(path);
+        }
+    }
+
+    /**
+     * Set the carbon distribution path and carbon runtime name options.
+     *
+     * @return an option to set the path to distribution.
+     */
+    public static CarbonDistributionBaseOption carbonDistribution(Path path, String runtimeName) {
+        if (path.toString().endsWith("zip")) {
+            return new CarbonDistributionBaseOption().distributionZipPath(path).carbonRuntimeName(runtimeName);
+        } else {
+            return new CarbonDistributionBaseOption().distributionDirectoryPath(path).carbonRuntimeName(runtimeName);
         }
     }
 

--- a/tests/osgi-tests/src/test/java/org/wso2/carbon/osgi/testcontainer/DistributionDirectoryWithCarbonRuntimeNameTest.java
+++ b/tests/osgi-tests/src/test/java/org/wso2/carbon/osgi/testcontainer/DistributionDirectoryWithCarbonRuntimeNameTest.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.wso2.carbon.osgi.testcontainer;
 
 import org.ops4j.pax.exam.Configuration;

--- a/tests/osgi-tests/src/test/java/org/wso2/carbon/osgi/testcontainer/DistributionDirectoryWithCarbonRuntimeNameTest.java
+++ b/tests/osgi-tests/src/test/java/org/wso2/carbon/osgi/testcontainer/DistributionDirectoryWithCarbonRuntimeNameTest.java
@@ -1,0 +1,56 @@
+package org.wso2.carbon.osgi.testcontainer;
+
+import org.ops4j.pax.exam.Configuration;
+import org.ops4j.pax.exam.ExamFactory;
+import org.ops4j.pax.exam.Option;
+import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
+import org.ops4j.pax.exam.spi.reactors.PerClass;
+import org.ops4j.pax.exam.testng.listener.PaxExam;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.testng.Assert;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+import org.wso2.carbon.container.CarbonContainerFactory;
+import org.wso2.carbon.kernel.CarbonServerInfo;
+
+import java.nio.file.Paths;
+import javax.inject.Inject;
+
+import static org.wso2.carbon.container.options.CarbonDistributionOption.carbonDistribution;
+
+/**
+ * To test pax exam container option carbonDistributionRuntimeName.
+ *
+ * @since 5.2.0
+ */
+@Listeners(PaxExam.class)
+@ExamReactorStrategy(PerClass.class)
+@ExamFactory(CarbonContainerFactory.class)
+public class DistributionDirectoryWithCarbonRuntimeNameTest {
+
+    @Inject
+    protected BundleContext bundleContext;
+
+    @Inject
+    private CarbonServerInfo carbonServerInfo;
+
+    @Configuration
+    public Option[] config() {
+        return new Option[]{carbonDistribution(
+                Paths.get("target", "wso2carbon-kernel-test-" + System.getProperty("carbon.kernel.version"))
+                , "default")};
+    }
+
+    @Test
+    public void testCarbonCoreBundleStatus() {
+        Bundle coreBundle = null;
+        for (Bundle bundle : bundleContext.getBundles()) {
+            if (bundle.getSymbolicName().equals("org.wso2.carbon.core")) {
+                coreBundle = bundle;
+                break;
+            }
+        }
+        Assert.assertNotNull(coreBundle, "Carbon Core bundle not found");
+    }
+}

--- a/tests/osgi-tests/src/test/java/org/wso2/carbon/osgi/testcontainer/DistributionMavenWithCarbonRuntimeNameTest.java
+++ b/tests/osgi-tests/src/test/java/org/wso2/carbon/osgi/testcontainer/DistributionMavenWithCarbonRuntimeNameTest.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.wso2.carbon.osgi.testcontainer;
 
 import org.ops4j.pax.exam.Configuration;

--- a/tests/osgi-tests/src/test/java/org/wso2/carbon/osgi/testcontainer/DistributionMavenWithCarbonRuntimeNameTest.java
+++ b/tests/osgi-tests/src/test/java/org/wso2/carbon/osgi/testcontainer/DistributionMavenWithCarbonRuntimeNameTest.java
@@ -1,0 +1,56 @@
+package org.wso2.carbon.osgi.testcontainer;
+
+import org.ops4j.pax.exam.Configuration;
+import org.ops4j.pax.exam.ExamFactory;
+import org.ops4j.pax.exam.Option;
+import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
+import org.ops4j.pax.exam.spi.reactors.PerClass;
+import org.ops4j.pax.exam.testng.listener.PaxExam;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.testng.Assert;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+import org.wso2.carbon.container.CarbonContainerFactory;
+import org.wso2.carbon.kernel.CarbonServerInfo;
+
+import javax.inject.Inject;
+
+import static org.ops4j.pax.exam.CoreOptions.maven;
+import static org.wso2.carbon.container.options.CarbonDistributionOption.carbonDistribution;
+
+/**
+ * To test pax exam container option carbonDistributionRuntimeName.
+ *
+ * @since 5.2.0
+ */
+@Listeners(PaxExam.class)
+@ExamReactorStrategy(PerClass.class)
+@ExamFactory(CarbonContainerFactory.class)
+public class DistributionMavenWithCarbonRuntimeNameTest {
+
+    @Inject
+    protected BundleContext bundleContext;
+
+    @Inject
+    private CarbonServerInfo carbonServerInfo;
+
+    @Configuration
+    public Option[] config() {
+        return new Option[] { carbonDistribution(
+                maven().groupId("org.wso2.carbon").artifactId("wso2carbon-kernel-test").type("zip")
+                        .versionAsInProject(), "default") };
+    }
+
+    @Test
+    public void testCarbonCoreBundleStatus() {
+        Bundle coreBundle = null;
+        for (Bundle bundle : bundleContext.getBundles()) {
+            if (bundle.getSymbolicName().equals("org.wso2.carbon.core")) {
+                coreBundle = bundle;
+                break;
+            }
+        }
+        Assert.assertNotNull(coreBundle, "Carbon Core bundle not found");
+    }
+}

--- a/tests/osgi-tests/src/test/resources/testng.xml
+++ b/tests/osgi-tests/src/test/resources/testng.xml
@@ -48,6 +48,8 @@ limitations under the License.
             <class name="org.wso2.carbon.osgi.testcontainer.DistributionZipTest"/>
             <class name="org.wso2.carbon.osgi.testcontainer.DistributionDirectoryTest"/>
             <class name="org.wso2.carbon.osgi.testcontainer.CopyOSGiLibTest"/>
+            <class name="org.wso2.carbon.osgi.testcontainer.DistributionDirectoryWithCarbonRuntimeNameTest"/>
+            <class name="org.wso2.carbon.osgi.testcontainer.DistributionMavenWithCarbonRuntimeNameTest"/>
 
             <class name="org.wso2.carbon.osgi.carbon.touchpoint.CarbonTouchpointOSGiTest"/>
 


### PR DESCRIPTION
## Purpose
> Currently, from the OSGi tests, it starts the server in 'Default' runtime only. This needs to be configured since different test cases required different runtimes.
https://github.com/wso2/carbon-kernel/issues/1545

## Goals
> Adding runtime name in the carbon distribution options.