### PR TITLE
Pass Secret object to doUpdateCredential method

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
@@ -1393,7 +1393,7 @@ public abstract class AbstractUserStoreManager implements UserStoreManager {
                 }
 
                 try {
-                    this.doUpdateCredential(userName, newCredential, oldCredential);
+                    this.doUpdateCredential(userName, newCredentialObj, oldCredentialObj);
                 } catch (UserStoreException ex) {
                     handleUpdateCredentialFailure(ErrorMessages.ERROR_CODE_ERROR_WHILE_UPDATING_CREDENTIAL.getCode(),
                             String.format(ErrorMessages.ERROR_CODE_ERROR_WHILE_UPDATING_CREDENTIAL.getMessage(),


### PR DESCRIPTION
Resolves #1744

## Purpose
> String password is passed to doUpdateCredential method instead of Secret object.

## Goals
> Pass Secret object to doUpdateCredential method
