### PR TITLE
Fix issue in rendering images

### DIFF
--- a/core/org.wso2.carbon.registry.core/src/main/java/org/wso2/carbon/registry/app/ResourceServlet.java
+++ b/core/org.wso2.carbon.registry.core/src/main/java/org/wso2/carbon/registry/app/ResourceServlet.java
@@ -162,9 +162,6 @@ public class ResourceServlet extends HttpServlet {
                         servletOutputStream.write(contentChunk, 0, byteCount);
                     }
 
-                    response.flushBuffer();
-                    servletOutputStream.flush();
-
                 } finally {
                     contentStream.close();
                 }


### PR DESCRIPTION
## Purpose
When images are fetched and rendered from the registry via `ResourceServlet`, the images are not getting rendered properly within the browser. 

Resolves: #1678 

## Goals
This fix removes a redundant flush logic which causes the issue in `ServletOutputStream` and `HttpServletResponse`.

## Approach
N/A

## User stories
N/A

## Release note
N/A

## Documentation
N/A

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
N/A
 
## Learning
N/A