### PR TITLE
OAEP Fix configurable cipher transformations

### DIFF
--- a/core/org.wso2.carbon.core/pom.xml
+++ b/core/org.wso2.carbon.core/pom.xml
@@ -117,6 +117,10 @@
             <artifactId>httpcore</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.tomcat</groupId>
             <artifactId>tomcat-catalina-ha</artifactId>
             <exclusions>

--- a/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/util/CipherHolder.java
+++ b/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/util/CipherHolder.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.core.util;
+
+import com.google.gson.Gson;
+import org.apache.axiom.om.util.Base64;
+
+/**
+ * Holds ciphertext with related metadata.
+ *
+ * IMPORTANT: this is replicated at org.wso2.carbon.user.core.config.UserStoreConfigXMLProcessor.CipherHolder,
+ *              what ever changes applied here need to update on above. This is done to avoid cyclic dependency.
+ */
+public class CipherHolder {
+
+    // Base64 encoded ciphertext.
+    private String c;
+
+    // Transformation used for encryption, default is "RSA".
+    private String t = "RSA";
+
+    // Thumbprint of the certificate.
+    private String tp;
+
+    // Digest used to generate certificate thumbprint.
+    private String tpd;
+
+
+    public String getTransformation() {
+        return t;
+    }
+
+    public void setTransformation(String transformation) {
+        this.t = transformation;
+    }
+
+    public String getCipherText() {
+        return c;
+    }
+
+    public byte[] getCipherBase64Decoded() {
+        return Base64.decode(c);
+    }
+
+    public void setCipherText(String cipher) {
+        this.c = cipher;
+    }
+
+    public String getThumbPrint() {
+        return tp;
+    }
+
+    public void setThumbPrint(String tp) {
+        this.tp = tp;
+    }
+
+    public String getThumbprintDigest() {
+        return tpd;
+    }
+
+    public void setThumbprintDigest(String digest) {
+        this.tpd = digest;
+    }
+
+    /**
+     * Function to base64 encode ciphertext and set ciphertext
+     * @param cipher
+     */
+    public void setCipherBase64Encoded(byte[] cipher) {
+        this.c = Base64.encode(cipher);
+    }
+
+    /**
+     * Function to set thumbprint
+     * @param tp thumb print
+     * @param digest digest (hash algorithm) used for to create thumb print
+     */
+    public void setThumbPrint(String tp, String digest) {
+        this.tp = tp;
+        this.tpd = digest;
+    }
+
+    @Override
+    public String toString() {
+        Gson gson = new Gson();
+        return gson.toJson(this);
+    }
+}

--- a/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/util/CryptoUtil.java
+++ b/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/util/CryptoUtil.java
@@ -15,6 +15,8 @@
  */
 package org.wso2.carbon.core.util;
 
+import com.google.gson.Gson;
+import com.google.gson.JsonSyntaxException;
 import org.apache.axiom.om.util.Base64;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -25,9 +27,13 @@ import org.wso2.carbon.core.internal.CarbonCoreDataHolder;
 import org.wso2.carbon.registry.core.service.RegistryService;
 
 import javax.crypto.Cipher;
+import java.nio.charset.Charset;
 import java.security.KeyStore;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
 import java.security.cert.Certificate;
+import java.security.cert.CertificateEncodingException;
 
 /**
  * The utility class to encrypt/decrypt passwords to be stored in the
@@ -47,7 +53,12 @@ public class CryptoUtil {
 
     private RegistryService registryService;
 
+    private Gson gson = new Gson();
+
     private static CryptoUtil instance = null;
+
+    private static final char[] HEX_CHARACTERS = new char[]{'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B',
+                                                            'C', 'D', 'E', 'F'};
 
     /**
      * This method returns CryptoUtil object, where this should only be used at runtime,
@@ -110,10 +121,14 @@ public class CryptoUtil {
      * Encrypt a given plain text
      *
      * @param plainTextBytes The plaintext bytes to be encrypted
+     * @param cipherTransformation The transformation that need to encrypt. If it is null, RSA is used as default
+     * @param returnSelfContainedCipherText Create self-contained cipher text if true, return simple encrypted
+     *                                      ciphertext otherwise.
      * @return The cipher text bytes
      * @throws CryptoException On error during encryption
      */
-    public byte[] encrypt(byte[] plainTextBytes) throws CryptoException {
+    public byte[] encrypt(byte[] plainTextBytes, String cipherTransformation, boolean returnSelfContainedCipherText)
+            throws CryptoException {
 
         byte[] encryptedKey;
         SymmetricEncryption encryption = SymmetricEncryption.getInstance();
@@ -130,13 +145,18 @@ public class CryptoUtil {
                 KeyStore keyStore = keyMan.getPrimaryKeyStore();
 
                 Certificate[] certs = keyStore.getCertificateChain(keyAlias);
-                String cipherTransformation = System.getProperty(CIPHER_TRANSFORMATION_SYSTEM_PROPERTY);
                 boolean isCipherTransformEnabled = false;
 
                 if (cipherTransformation != null) {
+                    if (log.isDebugEnabled()) {
+                        log.debug("Cipher transformation for encryption : " + cipherTransformation);
+                    }
                     keyStoreCipher = Cipher.getInstance(cipherTransformation, "BC");
                     isCipherTransformEnabled = true;
                 } else {
+                    if (log.isDebugEnabled()) {
+                        log.debug("Default Cipher transformation for encryption : RSA");
+                    }
                     keyStoreCipher = Cipher.getInstance("RSA", "BC");
                 }
 
@@ -148,13 +168,43 @@ public class CryptoUtil {
                     }
                 } else {
                     encryptedKey = keyStoreCipher.doFinal(plainTextBytes);
+                    if (isCipherTransformEnabled && returnSelfContainedCipherText) {
+                        encryptedKey = createSelfContainedCiphertext(encryptedKey, cipherTransformation, certs[0]);
+                    }
                 }
             }
         } catch (Exception e) {
-            throw new
-                    CryptoException("Error during encryption", e);
+            throw new CryptoException("Error during encryption", e);
         }
         return encryptedKey;
+    }
+
+    /**
+     * Encrypt a given plain text
+     *
+     * @param plainTextBytes The plaintext bytes to be encrypted
+     * @return The cipher text bytes (self-contained ciphertext)
+     * @throws CryptoException On error during encryption
+     */
+    public byte[] encrypt(byte[] plainTextBytes) throws CryptoException {
+        //encrypt with transformation configured in carbon.properties as self contained ciphertext
+        return encrypt(plainTextBytes, System.getProperty(CIPHER_TRANSFORMATION_SYSTEM_PROPERTY), true);
+    }
+
+    /**
+     * Encrypt the given plain text with given transformation and base64 encode the encrypted content.
+     *
+     * @param plainText The plaintext value to be encrypted and base64
+     *                  encoded
+     * @param transformation The transformation used for encryption
+     * @param returnSelfContainedCipherText Create self-contained cipher text if true, return simple encrypted
+     *                                      ciphertext otherwise.
+     * @return The base64 encoded cipher text
+     * @throws CryptoException On error during encryption
+     */
+    public String encryptAndBase64Encode(byte[] plainText, String transformation, boolean returnSelfContainedCipherText)
+            throws CryptoException {
+        return Base64.encode(encrypt(plainText, transformation, returnSelfContainedCipherText));
     }
 
     /**
@@ -179,12 +229,12 @@ public class CryptoUtil {
      */
     public byte[] decrypt(byte[] cipherTextBytes) throws CryptoException {
 
-        byte[] decyptedValue;
+        byte[] decryptedValue;
         SymmetricEncryption encryption = SymmetricEncryption.getInstance();
 
         try {
             if (Boolean.valueOf(encryption.getSymmetricKeyEncryptEnabled())) {
-                decyptedValue = encryption.decryptWithSymmetricKey(cipherTextBytes);
+                decryptedValue = encryption.decryptWithSymmetricKey(cipherTextBytes);
             } else {
                 Cipher keyStoreCipher;
                 KeyStoreManager keyMan = KeyStoreManager.getInstance(
@@ -198,27 +248,89 @@ public class CryptoUtil {
                 boolean isCipherTransformEnabled = false;
 
                 if (cipherTransformation != null) {
-                    keyStoreCipher = Cipher.getInstance(cipherTransformation, "BC");
-                    isCipherTransformEnabled = true;
+                    CipherHolder cipherHolder = cipherTextToCipherHolder(cipherTextBytes);
+                    if (cipherHolder != null) {
+                        // cipher with meta data
+                        if (log.isDebugEnabled()) {
+                            log.debug("Cipher transformation for decryption : " + cipherHolder.getTransformation());
+                        }
+                        keyStoreCipher = Cipher.getInstance(cipherHolder.getTransformation(), "BC");
+                        cipherTextBytes = cipherHolder.getCipherBase64Decoded();
+                        isCipherTransformEnabled = true;
+                    } else {
+                        keyStoreCipher = Cipher.getInstance(cipherTransformation, "BC");
+                        isCipherTransformEnabled = true;
+                    }
                 } else {
+                    // This will reach if the user have removed org.wso2.CipherTransformation from the carbon.properties
+                    // or delete carbon.properties file
                     keyStoreCipher = Cipher.getInstance("RSA", "BC");
                 }
 
                 keyStoreCipher.init(Cipher.DECRYPT_MODE, privateKey);
 
                 if (isCipherTransformEnabled && cipherTextBytes.length == 0) {
-                    decyptedValue = "".getBytes();
+                    decryptedValue = "".getBytes();
                     if (log.isDebugEnabled()) {
                         log.debug("Empty value for plainTextBytes null will persist to DB");
                     }
                 } else {
-                    decyptedValue = keyStoreCipher.doFinal(cipherTextBytes);
+                    decryptedValue = keyStoreCipher.doFinal(cipherTextBytes);
                 }
             }
         } catch (Exception e) {
             throw new CryptoException("errorDuringDecryption", e);
         }
-        return decyptedValue;
+        return decryptedValue;
+    }
+
+
+    /**
+     * Decrypt the given cipher text value using the WSO2 WSAS key.
+     *
+     * IMPORTANT: Since this decrypt method is provided to force required transformation, this will not decrypt
+     * self-contained ciphertexts. To decrypt self-contained ciphertext use decrypt(byte[] cipherTextBytes)
+     *
+     * @param cipherTextBytes The cipher text to be decrypted
+     * @param cipherTransformation The transformation that need to decrypt. If it is null, RSA is used as default.
+     *                             NOTE: If symmetric encryption enabled, cipherTransformation parameter will be ignored
+     * @return Decrypted bytes
+     * @throws CryptoException On an error during decryption
+     */
+    public byte[] decrypt(byte[] cipherTextBytes, String cipherTransformation) throws CryptoException {
+        byte[] decryptedValue;
+
+        SymmetricEncryption encryption = SymmetricEncryption.getInstance();
+        try {
+            if (Boolean.valueOf(encryption.getSymmetricKeyEncryptEnabled())) {
+                decryptedValue = encryption.decryptWithSymmetricKey(cipherTextBytes);
+            } else {
+                Cipher keyStoreCipher;
+                KeyStoreManager keyMan = KeyStoreManager
+                        .getInstance(MultitenantConstants.SUPER_TENANT_ID, this.getServerConfigService(), this.getRegistryService());
+                KeyStore keyStore = keyMan.getPrimaryKeyStore();
+                PrivateKey privateKey = (PrivateKey) keyStore.getKey(keyAlias, keyPass.toCharArray());
+                if (cipherTransformation != null) {
+                    keyStoreCipher = Cipher.getInstance(cipherTransformation, "BC");
+                } else {
+                    keyStoreCipher = Cipher.getInstance("RSA", "BC");
+                }
+
+                keyStoreCipher.init(Cipher.DECRYPT_MODE, privateKey);
+
+                if (cipherTextBytes.length == 0) {
+                    decryptedValue = "".getBytes();
+                    if (log.isDebugEnabled()) {
+                        log.debug("Empty value for plainTextBytes null will persist to DB");
+                    }
+                } else {
+                    decryptedValue = keyStoreCipher.doFinal(cipherTextBytes);
+                }
+            }
+        } catch (Exception e) {
+            throw new CryptoException("errorDuringDecryption", e);
+        }
+        return decryptedValue;
     }
 
     /**
@@ -231,6 +343,119 @@ public class CryptoUtil {
     public byte[] base64DecodeAndDecrypt(String base64CipherText) throws
             CryptoException {
         return decrypt(Base64.decode(base64CipherText));
+    }
+
+    /**
+     * Base64 decode the given value and decrypt using the WSO2 WSAS key.
+     *
+     * IMPORTANT: Since this decrypt method is provided to force required transformation, this will not decrypt
+     * self-contained ciphertexts. To decrypt self-contained ciphertext use base64DecodeAndDecrypt(byte[] cipherTextBytes)
+     *
+     * @param base64CipherText Base64 encoded cipher text
+     * @param transformation The transformation used for encryption
+     * @return Base64 decoded, decrypted bytes
+     * @throws CryptoException On an error during decryption
+     */
+    public byte[] base64DecodeAndDecrypt(String base64CipherText, String transformation) throws
+            CryptoException {
+        return decrypt(Base64.decode(base64CipherText), transformation);
+    }
+
+    /**
+     * Function to validate whether provided is self-contained ciphertext
+     *
+     * @param cipherBytes interested cipher text byte array
+     * @return true if provided cipher is encripted using custom transformation, false if it is RSA
+     */
+    public boolean isSelfContainedCipherText(byte[] cipherBytes) {
+        return cipherTextToCipherHolder(cipherBytes) != null;
+    }
+
+    /**
+     * Function to Base64 decode the given value and validate whether provided is self-contained ciphertext
+     *
+     * @param base64CipherText interested cipher text byte array
+     * @return true if provided cipher is self-contained cipher text
+     */
+    public boolean base64DecodeAndIsSelfContainedCipherText(String base64CipherText) throws
+            CryptoException {
+        return isSelfContainedCipherText(Base64.decode(base64CipherText));
+    }
+
+    /**
+     * This util method will extract the original cipher text content from self-contained cipher
+     *
+     * @param cipher cipher text in as a byte array
+     * @return returns
+     */
+    public byte[] extractOriginalCipher(byte[] cipher) {
+        CipherHolder cipherHolder = cipherTextToCipherHolder(cipher);
+        if (cipherHolder != null) {
+            return cipherHolder.getCipherBase64Decoded();
+        }
+        return cipher;
+    }
+
+    /**
+     * This function will create self-contained ciphertext with metadata
+     *
+     * @param originalCipher ciphertext need to wrap with metadata
+     * @param transformation transformation used to encrypt ciphertext
+     * @param certificate certificate that holds relevant keys used to encrypt
+     * @return setf-contained ciphertext
+     * @throws CertificateEncodingException
+     * @throws NoSuchAlgorithmException
+     */
+    public byte[] createSelfContainedCiphertext(byte[] originalCipher, String transformation, Certificate certificate)
+            throws CertificateEncodingException, NoSuchAlgorithmException {
+
+        CipherHolder cipherHolder = new CipherHolder();
+        cipherHolder.setCipherText(Base64.encode(originalCipher));
+        cipherHolder.setTransformation(transformation);
+        cipherHolder.setThumbPrint(calculateThumbprint(certificate, "SHA-1"), "SHA-1");
+        String cipherWithMetadataStr = gson.toJson(cipherHolder);
+        if (log.isDebugEnabled()) {
+            log.debug("Cipher with meta data : " + cipherWithMetadataStr);
+        }
+        return cipherWithMetadataStr.getBytes(Charset.defaultCharset());
+    }
+
+    /**
+     * Function to convert cipher byte array to {@link CipherHolder}
+     *
+     * @param cipherText cipher text as a byte array
+     * @return if cipher text is not a cipher with meta data
+     */
+    public CipherHolder cipherTextToCipherHolder(byte[] cipherText) {
+
+        String cipherStr = new String(cipherText, Charset.defaultCharset());
+        try {
+            return gson.fromJson(cipherStr, CipherHolder.class);
+        } catch (JsonSyntaxException e) {
+            if (log.isDebugEnabled()) {
+                log.debug("Deserialization failed since cipher string is not representing cipher with metadata");
+            }
+            return null;
+        }
+    }
+
+    private String calculateThumbprint(Certificate certificate, String digest)
+            throws NoSuchAlgorithmException, CertificateEncodingException {
+
+        MessageDigest messageDigest = MessageDigest.getInstance(digest);
+        messageDigest.update(certificate.getEncoded());
+        byte[] digestByteArray = messageDigest.digest();
+
+        // convert digest in form of byte array to hex format
+        StringBuffer strBuffer = new StringBuffer();
+
+        for (int i = 0; i < digestByteArray.length; i++) {
+            int leftNibble = (digestByteArray[i] & 0xF0) >> 4;
+            int rightNibble = (digestByteArray[i] & 0x0F);
+            strBuffer.append(HEX_CHARACTERS[leftNibble]).append(HEX_CHARACTERS[rightNibble]);
+        }
+
+        return strBuffer.toString();
     }
 }
 

--- a/core/org.wso2.carbon.user.core/pom.xml
+++ b/core/org.wso2.carbon.user.core/pom.xml
@@ -93,6 +93,10 @@
             <groupId>commons-lang.wso2</groupId>
             <artifactId>commons-lang</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/config/UserStoreConfigXMLProcessor.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/config/UserStoreConfigXMLProcessor.java
@@ -17,6 +17,8 @@
  */
 package org.wso2.carbon.user.core.config;
 
+import com.google.gson.Gson;
+import com.google.gson.JsonSyntaxException;
 import org.apache.axiom.om.OMAbstractFactory;
 import org.apache.axiom.om.OMAttribute;
 import org.apache.axiom.om.OMElement;
@@ -45,15 +47,22 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.Charset;
 import java.security.GeneralSecurityException;
+import java.security.InvalidKeyException;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
 import java.security.PrivateKey;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.regex.Pattern;
+import javax.crypto.BadPaddingException;
 import javax.crypto.Cipher;
+import javax.crypto.IllegalBlockSizeException;
+import javax.crypto.NoSuchPaddingException;
 import javax.xml.namespace.QName;
 import javax.xml.stream.XMLStreamException;
 
@@ -65,6 +74,7 @@ public class UserStoreConfigXMLProcessor {
     private static PrivateKey privateKey = getPrivateKey();
     private SecretResolver secretResolver;
     private String filePath = null;
+    private Gson gson = new Gson();
 
     public UserStoreConfigXMLProcessor(String path) {
         this.filePath = path;
@@ -307,7 +317,6 @@ public class UserStoreConfigXMLProcessor {
      */
     private String resolveEncryption(OMElement propElem) throws org.wso2.carbon.user.api.UserStoreException {
         String propValue = propElem.getText();
-        Cipher keyStoreCipher;
         if (propValue != null) {
             String secretPropName = propElem.getAttributeValue(new QName("encrypted"));
             if (secretPropName != null && secretPropName.equalsIgnoreCase("true")) {
@@ -316,21 +325,7 @@ public class UserStoreConfigXMLProcessor {
                             UserCoreConstants.RealmConfig.ATTR_NAME_PROP_NAME)));
                 }
                 try {
-                    String cipherTransformation = System.getProperty(CIPHER_TRANSFORMATION_SYSTEM_PROPERTY);
-                    if(cipherTransformation != null) {
-                        keyStoreCipher = Cipher.getInstance(cipherTransformation, "BC");
-                    } else {
-                        keyStoreCipher = Cipher.getInstance("RSA", "BC");
-                    }
-                    privateKey = (privateKey == null) ? getPrivateKey() : privateKey;
-                    if (privateKey == null) {
-                        throw new org.wso2.carbon.user.api.UserStoreException(
-                                "Private key initialization failed. Cannot decrypt the userstore password.");
-                    }
-
-                    keyStoreCipher.init(Cipher.DECRYPT_MODE, privateKey);
-                    propValue = new String(keyStoreCipher.doFinal(Base64.
-                            decode(propValue.trim())));
+                    propValue = decryptProperty(propValue);
                 } catch (GeneralSecurityException e) {
                     String errMsg = "encryption of Property=" + propElem.getAttributeValue(
                             new QName(UserCoreConstants.RealmConfig.ATTR_NAME_PROP_NAME))
@@ -395,5 +390,158 @@ public class UserStoreConfigXMLProcessor {
             }
         }
         return null;
+    }
+
+    /**
+     * Function to decrypt given cipher text
+     *
+     * @param propValue base64encoded ciphertext
+     * @return plaintext
+     * @throws NoSuchPaddingException
+     * @throws NoSuchAlgorithmException
+     * @throws NoSuchProviderException
+     * @throws org.wso2.carbon.user.api.UserStoreException
+     * @throws InvalidKeyException
+     * @throws BadPaddingException
+     * @throws IllegalBlockSizeException
+     */
+    private String decryptProperty(String propValue)
+            throws NoSuchPaddingException, NoSuchAlgorithmException, NoSuchProviderException,
+            org.wso2.carbon.user.api.UserStoreException, InvalidKeyException, BadPaddingException,
+            IllegalBlockSizeException {
+
+        Cipher keyStoreCipher;
+        String cipherTransformation = System.getProperty(CIPHER_TRANSFORMATION_SYSTEM_PROPERTY);
+        byte[] cipherTextBytes = Base64.decode(propValue.trim());
+
+        privateKey = (privateKey == null) ? getPrivateKey() : privateKey;
+        if (privateKey == null) {
+            throw new org.wso2.carbon.user.api.UserStoreException(
+                    "Private key initialization failed. Cannot decrypt the userstore password.");
+        }
+
+        if(cipherTransformation != null) {
+            // extract the original cipher if custom transformation is used configured in carbon.properties.
+            CipherHolder cipherHolder = cipherTextToCipherHolder(cipherTextBytes);
+            if (cipherHolder != null) {
+                // cipher with meta data.
+                if (log.isDebugEnabled()) {
+                    log.debug("Cipher transformation for decryption : " + cipherHolder.getTransformation());
+                }
+                keyStoreCipher = Cipher.getInstance(cipherHolder.getTransformation(), "BC");
+                cipherTextBytes = cipherHolder.getCipherBase64Decoded();
+            } else {
+                // If the ciphertext is not a self-contained, directly decrypt using transformation configured in
+                // carbon.properties file
+                keyStoreCipher = Cipher.getInstance(cipherTransformation, "BC");
+            }
+        } else {
+            // If reach here, user have removed org.wso2.CipherTransformation property or carbon.properties file
+            // hence RSA is considered as default transformation
+            keyStoreCipher = Cipher.getInstance("RSA", "BC");
+        }
+        keyStoreCipher.init(Cipher.DECRYPT_MODE, privateKey);
+        return new String(keyStoreCipher.doFinal(cipherTextBytes), Charset.defaultCharset());
+    }
+
+    /**
+     * Function to convert cipher byte array to {@link CipherHolder}.
+     *
+     * @param cipherText cipher text as a byte array
+     * @return if cipher text is not a cipher with meta data
+     */
+    private CipherHolder cipherTextToCipherHolder(byte[] cipherText) {
+
+        String cipherStr = new String(cipherText, Charset.defaultCharset());
+        try {
+            return gson.fromJson(cipherStr, CipherHolder.class);
+        } catch (JsonSyntaxException e) {
+            if (log.isDebugEnabled()) {
+                log.debug("Deserialization failed since cipher string is not representing cipher with metadata");
+            }
+            return null;
+        }
+    }
+
+    /**
+     * Holds encrypted cipher with related metadata.
+     *
+     * IMPORTANT: this is copy of org.wso2.carbon.core.util.CipherHolder, what ever changes applied here need to update
+     *              on above
+     */
+    private class CipherHolder {
+
+        // Base64 encoded ciphertext.
+        private String c;
+
+        // Transformation used for encryption, default is "RSA".
+        private String t = "RSA";
+
+        // Thumbprint of the certificate.
+        private String tp;
+
+        // Digest used to generate certificate thumbprint.
+        private String tpd;
+
+
+        public String getTransformation() {
+            return t;
+        }
+
+        public void setTransformation(String transformation) {
+            this.t = transformation;
+        }
+
+        public String getCipherText() {
+            return c;
+        }
+
+        public byte[] getCipherBase64Decoded() {
+            return Base64.decode(c);
+        }
+
+        public void setCipherText(String cipher) {
+            this.c = cipher;
+        }
+
+        public String getThumbPrint() {
+            return tp;
+        }
+
+        public void setThumbPrint(String tp) {
+            this.tp = tp;
+        }
+
+        public String getThumbprintDigest() {
+            return tpd;
+        }
+
+        public void setThumbprintDigest(String digest) {
+            this.tpd = digest;
+        }
+
+        /**
+         * Function to base64 encode ciphertext and set ciphertext
+         * @param cipher
+         */
+        public void setCipherBase64Encoded(byte[] cipher) {
+            this.c = Base64.encode(cipher);
+        }
+
+        /**
+         * Function to set thumbprint
+         * @param tp thumb print
+         * @param digest digest (hash algorithm) used for to create thumb print
+         */
+        public void setThumbPrint(String tp, String digest) {
+            this.tp = tp;
+            this.tpd = digest;
+        }
+
+        @Override
+        public String toString() {
+            Gson gson = new Gson();
+            return gson.toJson(this);
+        }
     }
 }


### PR DESCRIPTION
This fix will add support for self-contained cipher support

## Purpose
This fix will add support for self-contained cipher support

## Goals
Add support for configurable encryption transformations with self-contained ciphertext

## Approach
Creating self-contained cipher text embedding ciphertext, transformation, thumbprint
Example:
```
{
	"c":"bTe5TknDsXM2vStmclaI....................Di/dqv6zz+sGc\u003d",
	"t":"RSA/ECB/OAEPwithSHA1andMGF1Padding",
	"tp":"B0870632FBB459BD5A7C8BAEC5D29D8CA23893FF",
	"tpd":"SHA-1"
}
```

## Related PRs
> 

## Migrations (if applicable)
> 
