### PR TITLE
Add property to enable/disable hostname verification

### DIFF
--- a/core/src/main/java/org/wso2/carbon/kernel/config/model/CarbonConfiguration.java
+++ b/core/src/main/java/org/wso2/carbon/kernel/config/model/CarbonConfiguration.java
@@ -44,6 +44,9 @@ public class CarbonConfiguration {
     @Element(description = "server name")
     private String name = "WSO2 Carbon Kernel";
 
+    @Element(description = "enable/disable hostname verifier")
+    private boolean hostnameVerificationEnabled = true;
+
     @Ignore
     private String version;
 
@@ -64,6 +67,14 @@ public class CarbonConfiguration {
 
     public String getName() {
         return name;
+    }
+
+    public boolean isHostnameVerificationEnabled() {
+        return hostnameVerificationEnabled;
+    }
+
+    public void setHostnameVerificationEnabled(boolean hostnameVerificationEnabled) {
+        this.hostnameVerificationEnabled = hostnameVerificationEnabled;
     }
 
     public String getVersion() {

--- a/core/src/main/java/org/wso2/carbon/kernel/config/model/CarbonConfiguration.java
+++ b/core/src/main/java/org/wso2/carbon/kernel/config/model/CarbonConfiguration.java
@@ -45,7 +45,7 @@ public class CarbonConfiguration {
     private String name = "WSO2 Carbon Kernel";
 
     @Element(description = "enable/disable hostname verifier")
-    private boolean hostnameVerificationEnabled = true;
+    private boolean hostnameVerificationEnabled = false;
 
     @Ignore
     private String version;

--- a/core/src/test/resources/yaml/conf/deployment.yaml
+++ b/core/src/test/resources/yaml/conf/deployment.yaml
@@ -17,6 +17,7 @@
 wso2.carbon:
   id: carbon-kernel
   name: WSO2 Carbon Kernel
+  hostnameVerificationEnabled: false
   version: ${carbon.version}
   tenant: default
 

--- a/distribution/carbon-home/conf/deployment.yaml
+++ b/distribution/carbon-home/conf/deployment.yaml
@@ -18,6 +18,8 @@ wso2.carbon:
   id: carbon-kernel
     # server name
   name: WSO2 Carbon Kernel
+    # enable/disable hostname verifier
+  hostnameVerificationEnabled: false
     # ports used by this server
   ports:
       # port offset

--- a/tests/osgi-tests/src/test/resources/carbon-config/deployment.yaml
+++ b/tests/osgi-tests/src/test/resources/carbon-config/deployment.yaml
@@ -20,6 +20,8 @@ wso2.carbon:
   id: ${sys:server.id}
     # server name
   name: ${env:SERVER_NAME}
+    # enable/disable hostname verifier
+  hostnameVerificationEnabled: false
   tenant: ${sec:wso2.sample.tenant}
 
     # ports used by this server

--- a/tests/osgi-tests/src/test/resources/carbon-context/deployment.yaml
+++ b/tests/osgi-tests/src/test/resources/carbon-context/deployment.yaml
@@ -20,6 +20,8 @@ wso2.carbon:
   id: carbon-kernel
     # server name
   name: WSO2 Carbon Kernel
+    # enable/disable hostname verifier
+  hostnameVerificationEnabled: false
   tenant: ${tenant.name}
 
     # ports used by this server

--- a/tests/osgi-tests/src/test/resources/jmx/deployment.yaml
+++ b/tests/osgi-tests/src/test/resources/jmx/deployment.yaml
@@ -20,6 +20,8 @@ wso2.carbon:
   id: ${server.key}
     # server name
   name: ${server.name}
+    # enable/disable hostname verifier
+  hostnameVerificationEnabled: false
     # server version
   version: ${server.version}
   tenant: default

--- a/tests/osgi-tests/src/test/resources/runtime/deployment.yaml
+++ b/tests/osgi-tests/src/test/resources/runtime/deployment.yaml
@@ -20,6 +20,8 @@ wso2.carbon:
   id: carbon-kernel
     # server name
   name: WSO2 Carbon Kernel
+    # enable/disable hostname verifier
+  hostnameVerificationEnabled: false
   tenant: default
     # ports used by this server
   ports:

--- a/tests/test-carbon-touchpoint-distribution/carbon-home/conf/deployment.yaml
+++ b/tests/test-carbon-touchpoint-distribution/carbon-home/conf/deployment.yaml
@@ -18,6 +18,8 @@ wso2.carbon:
   id: carbon-kernel
     # server name
   name: WSO2 Carbon Kernel
+    # enable/disable hostname verifier
+  hostnameVerificationEnabled: false
     # ports used by this server
   ports:
       # port offset

--- a/tests/test-distribution/carbon-home/conf/deployment.yaml
+++ b/tests/test-distribution/carbon-home/conf/deployment.yaml
@@ -18,6 +18,8 @@ wso2.carbon:
   id: carbon-kernel
     # server name
   name: WSO2 Carbon Kernel
+  # enable/disable hostname verifier
+  hostnameVerificationEnabled: false
     # ports used by this server
   ports:
       # port offset


### PR DESCRIPTION
## Purpose
> Requirement to give user a configuration to enable hostname verification

## Goals
> Based on the property being set hostname verification can be enabled/disabled

## Approach
> Introduce a new property "hostnameVerificationEnabled" into the wso2.carbon namespace and set the default value to false

## User stories
> N/A

## Release note
> New property to enable/disable host name verification

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Unit tests 
   > N/A
 - Integration tests
   > N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> N/A
 
## Learning
> N/A