### PR TITLE
Log error when hazelcast exception at cluster init

### DIFF
--- a/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/internal/StartupFinalizerServiceComponent.java
+++ b/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/internal/StartupFinalizerServiceComponent.java
@@ -177,7 +177,7 @@ public class StartupFinalizerServiceComponent implements ServiceListener {
         // port information is needed when populating Member information
         try {
             ClusteringUtil.enableClustering(configCtx);
-        } catch (AxisFault e) {
+        } catch (Throwable e) {
             String msg = "Cannot initialize cluster";
             log.error(msg, e);
             throw new RuntimeException(msg, e);


### PR DESCRIPTION
When an exception except AxisFault occurs while initiating the hazelcast cluster, Server will not log the error and does not continue the server startup properly. This fix will log the exception when a hazelcast exception occurs at server startup to identify the exact issue in hazelcast. 