### PR TITLE
Fix for [APIMANAGER-6034] : In multi-tenant dual channel JMS messaging scenario message content drops in response  

### DIFF
--- a/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/multitenancy/MultitenantMessageReceiver.java
+++ b/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/multitenancy/MultitenantMessageReceiver.java
@@ -764,7 +764,7 @@ public class MultitenantMessageReceiver implements MessageReceiver {
      * @param messageContext Axis2 Message context
      * @return {boolean} Whether current message is HTTP/HTTPS
      */
-    protected static boolean isHTTPOrHTTPsRequest(org.apache.axis2.context.MessageContext messageContext) {
+    private boolean isHTTPOrHTTPsRequest(org.apache.axis2.context.MessageContext messageContext) {
         if (messageContext.getTransportOut() != null) {
             String incomingTransportName = String.valueOf(messageContext.getTransportOut().getName());
             if (incomingTransportName.equals("http") || incomingTransportName.equals("https")) {


### PR DESCRIPTION
## Purpose

- Validate the message transport for HTTP or HTTPS
- set `MESSAGE_BUILDER_INVOKED` property to `false` if outgoing message is an HTTP message
- Else set the `mainInMsgContext`  `MESSAGE_BUILDER_INVOKED` property value to  `tenantResponseMsgCtx`

## Goals

Address the following issue

[APIMANAGER-6034](https://wso2.org/jira/browse/APIMANAGER-6034)

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment

- Ubuntu 16.04 LTS
- java version "1.8.0_151"
- TIBCO EMS Version 8.4.0 V14 7/20/2017
