### PR TITLE
Fixed the LDAP twice user bind for same user authentication attempt.

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/ReadOnlyLDAPUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/ReadOnlyLDAPUserStoreManager.java
@@ -482,23 +482,26 @@ public class ReadOnlyLDAPUserStoreManager extends AbstractUserStoreManager {
                 }
             } else {
                 name = getNameInSpaceForUserName(userName);
-                try {
-                    if (name != null) {
-                        if (debug) {
-                            log.debug("Authenticating with " + name);
+                // if it is the same user DN found in the cache no need of futher authentication required.
+                if (!failedUserDN.equalsIgnoreCase(name)) {
+                    try {
+                        if (name != null) {
+                            if (debug) {
+                                log.debug("Authenticating with " + name);
+                            }
+                            bValue = this.bindAsUser(userName, name, credentialObj);
+                            if (bValue) {
+                                LdapName ldapName = new LdapName(name);
+                                putToUserCache(userName, ldapName);
+                            }
                         }
-                        bValue = this.bindAsUser(userName, name, credentialObj);
-                        if (bValue) {
-                            LdapName ldapName = new LdapName(name);
-                            putToUserCache(userName, ldapName);
+                    } catch (NamingException e) {
+                        String errorMessage = "Cannot bind user : " + userName;
+                        if (log.isDebugEnabled()) {
+                            log.debug(errorMessage, e);
                         }
+                        throw new UserStoreException(errorMessage, e);
                     }
-                } catch (NamingException e) {
-                    String errorMessage = "Cannot bind user : " + userName;
-                    if (log.isDebugEnabled()) {
-                        log.debug(errorMessage, e);
-                    }
-                    throw new UserStoreException(errorMessage, e);
                 }
             }
 

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/ReadOnlyLDAPUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/ReadOnlyLDAPUserStoreManager.java
@@ -482,11 +482,11 @@ public class ReadOnlyLDAPUserStoreManager extends AbstractUserStoreManager {
                 }
             } else {
                 name = getNameInSpaceForUserName(userName);
-                // if it is the same user DN found in the cache no need of futher authentication required.
-                if (!failedUserDN.equalsIgnoreCase(name)) {
-                    try {
-                        if (name != null) {
-                            if (debug) {
+                try {
+                    if (name != null) {
+                        // if it is the same user DN found in the cache no need of futher authentication required.
+                        if (failedUserDN == null || !failedUserDN.equalsIgnoreCase(name)) {
+                            if (log.isDebugEnabled()) {
                                 log.debug("Authenticating with " + name);
                             }
                             bValue = this.bindAsUser(userName, name, credentialObj);
@@ -495,13 +495,13 @@ public class ReadOnlyLDAPUserStoreManager extends AbstractUserStoreManager {
                                 putToUserCache(userName, ldapName);
                             }
                         }
-                    } catch (NamingException e) {
-                        String errorMessage = "Cannot bind user : " + userName;
-                        if (log.isDebugEnabled()) {
-                            log.debug(errorMessage, e);
-                        }
-                        throw new UserStoreException(errorMessage, e);
                     }
+                } catch (NamingException e) {
+                    String errorMessage = "Cannot bind user : " + userName;
+                    if (log.isDebugEnabled()) {
+                        log.debug(errorMessage, e);
+                    }
+                    throw new UserStoreException(errorMessage, e);
                 }
             }
 


### PR DESCRIPTION
## Purpose
>This PR addresses the issue of LDAP user being authenticated twice.
Relevant issue - wso2/carbon-kernel#1738

## Goal
> Introduce condition check if you have already bind using the cached DN, no further authentication attempt will try

## Approach
> N/A

## User stories
> N/A

## Release note
> Fixed the LDAP twice user bind for same user authentication attempt.

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> JDK 1.8 Ubuntu 16.04
 
## Learning
> N/A