### PR TITLE
Add version for maven-bundle-plugin

### DIFF
--- a/samples/student-manager/components/org.wso2.carbon.student.mgt.ui/pom.xml
+++ b/samples/student-manager/components/org.wso2.carbon.student.mgt.ui/pom.xml
@@ -82,6 +82,7 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
+                <version>${maven.bundle.plugin.version}</version>
                 <extensions>true</extensions>
                 <configuration>
                     <instructions>s

--- a/samples/student-manager/components/org.wso2.carbon.student.mgt/pom.xml
+++ b/samples/student-manager/components/org.wso2.carbon.student.mgt/pom.xml
@@ -20,6 +20,7 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
+                <version>${maven.bundle.plugin.version}</version>
                 <extensions>true</extensions>
                 <configuration>
                     <instructions>

--- a/samples/student-manager/pom.xml
+++ b/samples/student-manager/pom.xml
@@ -17,6 +17,7 @@
     <properties>
         <student.manager.version>4.4.35-SNAPSHOT</student.manager.version>
         <carbon.p2.plugin.version>1.5.4</carbon.p2.plugin.version>
+        <maven.bundle.plugin.version>2.3.5</maven.bundle.plugin.version>
 
         <orbit.version.axis2>1.6.1.wso2v20</orbit.version.axis2>
         <axis2.client.osgi.version>1.6.1.wso2v20</axis2.client.osgi.version>


### PR DESCRIPTION
Adding maven-bundle-plugin version to avoid the components being built with latest pluging

## Purpose
To fix a build break due to mismatching plugin version

## Goals
Fixing build break

## Approach
Adding the correct plugin version

## User stories
N/A

## Release note
N/A

## Documentation
N/A

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
N/A
 
## Learning
N/A