### PR TITLE
Add type parameter to carbon config.

### DIFF
--- a/core/src/main/java/org/wso2/carbon/kernel/config/model/CarbonConfiguration.java
+++ b/core/src/main/java/org/wso2/carbon/kernel/config/model/CarbonConfiguration.java
@@ -44,6 +44,9 @@ public class CarbonConfiguration {
     @Element(description = "server name")
     private String name = "WSO2 Carbon Kernel";
 
+    @Element(description = "server type", required = false)
+    private String type;
+
     @Element(description = "enable/disable hostname verifier")
     private boolean hostnameVerificationEnabled = false;
 
@@ -67,6 +70,10 @@ public class CarbonConfiguration {
 
     public String getName() {
         return name;
+    }
+
+    public String getType() {
+        return type;
     }
 
     public boolean isHostnameVerificationEnabled() {


### PR DESCRIPTION
## Purpose
Add type parameter to carbon config. 

WSO2 Stream Processor (SP) will use this type parameter to uniquely identity the type of the SP server (it can be one of wso2-sp, wso2-apim-analytics, wso2-is-analytics, wso2-ei-analytics).  

