### PR TITLE
Move role validation in add role method to inner level

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
@@ -3921,7 +3921,7 @@ public abstract class AbstractUserStoreManager implements UserStoreManager {
                         org.wso2.carbon.user.api.Permission[] permissions, boolean isSharedRole)
             throws org.wso2.carbon.user.api.UserStoreException {
 
-        if (!isRoleNameValid(roleName)) {
+        if (StringUtils.isEmpty(roleName)) {
             String regEx = realmConfig
                     .getUserStoreProperty(UserCoreConstants.RealmConfig.PROPERTY_ROLE_NAME_JAVA_REG_EX);
             String errorMessage = String
@@ -3992,6 +3992,16 @@ public abstract class AbstractUserStoreManager implements UserStoreManager {
             handleAddRoleFailure(ErrorMessages.ERROR_CODE_READONLY_USER_STORE.getCode(),
                     ErrorMessages.ERROR_CODE_READONLY_USER_STORE.getMessage(), roleName, userList, permissions);
             throw new UserStoreException(ErrorMessages.ERROR_CODE_READONLY_USER_STORE.toString());
+        }
+
+        if (!isRoleNameValid(roleName)) {
+            String regEx = realmConfig
+                    .getUserStoreProperty(UserCoreConstants.RealmConfig.PROPERTY_ROLE_NAME_JAVA_REG_EX);
+            String errorMessage = String
+                    .format(ErrorMessages.ERROR_CODE_INVALID_ROLE_NAME.getMessage(), roleName, regEx);
+            String errorCode = ErrorMessages.ERROR_CODE_INVALID_ROLE_NAME.getCode();
+            handleAddRoleFailure(errorCode, errorMessage, roleName, userList, permissions);
+            throw new UserStoreException(errorCode + " - " + errorMessage);
         }
 
         if (doCheckExistingRole(roleName)) {

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
@@ -3922,13 +3922,9 @@ public abstract class AbstractUserStoreManager implements UserStoreManager {
             throws org.wso2.carbon.user.api.UserStoreException {
 
         if (StringUtils.isEmpty(roleName)) {
-            String regEx = realmConfig
-                    .getUserStoreProperty(UserCoreConstants.RealmConfig.PROPERTY_ROLE_NAME_JAVA_REG_EX);
-            String errorMessage = String
-                    .format(ErrorMessages.ERROR_CODE_INVALID_ROLE_NAME.getMessage(), roleName, regEx);
-            String errorCode = ErrorMessages.ERROR_CODE_INVALID_ROLE_NAME.getCode();
-            handleAddRoleFailure(errorCode, errorMessage, roleName, userList, permissions);
-            throw new UserStoreException(errorCode + " - " + errorMessage);
+            handleAddRoleFailure(ErrorMessages.ERROR_CODE_CANNOT_ADD_EMPTY_ROLE.getCode(),
+                    ErrorMessages.ERROR_CODE_CANNOT_ADD_EMPTY_ROLE.getMessage(), roleName, userList, permissions);
+            throw new UserStoreException(ErrorMessages.ERROR_CODE_CANNOT_ADD_EMPTY_ROLE.toString());
         }
 
         UserStore userStore = getUserStore(roleName);

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/constants/UserCoreErrorConstants.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/constants/UserCoreErrorConstants.java
@@ -160,6 +160,7 @@ public class UserCoreErrorConstants {
         ERROR_CODE_ERROR_WHILE_ADDING_ROLE("31702", "Un-expected error while adding role, %s"),
         ERROR_CODE_ERROR_DURING_POST_ADD_ROLE("31703", "Un-expected error during post-step of adding role, "
                 + "%s"),
+        ERROR_CODE_CANNOT_ADD_EMPTY_ROLE("31704", "Cannot add role with empty role name"),
 
         // Error code while deleting role
         ERROR_CODE_ERROR_DURING_PRE_DELETE_ROLE("31801", "Un-expected error during pre-step of delete "

--- a/core/org.wso2.carbon.user.core/src/test/java/org/wso2/carbon/user/core/jdbc/AdvancedJDBCRealmTest.java
+++ b/core/org.wso2.carbon.user.core/src/test/java/org/wso2/carbon/user/core/jdbc/AdvancedJDBCRealmTest.java
@@ -177,7 +177,7 @@ public class AdvancedJDBCRealmTest extends BaseTestCase {
                     + "adding the role", 1, sampleAbstractUserManagementErrorListener.getAddRoleFailureCount());
             Assert.assertTrue("Error code does not match with the exact errorneous scenario, actual message is " + ex
                     .getMessage(), ex.getMessage()
-                    .startsWith(UserCoreErrorConstants.ErrorMessages.ERROR_CODE_INVALID_ROLE_NAME.getCode()));
+                    .startsWith(UserCoreErrorConstants.ErrorMessages.ERROR_CODE_CANNOT_ADD_EMPTY_ROLE.getCode()));
             //expected error
             if (log.isDebugEnabled()) {
                 log.debug("Expected error, hence ignored", ex);


### PR DESCRIPTION
## Purpose
This PR fixes the integration test failure in IS level. Integeration test failures has happened in IS level, since the validation related with role name validation was moved to outer layer with the PR https://github.com/wso2/carbon-kernel/pull/1737. This PR moves the validation to the previous level and also make sure no NPE is thrown by adding isEmpty check.

## Goals
Fix the behavioural change

## Approach
N/A

## User stories
N/A

## Release note
Since this issue is connected with the previous one. Release note is not applicable.

## Documentation
N/A

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
https://github.com/wso2/carbon-kernel/pull/1737

## Migrations (if applicable)
N/A

## Test environment
Ubuntu 16.04, JDK 1.8
 
## Learning
N/A