### PR TITLE
Moving popup confirm into carbon ui as it can be reused

### DIFF
--- a/core/org.wso2.carbon.ui/src/main/resources/web/dialog/js/dialog.js
+++ b/core/org.wso2.carbon.ui/src/main/resources/web/dialog/js/dialog.js
@@ -292,60 +292,70 @@ CARBON.showPopupDialog = function(message, title, windowHeight, okButton, callba
  * @param {String} message to display html/text
  * @return {Boolean}
  */
-CARBON.showPopupConfirm = function(htmlmessage, title, windowHeight, okButton, callback, windowWidth) {
-    if(!isHTML(htmlmessage)){
-        htmlmessage = htmlEncode(htmlmessage);
+CARBON.showPopupConfirm = function (htmlMessage, title, windowHeight, okButton, cancelButton, callback, windowWidth) {
+    if (!isHTML(htmlMessage)) {
+        htmlMessage = htmlEncode(htmlMessage);
     }
-    var strDialog = "<div id='dialog' title='" + title + "'><div id='popupDialog'></div>" + htmlmessage + "</div>";
+    var strDialog = "<div id='dialog' title='" + title + "'><div id='popupDialog'></div>" + htmlMessage + "</div>";
     var requiredWidth = 750;
     if (windowWidth) {
         requiredWidth = windowWidth;
     }
-    var func = function() {
+    var func = function () {
         jQuery("#dcontainer").html(strDialog);
         if (okButton) {
             jQuery("#dialog").dialog({
-                close:function() {
+                close: function () {
                     jQuery(this).dialog('destroy').remove();
                     jQuery("#dcontainer").empty();
                     return false;
                 },
-                buttons:{
-                    "OK":function() {
+                buttons: {
+                    "OK": function () {
                         if (callback && typeof callback == "function")
                             callback();
                         jQuery(this).dialog("destroy").remove();
                         jQuery("#dcontainer").empty();
                         return false;
                     },
-                    "Cancel":function() {
+                    "Cancel": function () {
                         jQuery(this).dialog('destroy').remove();
                         jQuery("#dcontainer").empty();
                         return false;
                     },
                 },
-                height:windowHeight,
-                width:requiredWidth,
-                minHeight:windowHeight,
-                minWidth:requiredWidth,
-                modal:true
+                height: windowHeight,
+                width: requiredWidth,
+                minHeight: windowHeight,
+                minWidth: requiredWidth,
+                modal: true
             });
         } else {
             jQuery("#dialog").dialog({
-                close:function() {
+                close: function () {
                     jQuery(this).dialog('destroy').remove();
                     jQuery("#dcontainer").empty();
                     return false;
                 },
-                height:windowHeight,
-                width:requiredWidth,
-                minHeight:windowHeight,
-                minWidth:requiredWidth,
-                modal:true
+                height: windowHeight,
+                width: requiredWidth,
+                minHeight: windowHeight,
+                minWidth: requiredWidth,
+                modal: true
             });
         }
 
-        jQuery('.ui-dialog-titlebar-close').click(function(){
+        if (okButton) {
+            $('.ui-dialog-buttonpane button:contains(OK)').attr("id", "dialog-confirm_ok-button");
+            $('#dialog-confirm_ok-button').html(okButton);
+        }
+        if (cancelButton) {
+            $('.ui-dialog-buttonpane button:contains(Cancel)').attr("id", "dialog-confirm_cancel-button");
+            $('#dialog-confirm_cancel-button').html(cancelButton);
+        }
+
+
+        jQuery('.ui-dialog-titlebar-close').click(function () {
             jQuery('#dialog').dialog("destroy").remove();
             jQuery("#dcontainer").empty();
             jQuery("#dcontainer").html('');
@@ -362,13 +372,13 @@ CARBON.showPopupConfirm = function(htmlmessage, title, windowHeight, okButton, c
         var a = document.createElement('div');
         a.innerHTML = str;
 
-        for (var c = a.childNodes, i = c.length; i--; ) {
+        for (var c = a.childNodes, i = c.length; i--;) {
             if (c[i].nodeType == 1) return true;
         }
 
         return false;
     }
-};
+}
 
 /**
  * Display the Input dialog.

--- a/core/org.wso2.carbon.ui/src/main/resources/web/dialog/js/dialog.js
+++ b/core/org.wso2.carbon.ui/src/main/resources/web/dialog/js/dialog.js
@@ -303,13 +303,15 @@ CARBON.showPopupConfirm = function (htmlMessage, title, windowHeight, okButton, 
     if (windowWidth) {
         requiredWidth = windowWidth;
     }
+    var dContainer = jQuery("#dcontainer");
+    var popUpDialog = jQuery("#dialog");
     var func = function () {
-        jQuery("#dcontainer").html(strDialog);
+        dContainer.html(strDialog);
         if (okButton) {
-            jQuery("#dialog").dialog({
+            popUpDialog.dialog({
                 close: function () {
                     jQuery(this).dialog('destroy').remove();
-                    jQuery("#dcontainer").empty();
+                    dContainer.empty();
                     return false;
                 },
                 buttons: {
@@ -317,12 +319,12 @@ CARBON.showPopupConfirm = function (htmlMessage, title, windowHeight, okButton, 
                         if (callback && typeof callback == "function")
                             callback();
                         jQuery(this).dialog("destroy").remove();
-                        jQuery("#dcontainer").empty();
+                        dContainer.empty();
                         return false;
                     },
                     "Cancel": function () {
                         jQuery(this).dialog('destroy').remove();
-                        jQuery("#dcontainer").empty();
+                        dContainer.empty();
                         return false;
                     },
                 },
@@ -333,10 +335,10 @@ CARBON.showPopupConfirm = function (htmlMessage, title, windowHeight, okButton, 
                 modal: true
             });
         } else {
-            jQuery("#dialog").dialog({
+            popUpDialog.dialog({
                 close: function () {
                     jQuery(this).dialog('destroy').remove();
-                    jQuery("#dcontainer").empty();
+                    dContainer.empty();
                     return false;
                 },
                 height: windowHeight,
@@ -359,8 +361,7 @@ CARBON.showPopupConfirm = function (htmlMessage, title, windowHeight, okButton, 
 
         jQuery('.ui-dialog-titlebar-close').click(function () {
             jQuery('#dialog').dialog("destroy").remove();
-            jQuery("#dcontainer").empty();
-            jQuery("#dcontainer").html('');
+            dContainer.empty();
         });
 
     };
@@ -371,14 +372,8 @@ CARBON.showPopupConfirm = function (htmlMessage, title, windowHeight, okButton, 
     }
 
     function isHTML(str) {
-        var a = document.createElement('div');
-        a.innerHTML = str;
-
-        for (var c = a.childNodes, i = c.length; i--;) {
-            if (c[i].nodeType == 1) return true;
-        }
-
-        return false;
+        var regex = RegExp(/<[a-z][\s\S]*>/i);
+        return regex.test(str);
     }
 }
 
@@ -401,7 +396,7 @@ CARBON.showInputDialog = function(message, handleOk, handleCancel, closeCallback
     var strInput = "<div style='margin:20px;'><p>"+message+ "</p><br/>"+
                    "<input type='text' id='carbon-ui-dialog-input' size='40' name='carbon-dialog-inputval'></div>";
     var strDialog = "<div id='dialog' title='WSO2 Carbon'>" + strInput + "</div>";
-    var func = function() {   
+    var func = function() {
 	    jQuery("#dcontainer").html(strDialog);
 	    jQuery("#dialog").dialog({
 	        close:function() {

--- a/core/org.wso2.carbon.ui/src/main/resources/web/dialog/js/dialog.js
+++ b/core/org.wso2.carbon.ui/src/main/resources/web/dialog/js/dialog.js
@@ -288,8 +288,10 @@ CARBON.showPopupDialog = function(message, title, windowHeight, okButton, callba
 
 /**
  * Display any info inside a jQuery UI's confirmation widget.
- * @method showPopupDialog
+ * @method showPopupConfirm
  * @param {String} message to display html/text
+ * @param {String} okButton to change ok button text
+ * @param {String} cancelButton to change cancel button text
  * @return {Boolean}
  */
 CARBON.showPopupConfirm = function (htmlMessage, title, windowHeight, okButton, cancelButton, callback, windowWidth) {

--- a/core/org.wso2.carbon.ui/src/main/resources/web/dialog/js/dialog.js
+++ b/core/org.wso2.carbon.ui/src/main/resources/web/dialog/js/dialog.js
@@ -227,7 +227,7 @@ CARBON.showConfirmationDialog = function(message, handleYes, handleNo, closeCall
  * @param {String} message to display
  * @return {Boolean}
  */
-CARBON.showPopupDialog = function(message, title, windowHight, okButton, callback, windowWidth) {
+CARBON.showPopupDialog = function(message, title, windowHeight, okButton, callback, windowWidth) {
     var strDialog = "<div id='dialog' title='" + title + "'><div id='popupDialog'></div>" + htmlEncode(message) + "</div>";
     var requiredWidth = 750;
     if (windowWidth) {
@@ -283,6 +283,90 @@ CARBON.showPopupDialog = function(message, title, windowHight, okButton, callbac
         jQuery(document).ready(func);
     } else {
         func();
+    }
+};
+
+/**
+ * Display any info inside a jQuery UI's confirmation widget.
+ * @method showPopupDialog
+ * @param {String} message to display html/text
+ * @return {Boolean}
+ */
+CARBON.showPopupConfirm = function(htmlmessage, title, windowHeight, okButton, callback, windowWidth) {
+    if(!isHTML(htmlmessage)){
+        htmlmessage = htmlEncode(htmlmessage);
+    }
+    var strDialog = "<div id='dialog' title='" + title + "'><div id='popupDialog'></div>" + htmlmessage + "</div>";
+    var requiredWidth = 750;
+    if (windowWidth) {
+        requiredWidth = windowWidth;
+    }
+    var func = function() {
+        jQuery("#dcontainer").html(strDialog);
+        if (okButton) {
+            jQuery("#dialog").dialog({
+                close:function() {
+                    jQuery(this).dialog('destroy').remove();
+                    jQuery("#dcontainer").empty();
+                    return false;
+                },
+                buttons:{
+                    "OK":function() {
+                        if (callback && typeof callback == "function")
+                            callback();
+                        jQuery(this).dialog("destroy").remove();
+                        jQuery("#dcontainer").empty();
+                        return false;
+                    },
+                    "Cancel":function() {
+                        jQuery(this).dialog('destroy').remove();
+                        jQuery("#dcontainer").empty();
+                        return false;
+                    },
+                },
+                height:windowHeight,
+                width:requiredWidth,
+                minHeight:windowHeight,
+                minWidth:requiredWidth,
+                modal:true
+            });
+        } else {
+            jQuery("#dialog").dialog({
+                close:function() {
+                    jQuery(this).dialog('destroy').remove();
+                    jQuery("#dcontainer").empty();
+                    return false;
+                },
+                height:windowHeight,
+                width:requiredWidth,
+                minHeight:windowHeight,
+                minWidth:requiredWidth,
+                modal:true
+            });
+        }
+
+        jQuery('.ui-dialog-titlebar-close').click(function(){
+            jQuery('#dialog').dialog("destroy").remove();
+            jQuery("#dcontainer").empty();
+            jQuery("#dcontainer").html('');
+        });
+
+    };
+    if (!pageLoaded) {
+        jQuery(document).ready(func);
+    } else {
+        func();
+    }
+
+    function isHTML(str) {
+        var a = document.createElement('div');
+        a.innerHTML = str;
+
+        for (var c = a.childNodes, i = c.length; i--; ) {
+            if (c[i].nodeType == 1) return true;
+        }
+
+        return false;
     }
 };
 


### PR DESCRIPTION


## Purpose
> Fixes https://github.com/wso2/product-is/issues/3223

## Goals
> Adding reusable popup content with both html and text message support

## Related PRs
> Part related to the fix  https://github.com/wso2/carbon-identity-framework/pull/1640
