### PR TITLE
Added logs in add data source flow (Failure - printing stacktrace)

### DIFF
--- a/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/util/CryptoUtil.java
+++ b/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/util/CryptoUtil.java
@@ -181,6 +181,7 @@ public class CryptoUtil {
                 }
             }
         } catch (Exception e) {
+            log.error("Error during encryption : ", e);
             throw new CryptoException("Error during encryption", e);
         }
         return encryptedKey;

--- a/core/org.wso2.carbon.ndatasource.core/src/main/java/org/wso2/carbon/ndatasource/core/DataSourceRepository.java
+++ b/core/org.wso2.carbon.ndatasource.core/src/main/java/org/wso2/carbon/ndatasource/core/DataSourceRepository.java
@@ -318,6 +318,7 @@ public class DataSourceRepository {
 			this.getRegistry().put(DataSourceConstants.DATASOURCES_REPOSITORY_BASE_PATH + "/" +
 			        dsmInfo.getName(), resource);
 		} catch (Exception e) {
+			log.error("Error in persisting data source: " + dsmInfo.getName() + "-" + e.getMessage(), e);
 			throw new DataSourceException("Error in persisting data source: " + 
 		            dsmInfo.getName() + " - " + e.getMessage(), e);
 		}


### PR DESCRIPTION
## Purpose
Add data source failure flow does not print logs with the stack trace. It only prints the exception message. Fixes https://github.com/wso2/carbon-kernel/issues/1751

## Goals
Adding logs when exceptions occur for better debugging.

## Approach
Added error logs

## User stories
N/A

## Release note
N/A

## Documentation
N/A

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
N/A
 
## Learning
N/A
