### PR TITLE
Add support for IAM Role in AWSMembershipScheme in Clustering

### DIFF
--- a/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/clustering/hazelcast/aws/AWSBasedMembershipScheme.java
+++ b/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/clustering/hazelcast/aws/AWSBasedMembershipScheme.java
@@ -99,6 +99,7 @@ public class AWSBasedMembershipScheme implements HazelcastMembershipScheme {
 
         Parameter accessKey = getParameter(AWSConstants.ACCESS_KEY);
         Parameter secretKey = getParameter(AWSConstants.SECRET_KEY);
+        Parameter iamRole = getParameter(AWSConstants.IAM_ROLE);
         Parameter securityGroup = getParameter(AWSConstants.SECURITY_GROUP);
         Parameter connTimeout = getParameter(AWSConstants.CONNECTION_TIMEOUT);
         Parameter hostHeader = getParameter(AWSConstants.HOST_HEADER);
@@ -123,6 +124,9 @@ public class AWSBasedMembershipScheme implements HazelcastMembershipScheme {
             } else {
                 awsConfig.setSecretKey(((String)secretKey.getValue()).trim());
             }
+        }
+        if (iamRole != null) {
+            awsConfig.setIamRole(((String) iamRole.getValue()).trim());
         }
         if (securityGroup != null) {
             awsConfig.setSecurityGroupName(((String)securityGroup.getValue()).trim());

--- a/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/clustering/hazelcast/aws/AWSConstants.java
+++ b/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/clustering/hazelcast/aws/AWSConstants.java
@@ -30,4 +30,5 @@ public class AWSConstants {
     public static final String REGION = "region";
     public static final String TAG_KEY = "tagKey";
     public static final String TAG_VALUE = "tagValue";
+    public static final String IAM_ROLE = "iamRole";
 }


### PR DESCRIPTION
## Purpose
There is no support for IAM Roles for Hazelcast AWS Membership Scheme.

## Goals
It should be possible to just provide the IAM Instance Role without providing the AWS Access and Secret Keys for AWS based Clustering.

## Approach
Hazelcast `AWSConfig` already [supports](https://github.com/hazelcast/hazelcast/blob/master/hazelcast/src/main/java/com/hazelcast/config/AwsConfig.java#L268) this functionality. Only `AWSBasedMembershipScheme` needs to add the support.

Resolves #1819 .

## Documentation
https://docs.google.com/document/d/1CEQkN9vQ2OUkHrmsqF66zmMDFYlsCrVTsYlvKx8M2nk/edit?usp=sharing 