### PR TITLE
Add fix for path issue in Windows, fixes #1641

### DIFF
--- a/features/org.wso2.carbon.runtime.feature/resources/wso2/default/bin/carbon.bat
+++ b/features/org.wso2.carbon.runtime.feature/resources/wso2/default/bin/carbon.bat
@@ -52,6 +52,7 @@ if not "%curDrive%" == "%wsasDrive%" %wsasDrive%:
 
 rem ----- Only set RUNTIME_HOME if not already set ----------------------------
 :setRuntimeHome
+setlocal
 if "%RUNTIME_HOME%"=="" set RUNTIME_HOME=%~sdp0..
 rem --- derive RUNTIME NAME from the RUNTIME_HOME path.
 cd /d %RUNTIME_HOME%


### PR DESCRIPTION
## Purpose
Fixes #1641 

## Goals
Prevent global setting of environment variables

## Approach
Enables the path and runtime environment variables to be set locally, so that the implicit `endlocal` call will clear them upon exit.