### PR TITLE
Post release 4.4.27: prepare branch for next development iteration

### DIFF
--- a/core/org.wso2.carbon.ui/src/main/resources/web/docs/about.html
+++ b/core/org.wso2.carbon.ui/src/main/resources/web/docs/about.html
@@ -21,7 +21,7 @@
 <link href="../admin/css/documentation.css" rel="stylesheet" type="text/css" media="all"/>
 </head>
 <body>
-<h1>Version 4.4.27</h1>
+<h1>Version 4.4.28-SNAPSHOT</h1>
 <h2>About WSO2 Carbon </h2>
 <p>WSO2 Carbon is a component based Enterprise SOA platform. The
 design of

--- a/distribution/kernel/carbon.product
+++ b/distribution/kernel/carbon.product
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?pde version="3.5"?>
 
-<product name="Carbon Product" uid="carbon.product.id" id="carbon.product" application="carbon.application" version="4.4.27" useFeatures="true" includeLaunchers="true">
+<product name="Carbon Product" uid="carbon.product.id" id="carbon.product" application="carbon.application" version="4.4.28-SNAPSHOT" useFeatures="true" includeLaunchers="true">
 
    <configIni use="default">
    </configIni>
@@ -13,7 +13,7 @@
    </plugins>
 
    <features>
-      <feature id="org.wso2.carbon.core.runtime" version="4.4.27"/>
+      <feature id="org.wso2.carbon.core.runtime" version="4.4.28-SNAPSHOT"/>
    </features>
 
   <configurations>

--- a/distribution/kernel/src/assembly/filter.properties
+++ b/distribution/kernel/src/assembly/filter.properties
@@ -1,2 +1,2 @@
-carbon.version=4.4.27
+carbon.version=4.4.28-SNAPSHOT
 p2.repo.url=http://product-dist.wso2.com/p2/carbon/releases/wilkes/

--- a/distribution/product/modules/distribution/src/assembly/filter.properties
+++ b/distribution/product/modules/distribution/src/assembly/filter.properties
@@ -1,8 +1,8 @@
 product.name=WSO2 Carbon
-product.version=4.4.27
+product.version=4.4.28-SNAPSHOT
 product.key=Carbon
-carbon.product.version=4.4.27
-carbon.version=4.4.27
+carbon.product.version=4.4.28-SNAPSHOT
+carbon.version=4.4.28-SNAPSHOT
 default.server.role=CarbonServer
 hotdeployment=true
 hotupdate=true


### PR DESCRIPTION
Preparing branch for the next release iteration.

This PR updates the following files with the development version which is 4.4.28-SNAPSHOT

- core/org.wso2.carbon.ui/src/main/resources/web/docs/about.html
- distribution/kernel/carbon.product
- distribution/kernel/src/assembly/filter.properties
- distribution/product/modules/distribution/src/assembly/filter.properties
