### PR TITLE
Create self-contained ciphertext for empty plaintexts

### DIFF
--- a/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/util/CryptoUtil.java
+++ b/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/util/CryptoUtil.java
@@ -168,9 +168,9 @@ public class CryptoUtil {
                     }
                 } else {
                     encryptedKey = keyStoreCipher.doFinal(plainTextBytes);
-                    if (isCipherTransformEnabled && returnSelfContainedCipherText) {
-                        encryptedKey = createSelfContainedCiphertext(encryptedKey, cipherTransformation, certs[0]);
-                    }
+                }
+                if (isCipherTransformEnabled && returnSelfContainedCipherText) {
+                    encryptedKey = createSelfContainedCiphertext(encryptedKey, cipherTransformation, certs[0]);
                 }
             }
         } catch (Exception e) {


### PR DESCRIPTION
## Purpose
When encrypting the plaintext, we just return an empty byte array. This fix will create self-contained ciphertext for empty plaintext as well

## Goals
Create self-contained ciphertexts for empty plaintext as well