### PR TITLE
Add MultitenantMsgContextServiceComponent and MultitenantMsgContextDataHolder to read and add additional multitenant message context properties.

### DIFF
--- a/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/internal/MultitenantMsgContextDataHolder.java
+++ b/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/internal/MultitenantMsgContextDataHolder.java
@@ -1,0 +1,45 @@
+/*
+ *  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.core.internal;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * This singleton data holder contains the list of additional tenant message context properties read from
+ * multitenant-msg-context.properties file in MultitenantMsgContextServiceComponent
+ */
+public class MultitenantMsgContextDataHolder {
+
+    private static MultitenantMsgContextDataHolder instance = new MultitenantMsgContextDataHolder();
+
+    private List<String> tenantMsgContextProperties = new ArrayList<>();
+
+    public static MultitenantMsgContextDataHolder getInstance() {
+        return instance;
+    }
+
+    private MultitenantMsgContextDataHolder() {
+    }
+
+    public List<String> getTenantMsgContextProperties() {
+        return tenantMsgContextProperties;
+    }
+
+}

--- a/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/internal/MultitenantMsgContextServiceComponent.java
+++ b/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/internal/MultitenantMsgContextServiceComponent.java
@@ -32,7 +32,7 @@ import java.util.Properties;
 
 /**
  * This service component is responsible for loading the list of additional multitenant message context property names
- * from tenant-msg-context.properties file if given in Carbon config directory. It will be read in Carbon
+ * from multitenant-msg-context.properties file if given in Carbon config directory. It will be read in Carbon
  * server startup. These property names are the properties which we need to additionally copy in to tenant message
  * context if available in original message context.
  *
@@ -69,9 +69,13 @@ public class MultitenantMsgContextServiceComponent {
                 //get only the keys of property file (multitenant message context property names)
                 for (Object key : properties.keySet()) {
                     tenantMsgContextProperties.add((String) key);
+                    if (log.isDebugEnabled()) {
+                        log.debug((String) key +
+                                " is added to MultitenantMsgContextDataHolder.tenantMsgContextProperties list");
+                    }
                 }
             } catch (IOException e) {
-                log.warn("Error while reading file from " + filePath);
+                log.warn("Error while reading file from " + filePath, e);
             }
         }
     }

--- a/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/internal/MultitenantMsgContextServiceComponent.java
+++ b/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/internal/MultitenantMsgContextServiceComponent.java
@@ -58,7 +58,7 @@ public class MultitenantMsgContextServiceComponent {
      * This method is used to load the additional multitenant context property name list from the
      * multitenant-msg-context.properties file and add the list to the MultitenantMsgContextDataHolder.
      */
-    protected void loadTenantMessageContextProperties() {
+    private void loadTenantMessageContextProperties() {
         Properties properties = new Properties();
         List<String> tenantMsgContextProperties = dataHolder.getTenantMsgContextProperties();
         String filePath = CarbonUtils.getCarbonConfigDirPath() + File.separator + MULTITENANT_MSG_CONTEXT_PROPERTIES_FILE;

--- a/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/internal/MultitenantMsgContextServiceComponent.java
+++ b/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/internal/MultitenantMsgContextServiceComponent.java
@@ -1,0 +1,79 @@
+/*
+ *  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.core.internal;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.osgi.service.component.ComponentContext;
+import org.wso2.carbon.utils.CarbonUtils;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Properties;
+
+/**
+ * This service component is responsible for loading the list of additional multitenant message context property names
+ * from tenant-msg-context.properties file if given in Carbon config directory. It will be read in Carbon
+ * server startup. These property names are the properties which we need to additionally copy in to tenant message
+ * context if available in original message context.
+ *
+ * @scr.component name="org.wso2.carbon.core.internal.MultitenantMsgContextServiceComponent" immediate="true"
+ */
+public class MultitenantMsgContextServiceComponent {
+
+    private static final Log log = LogFactory.getLog(MultitenantMsgContextServiceComponent.class);
+
+    private MultitenantMsgContextDataHolder dataHolder = MultitenantMsgContextDataHolder.getInstance();
+
+    private static String MULTITENANT_MSG_CONTEXT_PROPERTIES_FILE = "multitenant-msg-context.properties";
+
+    protected void activate(ComponentContext context)
+    {
+        //load the additional multitenant context property name list from property file if given and add to data holder
+        loadTenantMessageContextProperties();
+    }
+
+    protected void deactivate(ComponentContext context) { }
+
+    /**
+     * This method is used to load the additional multitenant context property name list from the
+     * multitenant-msg-context.properties file and add the list to the MultitenantMsgContextDataHolder.
+     */
+    protected void loadTenantMessageContextProperties() {
+        Properties properties = new Properties();
+        List<String> tenantMsgContextProperties = dataHolder.getTenantMsgContextProperties();
+        String filePath = CarbonUtils.getCarbonConfigDirPath() + File.separator + MULTITENANT_MSG_CONTEXT_PROPERTIES_FILE;
+        File file = new File(filePath);
+        if (file.exists()) {
+            try (InputStream in = new FileInputStream(file)) {
+                properties.load(in);
+                //get only the keys of property file (multitenant message context property names)
+                for (Object key : properties.keySet()) {
+                    tenantMsgContextProperties.add((String) key);
+                }
+            } catch (IOException e) {
+                log.warn("Error while reading file from " + filePath);
+            }
+        }
+    }
+
+}

--- a/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/multitenancy/MultitenantMessageReceiver.java
+++ b/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/multitenancy/MultitenantMessageReceiver.java
@@ -48,6 +48,7 @@ import org.apache.axis2.wsdl.WSDLConstants;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
+import org.wso2.carbon.core.internal.MultitenantMsgContextDataHolder;
 import org.wso2.carbon.core.multitenancy.utils.TenantAxisUtils;
 import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
@@ -75,6 +76,8 @@ public class MultitenantMessageReceiver implements MessageReceiver {
     private static final String FORCE_SC_ACCEPTED = "FORCE_SC_ACCEPTED";
     private static final String SYNAPSE_IS_RESPONSE = "synapse.isresponse";
     private static final String FORCE_POST_PUT_NOBODY = "FORCE_POST_PUT_NOBODY";
+
+    private MultitenantMsgContextDataHolder dataHolder = MultitenantMsgContextDataHolder.getInstance();
 
     public void receive(MessageContext mainInMsgContext) throws AxisFault {
 
@@ -744,6 +747,13 @@ public class MultitenantMessageReceiver implements MessageReceiver {
             String key = (String) itr.next();
             if (key != null) {                
                 tenantMsgCtx.setProperty(key, mainMsgCtx.getProperty(key));
+            }
+        }
+
+        // set additional multitenant message context properties read from multitenant-msg-context.properties file
+        for (String property : dataHolder.getTenantMsgContextProperties()) {
+            if (mainMsgCtx.getProperty(property) != null) {
+                tenantMsgCtx.setProperty(property, mainMsgCtx.getProperty(property));
             }
         }
     }

--- a/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/multitenancy/transports/TenantTransportSender.java
+++ b/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/multitenancy/transports/TenantTransportSender.java
@@ -240,7 +240,7 @@ public class TenantTransportSender extends AbstractHandler implements TransportS
             superTenantOutMessageContext.setProperty(NO_ENTITY_BODY, msgContext.getProperty(NO_ENTITY_BODY));
         }
 
-        // set additional multitenant message context properties read from tenant-msg-context.properties file
+        // set additional multitenant message context properties read from multitenant-msg-context.properties file
         for (String property : dataHolder.getTenantMsgContextProperties()) {
             if (msgContext.getProperty(property) != null) {
                 superTenantOutMessageContext.setProperty(property, msgContext.getProperty(property));

--- a/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/multitenancy/transports/TenantTransportSender.java
+++ b/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/multitenancy/transports/TenantTransportSender.java
@@ -39,6 +39,7 @@ import org.apache.axis2.transport.http.HTTPConstants;
 import org.apache.axis2.util.JavaUtils;
 import org.apache.axis2.wsdl.WSDLConstants;
 import org.apache.commons.httpclient.HttpMethod;
+import org.wso2.carbon.core.internal.MultitenantMsgContextDataHolder;
 import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 
 import java.util.Map;
@@ -55,6 +56,8 @@ public class TenantTransportSender extends AbstractHandler implements TransportS
     private static final String FORCE_SC_ACCEPTED = "FORCE_SC_ACCEPTED";
     private static final String FORCE_POST_PUT_NOBODY = "FORCE_POST_PUT_NOBODY";
     private static final String DELETE_REQUEST_WITH_PAYLOAD = "DELETE_REQUEST_WITH_PAYLOAD";
+
+    private MultitenantMsgContextDataHolder dataHolder = MultitenantMsgContextDataHolder.getInstance();
 
     public TenantTransportSender(ConfigurationContext superTenantConfigurationContext) {
         this.superTenantConfigurationContext = superTenantConfigurationContext;
@@ -235,6 +238,13 @@ public class TenantTransportSender extends AbstractHandler implements TransportS
 
         if (msgContext.getProperty(NO_ENTITY_BODY) != null) {
             superTenantOutMessageContext.setProperty(NO_ENTITY_BODY, msgContext.getProperty(NO_ENTITY_BODY));
+        }
+
+        // set additional multitenant message context properties read from tenant-msg-context.properties file
+        for (String property : dataHolder.getTenantMsgContextProperties()) {
+            if (msgContext.getProperty(property) != null) {
+                superTenantOutMessageContext.setProperty(property, msgContext.getProperty(property));
+            }
         }
 
         setDeleteRequestWithPayloadProperty(superTenantOutMessageContext, msgContext);


### PR DESCRIPTION
## Purpose
The current implementation of TenantTransportSender is to copy the original message context properties to tenant message context.  Hence foreach time we add a new property to original synapse message context,  we need to fix the TenantTransportSender and MultitenantMessageReceiver code to copy the property to tenant message context. 

## Goals
Avoid the manual effort to fix the code each time when introducing new property to original synapse message context.

## Approach
This PR introduces a new carbon service component and a dataholder, MultitenantMsgContextServiceComponent and MultitenantMsgContextDataHolder. MultitenantMsgContextServiceComponent load the multitenant-msg-context.properties file from <CARBON_HOME>/repository/conf directory if provided and load the given message context property names to tenantMsgContextProperties array list. 

Each time the TenantTransportSender and MultitenantMessageReceiver are invoked, the property name list will be read from MultitenantMsgContextDataHolder and will copy the message context properties from original message context if available and set them in tenant message context.

This PR fixes https://github.com/wso2/product-apim/issues/3705



