### PR TITLE
[Fix 1779] Race Condition in UserStoreManagerRegistry on HashMap access

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/tracker/UserStoreManagerRegistry.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/tracker/UserStoreManagerRegistry.java
@@ -25,6 +25,7 @@ import org.wso2.carbon.user.api.Properties;
 import org.wso2.carbon.user.api.UserStoreManager;
 import org.wso2.carbon.user.core.internal.UserStoreMgtDSComponent;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -32,10 +33,13 @@ import java.util.Set;
 public class UserStoreManagerRegistry extends UserStoreMgtDSComponent {
     private static Log log = LogFactory.getLog(UserStoreManagerRegistry.class);
     private static ServiceTracker userStoreManagerTracker;
-    private static Map<String, Properties> userStoreManagers = new HashMap<String, Properties>();
-
 
     public static void init(BundleContext bc) throws Exception {
+        if(userStoreManagerTracker != null) {
+            // Log an error as there is no need to call this other than UserStoreMgtDSComponent. We can not change the
+            // signature or behavior as it constitute an API change.
+            log.error("UserStoreManagerRegistry init called more than once, with trace, ", new Throwable());
+        }
         try {
             userStoreManagerTracker = new ServiceTracker(bc, UserStoreManager.class.getName(), null);
             userStoreManagerTracker.open();
@@ -58,6 +62,7 @@ public class UserStoreManagerRegistry extends UserStoreMgtDSComponent {
      */
     private static Map<String, Properties> getUserStoreManagers() {
 
+        Map<String, Properties> userStoreManagers = new HashMap<>();
         Object[] objects = userStoreManagerTracker.getServices();
         int length = objects.length;
         UserStoreManager userStoreManager;
@@ -68,12 +73,21 @@ public class UserStoreManagerRegistry extends UserStoreMgtDSComponent {
             if (userStoreManager.getDefaultUserStoreProperties() != null) {
                 userStoreProperties = userStoreManager.getDefaultUserStoreProperties();
                 userStoreManagers.put(userStoreManager.getClass().getName(), userStoreProperties);
+                if (log.isDebugEnabled()) {
+                    log.debug(
+                            "Adding UserStoreManager with name: " + userStoreManager.getClass().getName()+
+                                    ". UserStoreManager class: " + userStoreManager);
+                }
             } else {
-
+                if (log.isDebugEnabled()) {
+                    log.debug(
+                            "The user store manager has no DefaultUserStoreProperties, " +
+                                    "and will be skipped. UserStoreManager : " + userStoreManager);
+                }
             }
 
         }
-        return userStoreManagers;
+        return Collections.unmodifiableMap(userStoreManagers);
     }
 
     /**
@@ -97,8 +111,5 @@ public class UserStoreManagerRegistry extends UserStoreMgtDSComponent {
         Properties properties;
         properties = getUserStoreManagers().get(className);
         return properties;
-
     }
-
-
 }


### PR DESCRIPTION
## Purpose
Fixing 
https://github.com/wso2/carbon-kernel/issues/1779

## Goals
Fixing high concurrency issue,
https://github.com/wso2/carbon-kernel/issues/1779

## Approach
Removed static variable which changes on each access.

## User stories
N/A

## Release note
N/A

## Documentation
“N/A” . This fixes concurrent issue

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.