### PR TITLE
Claims with same claim URI in different dialects, are not getting added. Resolves #1621

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/claim/ClaimKey.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/claim/ClaimKey.java
@@ -22,10 +22,8 @@ import java.io.Serializable;
 
 /**
  * Unique key to represent a claim across the dialect.
- *
  */
-//implements Serializable
-public class ClaimKey  {
+public class ClaimKey implements Serializable {
     private static final long serialVersionUID = -2002899750350065724L;
     private String claimUri;
     private String dialectUri;

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/claim/ClaimKey.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/claim/ClaimKey.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.user.core.claim;
+
+import java.io.Serializable;
+
+/**
+ * Unique key to represent a claim across the dialect.
+ *
+ */
+//implements Serializable
+public class ClaimKey  {
+    private static final long serialVersionUID = -2002899750350065724L;
+    private String claimUri;
+    private String dialectUri;
+
+    public ClaimKey() {
+    }
+
+    public ClaimKey(String claimUri, String dialectUri) {
+        this.claimUri = claimUri;
+        this.dialectUri = dialectUri;
+    }
+
+    public String getClaimUri() {
+        return claimUri;
+    }
+
+    public void setClaimUri(String claimUri) {
+        this.claimUri = claimUri;
+    }
+
+    public String getDialectUri() {
+        return dialectUri;
+    }
+
+    public void setDialectUri(String dialectUri) {
+        this.dialectUri = dialectUri;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        ClaimKey that = (ClaimKey) o;
+
+        if (!claimUri.equals(that.claimUri)) {
+            return false;
+        }
+        return dialectUri.equals(that.dialectUri);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = claimUri.hashCode();
+        result = 31 * result + dialectUri.hashCode();
+        return result;
+    }
+}

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/claim/inmemory/ClaimConfig.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/claim/inmemory/ClaimConfig.java
@@ -18,8 +18,10 @@
 
 package org.wso2.carbon.user.core.claim.inmemory;
 
+import org.wso2.carbon.user.core.claim.ClaimKey;
 import org.wso2.carbon.user.core.claim.ClaimMapping;
 
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -32,13 +34,13 @@ public class ClaimConfig {
     /**
      * contains claim uri as the key and claim mapping of each claim as the value.
      */
-    private Map<String, ClaimMapping> claims;
+    private Map<ClaimKey, ClaimMapping> claims;
 
     /**
      * inside map contains meta data value as the key and value of that meta data as the value (including claim dialect
      * info). PropertyHolder map contains that meta data map and the related claim uri as key value.
      */
-    private Map<String, Map<String, String>> propertyHolder;
+    private Map<ClaimKey, Map<String, String>> propertyHolder;
 
     public ClaimConfig() {
 
@@ -47,31 +49,115 @@ public class ClaimConfig {
     /**
      * Contains the claims and the related meta data info.
      *
-     * @param claims         contains claim uri as the key and claim mapping of each claim as the value.
-     * @param propertyHolder inside map contains meta data value as the key and value of that meta data as the value
-     *                       (including claim dialect info). PropertyHolder map contains that meta data map and the
-     *                       related claim uri as key value.
+     * @param claims
+     *         contains claim uri as the key and claim mapping of each claim as the value.
+     * @param propertyHolder
+     *         inside map contains meta data value as the key and value of that meta data as the value (including claim
+     *         dialect info). PropertyHolder map contains that meta data map and the related claim uri as key value.
      */
-
     public ClaimConfig(Map<String, ClaimMapping> claims, Map<String, Map<String, String>> propertyHolder) {
-        this.claims = claims;
-        this.propertyHolder = propertyHolder;
+        setClaims(claims);
+        setPropertyHolder(propertyHolder);
     }
 
+    /**
+     * Get the Claims.
+     * This method is deprecated because of this will not support for multiple claim uri across the dialect.
+     * To support that, we can use 'getClaims' instead of this method.
+     *
+     * @return
+     */
     public Map<String, ClaimMapping> getClaims() {
+        Map<String, ClaimMapping> convertedClaimMap = new HashMap<>();
+        for (Map.Entry<ClaimKey, ClaimMapping> entry : claims.entrySet()) {
+            convertedClaimMap.put(entry.getKey().getClaimUri(), entry.getValue());
+        }
+        return convertedClaimMap;
+    }
+
+    /**
+     * Set the claim map.
+     * <p>
+     * This method is deprecated because of this will not support for multiple claim uri across the dialect.
+     * To support that, we can use 'setClaimMap' instead of this method.
+     *
+     * @param claims
+     */
+    public void setClaims(Map<String, ClaimMapping> claims) {
+        this.claims = new HashMap<>();
+        for (Map.Entry<String, ClaimMapping> entry : claims.entrySet()) {
+            ClaimKey claimKey = new ClaimKey(entry.getKey(), entry.getValue().getClaim().getDialectURI());
+            this.claims.put(claimKey, entry.getValue());
+        }
+    }
+
+    /**
+     * Get PropertyHolder.
+     * This method is deprecated because of this will not support for multiple claim uri across the dialect.
+     * To support that, we can use 'getPropertyHolderMap' instead of this method.
+     *
+     * @return
+     */
+    public Map<String, Map<String, String>> getPropertyHolder() {
+        Map<String, Map<String, String>> convertedPropertyHolder = new HashMap<>();
+        for (Map.Entry<ClaimKey, Map<String, String>> entry : propertyHolder.entrySet()) {
+            convertedPropertyHolder.put(entry.getKey().getClaimUri(), entry.getValue());
+        }
+        return convertedPropertyHolder;
+    }
+
+    /**
+     * Set Property Holder.
+     * This method is deprecated because of this will not support for multiple claim uri across the dialect.
+     * To support that, we can use 'setPropertyHolderMap' instead of this method.
+     *
+     * @param propertyHolder
+     */
+    @Deprecated
+    public void setPropertyHolder(Map<String, Map<String, String>> propertyHolder) {
+        this.propertyHolder = new HashMap<>();
+        for (Map.Entry<String, Map<String, String>> entry : propertyHolder.entrySet()) {
+            ClaimKey claimKey = new ClaimKey();
+            claimKey.setClaimUri(entry.getKey());
+            claimKey.setDialectUri(claims.get(entry.getKey()).getClaim().getDialectURI());
+            this.propertyHolder.put(claimKey, entry.getValue());
+        }
+    }
+
+
+    /**
+     * This is for get claim mappings for all the uri's.
+     *
+     * @return
+     */
+    public Map<ClaimKey, ClaimMapping> getClaimMap() {
         return claims;
     }
 
-    public void setClaims(Map<String, ClaimMapping> claims) {
+    /**
+     * Set the claim uri's againse claim mapping.
+     *
+     * @param claims
+     */
+    public void setClaimMap(Map<ClaimKey, ClaimMapping> claims) {
         this.claims = claims;
     }
 
-    public Map<String, Map<String, String>> getPropertyHolder() {
+    /**
+     * Get the claim properties.
+     *
+     * @return
+     */
+    public Map<ClaimKey, Map<String, String>> getPropertyHolderMap() {
         return propertyHolder;
     }
 
-    public void setPropertyHolder(Map<String, Map<String, String>> propertyHolder) {
+    /**
+     * Set the claim properties.
+     *
+     * @param propertyHolder
+     */
+    public void setPropertyHolderMap(Map<ClaimKey, Map<String, String>> propertyHolder) {
         this.propertyHolder = propertyHolder;
     }
-
 }

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/claim/inmemory/ClaimConfig.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/claim/inmemory/ClaimConfig.java
@@ -49,11 +49,11 @@ public class ClaimConfig {
     /**
      * Contains the claims and the related meta data info.
      *
-     * @param claims
-     *         contains claim uri as the key and claim mapping of each claim as the value.
-     * @param propertyHolder
-     *         inside map contains meta data value as the key and value of that meta data as the value (including claim
-     *         dialect info). PropertyHolder map contains that meta data map and the related claim uri as key value.
+     * @param claims         contains claim uri as the key and claim mapping of each claim as the value.
+     * @param propertyHolder inside map contains meta data value as the key and value of that meta data as the value
+     *                       (including claim
+     *                       dialect info). PropertyHolder map contains that meta data map and the related claim uri
+     *                       as key value.
      */
     public ClaimConfig(Map<String, ClaimMapping> claims, Map<String, Map<String, String>> propertyHolder) {
         setClaims(claims);

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/claim/inmemory/FileBasedClaimBuilder.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/claim/inmemory/FileBasedClaimBuilder.java
@@ -25,6 +25,7 @@ import org.apache.commons.logging.LogFactory;
 import org.osgi.framework.BundleContext;
 import org.wso2.carbon.user.core.UserStoreException;
 import org.wso2.carbon.user.core.claim.Claim;
+import org.wso2.carbon.user.core.claim.ClaimKey;
 import org.wso2.carbon.user.core.claim.ClaimMapping;
 import org.wso2.carbon.utils.CarbonUtils;
 
@@ -39,6 +40,8 @@ import java.net.URL;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
+import javax.xml.namespace.QName;
+import javax.xml.stream.XMLStreamException;
 
 public class FileBasedClaimBuilder {
 
@@ -74,11 +77,11 @@ public class FileBasedClaimBuilder {
      * @throws org.wso2.carbon.user.core.UserStoreException
      */
     public static ClaimConfig buildClaimMappingsFromConfigFile() throws IOException, XMLStreamException,
-            UserStoreException {
+                                                                        UserStoreException {
 
         OMElement dom;
-        Map<String, ClaimMapping> claims = new HashMap<>();
-        Map<String, Map<String, String>> propertyHolder = new HashMap<>();
+        Map<ClaimKey, ClaimMapping> claims = new HashMap<>();
+        Map<ClaimKey, Map<String, String>> propertyHolder = new HashMap<>();
 
         String dialectUri;
 
@@ -128,17 +131,22 @@ public class FileBasedClaimBuilder {
                         properties.put(key, value);
                         properties.put(LOCAL_NAME_DIALECT, dialectUri);
                     }
+                    //Unique key for claim.
+                    ClaimKey claimKey = new ClaimKey();
+                    claimKey.setClaimUri(claimUri);
+                    claimKey.setDialectUri(dialectUri);
 
-                    propertyHolder.put(claimUri, properties);
+                    propertyHolder.put(claimKey, properties);
                     claimMapping = new ClaimMapping();
                     claimMapping.setClaim(claim);
                     setMappedAttributes(claimMapping, attributeId);
-
-                    claims.put(claimUri, claimMapping);
+                    claims.put(claimKey, claimMapping);
                 }
             }
         }
-        claimConfig = new ClaimConfig(claims, propertyHolder);
+        claimConfig = new ClaimConfig();
+        claimConfig.setClaimMap(claims);
+        claimConfig.setPropertyHolderMap(propertyHolder);
         return claimConfig;
     }
 

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/claim/inmemory/FileBasedClaimBuilder.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/claim/inmemory/FileBasedClaimBuilder.java
@@ -29,8 +29,6 @@ import org.wso2.carbon.user.core.claim.ClaimKey;
 import org.wso2.carbon.user.core.claim.ClaimMapping;
 import org.wso2.carbon.utils.CarbonUtils;
 
-import javax.xml.namespace.QName;
-import javax.xml.stream.XMLStreamException;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/claim/inmemory/InMemoryClaimManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/claim/inmemory/InMemoryClaimManager.java
@@ -23,6 +23,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.user.api.Claim;
 import org.wso2.carbon.user.core.UserStoreException;
+import org.wso2.carbon.user.core.claim.ClaimKey;
 import org.wso2.carbon.user.core.claim.ClaimManager;
 import org.wso2.carbon.user.core.claim.ClaimMapping;
 import org.wso2.carbon.user.core.claim.DefaultClaimManager;
@@ -62,7 +63,11 @@ public class InMemoryClaimManager implements ClaimManager {
 
 
     public InMemoryClaimManager() throws UserStoreException {
-        claimMapping = claimConfig.getClaims();
+        //Convert the new data structure to the existing model to make this backward compatible.
+        Map<ClaimKey, ClaimMapping> tmpClaimMap = claimConfig.getClaimMap();
+        for (Map.Entry<ClaimKey, ClaimMapping> entry : tmpClaimMap.entrySet()) {
+            claimMapping.put(entry.getKey().getClaimUri(), entry.getValue());
+        }
     }
 
     /**
@@ -186,7 +191,7 @@ public class InMemoryClaimManager implements ClaimManager {
     @Override
     public void addNewClaimMapping(org.wso2.carbon.user.api.ClaimMapping mapping)
             throws UserStoreException{
-        claimMapping.put(mapping.getClaim().getClaimUri(), (ClaimMapping) claimMapping);
+        claimMapping.put(mapping.getClaim().getClaimUri(), (ClaimMapping) mapping);
     }
 
     /**
@@ -194,13 +199,13 @@ public class InMemoryClaimManager implements ClaimManager {
      */
     public void updateClaimMapping(org.wso2.carbon.user.api.ClaimMapping mapping)
             throws UserStoreException{
-        claimMapping.remove(mapping);
-        claimMapping.put(mapping.getClaim().getClaimUri(), (ClaimMapping) claimMapping);
+        claimMapping.remove(mapping.getClaim().getClaimUri());
+        claimMapping.put(mapping.getClaim().getClaimUri(), (ClaimMapping) mapping);
     }
     /**
      * {@inheritDoc}
      */
     public void deleteClaimMapping(org.wso2.carbon.user.api.ClaimMapping mapping) throws UserStoreException {
-        claimMapping.remove(mapping);
+        claimMapping.remove(mapping.getClaim().getClaimUri());
     }
 }


### PR DESCRIPTION
## Purpose
> Claims with same claim URI in other dialects, are not getting added to IDN_CLAIM table

## Goals
> Fix claims with same claim URI in other dialects, are not getting added to IDN_CLAIM table

## Approach
> When creating claim map from the claims in claim-mgt.xml file, key is created with a combination of claim dialect uri and claim uri.

## User stories
> N/A

## Release note
> N/A

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> N/A
 
## Learning
> N/A