### PR TITLE
Sorting carbon.initial.osgi bundles

### DIFF
--- a/launcher/src/main/java/org/wso2/carbon/launcher/config/CarbonLaunchConfig.java
+++ b/launcher/src/main/java/org/wso2/carbon/launcher/config/CarbonLaunchConfig.java
@@ -59,7 +59,6 @@ import static org.wso2.carbon.launcher.Constants.OSGI_INSTANCE_AREA;
 public class CarbonLaunchConfig {
 
     private static final Logger logger = Logger.getLogger(CarbonLaunchConfig.class.getName());
-
     private static final String VAR_REGEXP = "(?<=@)(\\d)";
     private static final Pattern varPattern = Pattern.compile(VAR_REGEXP);
 
@@ -167,7 +166,6 @@ public class CarbonLaunchConfig {
             return Integer.parseInt(num);
         }
     };
-
 
     /**
      * Load carbon configuration from a java.io.File object.

--- a/launcher/src/main/java/org/wso2/carbon/launcher/config/CarbonLaunchConfig.java
+++ b/launcher/src/main/java/org/wso2/carbon/launcher/config/CarbonLaunchConfig.java
@@ -28,6 +28,7 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -58,6 +59,9 @@ import static org.wso2.carbon.launcher.Constants.OSGI_INSTANCE_AREA;
 public class CarbonLaunchConfig {
 
     private static final Logger logger = Logger.getLogger(CarbonLaunchConfig.class.getName());
+
+    private static final String VAR_REGEXP = "(?<=@)(\\d)";
+    private static final Pattern varPattern = Pattern.compile(VAR_REGEXP);
 
     private URL carbonOSGiRepository;
     private URL carbonProfileRepository;
@@ -143,8 +147,27 @@ public class CarbonLaunchConfig {
         String[] customBundlesArray = Utils.tokenize(customBundles, ",");
         List list = Arrays.stream(defaultBundlesArray).collect(Collectors.toList());
         list.addAll(list.size() - 1, Arrays.stream(customBundlesArray).collect(Collectors.toList()));
+        Collections.sort(list, initialBundleComparator);
         return list.toString().substring(1, list.toString().length() - 1);
     }
+
+    private static Comparator<String> initialBundleComparator = new Comparator<String>() {
+        public int compare(String o1, String o2) {
+            return extractInt(o1) - extractInt(o2);
+        }
+
+        int extractInt(String bundle) {
+            Matcher matcher = varPattern.matcher(bundle);
+            if (!matcher.find()) {
+                String errorMsg = "Invalid carbon.initial.osgi bundle found in launch.properties: " + bundle;
+                logger.log(Level.SEVERE, errorMsg);
+                throw new RuntimeException(errorMsg);
+            }
+            String num = matcher.group(0);
+            return Integer.parseInt(num);
+        }
+    };
+
 
     /**
      * Load carbon configuration from a java.io.File object.

--- a/launcher/src/test/java/org/wso2/carbon/launcher/test/LaunchConfigExceptionsTest.java
+++ b/launcher/src/test/java/org/wso2/carbon/launcher/test/LaunchConfigExceptionsTest.java
@@ -116,9 +116,9 @@ public class LaunchConfigExceptionsTest extends BaseTest {
 
         CarbonLaunchConfig carbonLaunchConfig = new CarbonLaunchConfig(launchPropFile);
         List<CarbonInitialBundle> bundles = carbonLaunchConfig.getInitialBundles();
-        Assert.assertTrue(bundles.get(0).getLocation().toString().contains("org.apache.felix.gogo.runtime"));
-        Assert.assertTrue(bundles.get(1).getLocation().toString().contains("org.apache.felix.gogo.command"));
-        Assert.assertTrue(bundles.get(2).getLocation().toString().contains("org.eclipse.equinox.simpleconfigurator"));
+        Assert.assertTrue(bundles.get(0).getLocation().toString().contains("org.eclipse.equinox.simpleconfigurator"));
+        Assert.assertTrue(bundles.get(1).getLocation().toString().contains("org.apache.felix.gogo.runtime"));
+        Assert.assertTrue(bundles.get(2).getLocation().toString().contains("org.apache.felix.gogo.command"));
     }
 
     /**


### PR DESCRIPTION
## Purpose
> Resolving the issue in initial OSGI bundle resolving order by sorting the entries.

## Goals
> The BundleStartLevel was disregarded when initialising the launch properties which caused issues in the resolving order for the OSGI bundles. Resolving the issue by sorting after merging the default and custom OSGI bundle entries.

## Approach
> Sorting the carbon.initial.osgi bundles according to BundleStartLevel

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
> JDK 1.8.0_131
> Ubuntu 16.04