### PR TITLE
Do not put default resource to registry if it doesn't exist

### DIFF
--- a/core/server-role-manager/org.wso2.carbon.roles.mgt/src/main/java/org/wso2/carbon/roles/mgt/ServerRolesManager.java
+++ b/core/server-role-manager/org.wso2.carbon.roles.mgt/src/main/java/org/wso2/carbon/roles/mgt/ServerRolesManager.java
@@ -153,7 +153,7 @@ public class ServerRolesManager extends AbstractAdmin implements ServerRolesMana
         return status;
     }
     
-    private void createDefaultProductServerRoles(Registry configReg, List<String> productServerRolesList) {
+    private Resource createDefaultProductServerRoles(Registry configReg, List<String> productServerRolesList) {
         Resource resource = configReg.newResource();
         resource.setProperty(ServerRoleConstants.DEFAULT_ROLES_ID, productServerRolesList);
         resource.setProperty(ServerRoleConstants.MODIFIED_TAG,

--- a/core/server-role-manager/org.wso2.carbon.roles.mgt/src/main/java/org/wso2/carbon/roles/mgt/ServerRolesManager.java
+++ b/core/server-role-manager/org.wso2.carbon.roles.mgt/src/main/java/org/wso2/carbon/roles/mgt/ServerRolesManager.java
@@ -34,12 +34,8 @@ public class ServerRolesManager extends AbstractAdmin implements ServerRolesMana
             List<String> productServerRolesList = ServerRoleUtils.readProductServerRoles();
 
             if (resource == null) {
-                try {
-                    this.createDefaultProductServerRoles(configReg, productServerRolesList);
-                    this.putResourceToRegistry(configReg, resource, regPath);
-                } catch (RegistryException e) {
-                    this.handleException(e.getMessage(), e);
-                }
+                this.createDefaultProductServerRoles(configReg, productServerRolesList);
+                this.putResourceToRegistry(configReg, resource, regPath);
             } else {
                 modified = resource.getProperty(ServerRoleConstants.MODIFIED_TAG);
                 if (modified == null || ServerRoleConstants.MODIFIED_TAG_FALSE.equals(modified)) {
@@ -131,12 +127,8 @@ public class ServerRolesManager extends AbstractAdmin implements ServerRolesMana
                 serverRolesList = ServerRoleUtils.mergeLists(serverRolesList, serverRolesListToAdd);
                 resource.setProperty(serverRoleType, serverRolesList);
             }
-            try {
-                putResourceToRegistry(configReg, resource, regPath);
-                status = true;
-            } catch (RegistryException e) {
-                this.handleException(e.getMessage(), e);
-            }
+            putResourceToRegistry(configReg, resource, regPath);
+            status = true;
 
             // We have to update the modified flag in any case.. serverRoleType above
             // is always custom.

--- a/core/server-role-manager/org.wso2.carbon.roles.mgt/src/main/java/org/wso2/carbon/roles/mgt/ServerRolesManager.java
+++ b/core/server-role-manager/org.wso2.carbon.roles.mgt/src/main/java/org/wso2/carbon/roles/mgt/ServerRolesManager.java
@@ -123,20 +123,20 @@ public class ServerRolesManager extends AbstractAdmin implements ServerRolesMana
 
             Resource resource = this.getResourceFromRegistry(configReg, regPath);
             if (resource == null) {
-                try {
-                    resource = configReg.newResource();
-                    resource.setProperty(serverRoleType, serverRolesListToAdd);
-                } catch (RegistryException e) {
-                    this.handleException(e.getMessage(), e);
-                }
+                resource = configReg.newResource();
+                resource.setProperty(serverRoleType, serverRolesListToAdd);
             } else {
                 List<String> serverRolesList = resource.getPropertyValues(serverRoleType);
                 //todo manage duplicates - done(used Sets)
                 serverRolesList = ServerRoleUtils.mergeLists(serverRolesList, serverRolesListToAdd);
                 resource.setProperty(serverRoleType, serverRolesList);
-                status = true;
             }
-            putResourceToRegistry(configReg, resource, regPath);
+            try {
+                putResourceToRegistry(configReg, resource, regPath);
+                status = true;
+            } catch (RegistryException e) {
+                this.handleException(e.getMessage(), e);
+            }
 
             // We have to update the modified flag in any case.. serverRoleType above
             // is always custom.

--- a/core/server-role-manager/org.wso2.carbon.roles.mgt/src/main/java/org/wso2/carbon/roles/mgt/ServerRolesManager.java
+++ b/core/server-role-manager/org.wso2.carbon.roles.mgt/src/main/java/org/wso2/carbon/roles/mgt/ServerRolesManager.java
@@ -114,6 +114,7 @@ public class ServerRolesManager extends AbstractAdmin implements ServerRolesMana
             throws ServerRolesException {
         log.debug("Adding " + serverRoleType + " Server-Roles to Registry.");
 
+        boolean status = false;
         Registry configReg = getConfigSystemRegistry();
         String regPath = this.getRegistryPath(serverRoleType);
 
@@ -151,8 +152,9 @@ public class ServerRolesManager extends AbstractAdmin implements ServerRolesMana
             defaultResource.setProperty(ServerRoleConstants.MODIFIED_TAG,
                     ServerRoleConstants.MODIFIED_TAG_TRUE);
             putResourceToRegistry(configReg, defaultResource, defaultPath);
+            status = true;
         }
-        return true;
+        return status;
     }
     
     private Resource createDefaultProductServerRoles(Registry configReg, List<String> productServerRolesList)

--- a/core/server-role-manager/org.wso2.carbon.roles.mgt/src/main/java/org/wso2/carbon/roles/mgt/ServerRolesManager.java
+++ b/core/server-role-manager/org.wso2.carbon.roles.mgt/src/main/java/org/wso2/carbon/roles/mgt/ServerRolesManager.java
@@ -34,7 +34,7 @@ public class ServerRolesManager extends AbstractAdmin implements ServerRolesMana
             List<String> productServerRolesList = ServerRoleUtils.readProductServerRoles();
 
             if (resource == null) {
-                this.createDefaultProductServerRoles(configReg, productServerRolesList);
+                resource = this.createDefaultProductServerRoles(configReg, productServerRolesList);
                 this.putResourceToRegistry(configReg, resource, regPath);
             } else {
                 modified = resource.getProperty(ServerRoleConstants.MODIFIED_TAG);

--- a/core/server-role-manager/org.wso2.carbon.roles.mgt/src/main/java/org/wso2/carbon/roles/mgt/ServerRolesManager.java
+++ b/core/server-role-manager/org.wso2.carbon.roles.mgt/src/main/java/org/wso2/carbon/roles/mgt/ServerRolesManager.java
@@ -123,7 +123,6 @@ public class ServerRolesManager extends AbstractAdmin implements ServerRolesMana
                     resource.setProperty(serverRoleType, serverRolesListToAdd);
                 } catch (RegistryException e) {
                     this.handleException(e.getMessage(), e);
-                    return false;
                 }
             } else {
                 List<String> serverRolesList = resource.getPropertyValues(serverRoleType);

--- a/core/server-role-manager/org.wso2.carbon.roles.mgt/src/main/java/org/wso2/carbon/roles/mgt/ServerRolesManager.java
+++ b/core/server-role-manager/org.wso2.carbon.roles.mgt/src/main/java/org/wso2/carbon/roles/mgt/ServerRolesManager.java
@@ -148,8 +148,8 @@ public class ServerRolesManager extends AbstractAdmin implements ServerRolesMana
             if (defaultResource != null) {
                 defaultResource.setProperty(ServerRoleConstants.MODIFIED_TAG,
                         ServerRoleConstants.MODIFIED_TAG_TRUE);
+                putResourceToRegistry(configReg, defaultResource, defaultPath);
             }
-            putResourceToRegistry(configReg, defaultResource, defaultPath);
         }
         return status;
     }

--- a/core/server-role-manager/org.wso2.carbon.roles.mgt/src/main/java/org/wso2/carbon/roles/mgt/ServerRolesManager.java
+++ b/core/server-role-manager/org.wso2.carbon.roles.mgt/src/main/java/org/wso2/carbon/roles/mgt/ServerRolesManager.java
@@ -35,10 +35,7 @@ public class ServerRolesManager extends AbstractAdmin implements ServerRolesMana
 
             if (resource == null) {
                 try {
-                    resource = configReg.newResource();
-                    resource.setProperty(serverRoleType, productServerRolesList);
-                    resource.setProperty(ServerRoleConstants.MODIFIED_TAG,
-                            ServerRoleConstants.MODIFIED_TAG_FALSE);
+                    this.createDefaultProductServerRoles(configReg, productServerRolesList);
                     this.putResourceToRegistry(configReg, resource, regPath);
                 } catch (RegistryException e) {
                     this.handleException(e.getMessage(), e);
@@ -145,13 +142,23 @@ public class ServerRolesManager extends AbstractAdmin implements ServerRolesMana
             // is always custom.
             String defaultPath = getRegistryPath(ServerRoleConstants.DEFAULT_ROLES_ID);
             Resource defaultResource = getResourceFromRegistry(configReg, defaultPath);
-            if (defaultResource != null) {
-                defaultResource.setProperty(ServerRoleConstants.MODIFIED_TAG,
-                        ServerRoleConstants.MODIFIED_TAG_TRUE);
+            if (defaultResource == null) {
+                List<String> productServerRolesList = ServerRoleUtils.readProductServerRoles();
+                defaultResource = this.createDefaultProductServerRoles(configReg, productServerRolesList);
             }
+            defaultResource.setProperty(ServerRoleConstants.MODIFIED_TAG,
+                    ServerRoleConstants.MODIFIED_TAG_TRUE);
             putResourceToRegistry(configReg, defaultResource, defaultPath);
         }
         return status;
+    }
+    
+    private void createDefaultProductServerRoles(Registry configReg, List<String> productServerRolesList) {
+        Resource resource = configReg.newResource();
+        resource.setProperty(ServerRoleConstants.DEFAULT_ROLES_ID, productServerRolesList);
+        resource.setProperty(ServerRoleConstants.MODIFIED_TAG,
+                ServerRoleConstants.MODIFIED_TAG_FALSE);
+        return resource;
     }
 
     /**

--- a/core/server-role-manager/org.wso2.carbon.roles.mgt/src/main/java/org/wso2/carbon/roles/mgt/ServerRolesManager.java
+++ b/core/server-role-manager/org.wso2.carbon.roles.mgt/src/main/java/org/wso2/carbon/roles/mgt/ServerRolesManager.java
@@ -34,8 +34,12 @@ public class ServerRolesManager extends AbstractAdmin implements ServerRolesMana
             List<String> productServerRolesList = ServerRoleUtils.readProductServerRoles();
 
             if (resource == null) {
-                resource = this.createDefaultProductServerRoles(configReg, productServerRolesList);
-                this.putResourceToRegistry(configReg, resource, regPath);
+                try {
+                    resource = this.createDefaultProductServerRoles(configReg, productServerRolesList);
+                    this.putResourceToRegistry(configReg, resource, regPath);
+                } catch (RegistryException e) {
+                    this.handleException(e.getMessage(), e);
+                }
             } else {
                 modified = resource.getProperty(ServerRoleConstants.MODIFIED_TAG);
                 if (modified == null || ServerRoleConstants.MODIFIED_TAG_FALSE.equals(modified)) {
@@ -138,7 +142,11 @@ public class ServerRolesManager extends AbstractAdmin implements ServerRolesMana
             Resource defaultResource = getResourceFromRegistry(configReg, defaultPath);
             if (defaultResource == null) {
                 List<String> productServerRolesList = ServerRoleUtils.readProductServerRoles();
-                defaultResource = this.createDefaultProductServerRoles(configReg, productServerRolesList);
+                try {
+                    defaultResource = this.createDefaultProductServerRoles(configReg, productServerRolesList);
+                } catch (RegistryException e) {
+                    this.handleException(e.getMessage(), e);
+                }
             }
             defaultResource.setProperty(ServerRoleConstants.MODIFIED_TAG,
                     ServerRoleConstants.MODIFIED_TAG_TRUE);
@@ -148,16 +156,11 @@ public class ServerRolesManager extends AbstractAdmin implements ServerRolesMana
     }
     
     private Resource createDefaultProductServerRoles(Registry configReg, List<String> productServerRolesList)
-        throws ServerRolesException {
-        Resource resource = null;
-        try {
-            resource = configReg.newResource();
-            resource.setProperty(ServerRoleConstants.DEFAULT_ROLES_ID, productServerRolesList);
-            resource.setProperty(ServerRoleConstants.MODIFIED_TAG,
-                    ServerRoleConstants.MODIFIED_TAG_FALSE);
-        } catch (RegistryException e) {
-            this.handleException(e.getMessage(), e);
-        }
+            throws RegistryException, ServerRolesException {
+        Resource resource = configReg.newResource();
+        resource.setProperty(ServerRoleConstants.DEFAULT_ROLES_ID, productServerRolesList);
+        resource.setProperty(ServerRoleConstants.MODIFIED_TAG,
+                ServerRoleConstants.MODIFIED_TAG_FALSE);
 
         return resource;
     }


### PR DESCRIPTION
## Purpose
When calling the ServerRole Service to add a custom role, the following exception is thrown:
Caused by: java.lang.NullPointerException
	at org.wso2.carbon.registry.core.caching.CachingHandler.put(CachingHandler.java:332)
	at org.wso2.carbon.registry.core.jdbc.handlers.HandlerManager.put(HandlerManager.java:2503)
	... 73 more
