### PR TITLE
Fixing IDENTITY-7264, Special characters in UserName fails on some LDAP

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/ReadWriteLDAPUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/ReadWriteLDAPUserStoreManager.java
@@ -390,7 +390,7 @@ public class ReadWriteLDAPUserStoreManager extends ReadOnlyLDAPUserStoreManager 
             objectClass.add("subschema");
         }
         basicAttributes.put(objectClass);
-        if(isSaveUserNameAsAnAttribute()) {
+        if (shouldSaveUserNameAsAnAttribute()) {
             BasicAttribute userNameAttribute = new BasicAttribute(realmConfig.
                     getUserStoreProperty(LDAPConstants.USER_NAME_ATTRIBUTE));
             userNameAttribute.add(userName);
@@ -425,17 +425,16 @@ public class ReadWriteLDAPUserStoreManager extends ReadOnlyLDAPUserStoreManager 
     }
 
     /**
-     * Returns true iff Saving username as an attribute is not disabled.
+     * Returns true iff saving username as an attribute is not disabled.
      * @return
      */
-    private boolean isSaveUserNameAsAnAttribute() {
+    private boolean shouldSaveUserNameAsAnAttribute() {
 
-        String saveUserNameAsAnAttribute =
-                realmConfig.getUserStoreProperty(ADD_USER_NAME_AS_ATTRIBUTE);
-        if(StringUtils.isEmpty(saveUserNameAsAnAttribute)) {
+        String saveUserNameAsAnAttribute = realmConfig.getUserStoreProperty(ADD_USER_NAME_AS_ATTRIBUTE);
+        if (StringUtils.isEmpty(saveUserNameAsAnAttribute)) {
             return true;
         }
-        return  Boolean.parseBoolean(saveUserNameAsAnAttribute);
+        return Boolean.parseBoolean(saveUserNameAsAnAttribute);
     }
 
     /**

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/ReadWriteLDAPUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/ReadWriteLDAPUserStoreManager.java
@@ -98,7 +98,7 @@ public class ReadWriteLDAPUserStoreManager extends ReadOnlyLDAPUserStoreManager 
     private static Log logger = LogFactory.getLog(ReadWriteLDAPUserStoreManager.class);
     private static Log log = LogFactory.getLog(ReadWriteLDAPUserStoreManager.class);
     private static final String BULK_IMPORT_SUPPORT = "BulkImportSupported";
-    private static final String SKIP_SAVE_USER_NAME_AS_ATTRIBUTE = "SkipSaveUserNameAsAttribute";
+    private static final String ADD_USER_NAME_AS_ATTRIBUTE = "AddUserNameAsAttribute";
 
     protected Random random = new Random();
 
@@ -431,8 +431,11 @@ public class ReadWriteLDAPUserStoreManager extends ReadOnlyLDAPUserStoreManager 
     private boolean isSaveUserNameAsAnAttribute() {
 
         String saveUserNameAsAnAttribute =
-                realmConfig.getUserStoreProperty(SKIP_SAVE_USER_NAME_AS_ATTRIBUTE);
-        return ! Boolean.parseBoolean(saveUserNameAsAnAttribute);
+                realmConfig.getUserStoreProperty(ADD_USER_NAME_AS_ATTRIBUTE);
+        if(StringUtils.isEmpty(saveUserNameAsAnAttribute)) {
+            return true;
+        }
+        return  Boolean.parseBoolean(saveUserNameAsAnAttribute);
     }
 
     /**
@@ -2030,8 +2033,8 @@ public class ReadWriteLDAPUserStoreManager extends ReadOnlyLDAPUserStoreManager 
                 USER_CACHE_EXPIRY_TIME_ATTRIBUTE_DESCRIPTION);
         setAdvancedProperty(LDAPConstants.USER_DN_CACHE_ENABLED, USER_DN_CACHE_ENABLED_ATTRIBUTE_NAME, "true",
                 USER_DN_CACHE_ENABLED_ATTRIBUTE_DESCRIPTION);
-        setAdvancedProperty(SKIP_SAVE_USER_NAME_AS_ATTRIBUTE, "Skip Saving the User Name as an Attribute",
-                "false","Skip Saving the user name as attribute. Some LDAP servers may save duplicate CN without this.");
+        setAdvancedProperty(ADD_USER_NAME_AS_ATTRIBUTE, "Always add the User Name as an Attribute",
+                "true","Adds the user name as attribute. Some LDAP servers may save duplicate CN with this enabled.");
     }
 
 //

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/ReadWriteLDAPUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/ReadWriteLDAPUserStoreManager.java
@@ -98,6 +98,7 @@ public class ReadWriteLDAPUserStoreManager extends ReadOnlyLDAPUserStoreManager 
     private static Log logger = LogFactory.getLog(ReadWriteLDAPUserStoreManager.class);
     private static Log log = LogFactory.getLog(ReadWriteLDAPUserStoreManager.class);
     private static final String BULK_IMPORT_SUPPORT = "BulkImportSupported";
+    private static final String SKIP_SAVE_USER_NAME_AS_ATTRIBUTE = "SkipSaveUserNameAsAttribute";
 
     protected Random random = new Random();
 
@@ -389,10 +390,12 @@ public class ReadWriteLDAPUserStoreManager extends ReadOnlyLDAPUserStoreManager 
             objectClass.add("subschema");
         }
         basicAttributes.put(objectClass);
-        BasicAttribute userNameAttribute = new BasicAttribute(
-                realmConfig.getUserStoreProperty(LDAPConstants.USER_NAME_ATTRIBUTE));
-        userNameAttribute.add(userName);
-        basicAttributes.put(userNameAttribute);
+        if(isSaveUserNameAsAnAttribute()) {
+            BasicAttribute userNameAttribute = new BasicAttribute(realmConfig.
+                    getUserStoreProperty(LDAPConstants.USER_NAME_ATTRIBUTE));
+            userNameAttribute.add(userName);
+            basicAttributes.put(userNameAttribute);
+        }
 
         if (kdcEnabled) {
             CarbonContext cc = CarbonContext.getThreadLocalCarbonContext();
@@ -419,6 +422,17 @@ public class ReadWriteLDAPUserStoreManager extends ReadOnlyLDAPUserStoreManager 
             basicAttributes.put(versionNumberAttribute);
         }
         return basicAttributes;
+    }
+
+    /**
+     * Returns true iff Saving username as an attribute is not disabled.
+     * @return
+     */
+    private boolean isSaveUserNameAsAnAttribute() {
+
+        String saveUserNameAsAnAttribute =
+                realmConfig.getUserStoreProperty(SKIP_SAVE_USER_NAME_AS_ATTRIBUTE);
+        return ! Boolean.parseBoolean(saveUserNameAsAnAttribute);
     }
 
     /**
@@ -2016,6 +2030,8 @@ public class ReadWriteLDAPUserStoreManager extends ReadOnlyLDAPUserStoreManager 
                 USER_CACHE_EXPIRY_TIME_ATTRIBUTE_DESCRIPTION);
         setAdvancedProperty(LDAPConstants.USER_DN_CACHE_ENABLED, USER_DN_CACHE_ENABLED_ATTRIBUTE_NAME, "true",
                 USER_DN_CACHE_ENABLED_ATTRIBUTE_DESCRIPTION);
+        setAdvancedProperty(SKIP_SAVE_USER_NAME_AS_ATTRIBUTE, "Skip Saving the User Name as an Attribute",
+                "false","Skip Saving the user name as attribute. Some LDAP servers may save duplicate CN without this.");
     }
 
 //


### PR DESCRIPTION

## Purpose
> Fixed IDENTITY-7264
> Adding new configuration property to disable saving the user name as an attribute.

## Goals
> Disables saving user-name as attribute in selective cases. default false.

## Approach
> The saving user name (which is UID) ad an attribute causes duplicate CN to be saved in some LDAP server versions. e.g OpenLDAP.
This allows user to disable saving if the underlying LDAP is one of the affected versions.

## User stories
> N/A

## Release note
> N/A

## Documentation
> https://wso2.org/jira/browse/IDENTITY-7264?focusedCommentId=141827&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-141827

## Training
> N/A


## Marketing
> Bug Fix. 

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.