### PR TITLE
 Improving Observability by adding Correlation logs for JDBC and LDAP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ target
 .project
 *.i??
 .idea
+.DS_Store

--- a/core/org.wso2.carbon.ndatasource.rdbms/src/main/java/org/wso2/carbon/ndatasource/rdbms/CorrelationLogInterceptor.java
+++ b/core/org.wso2.carbon.ndatasource.rdbms/src/main/java/org/wso2/carbon/ndatasource/rdbms/CorrelationLogInterceptor.java
@@ -1,0 +1,215 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.ndatasource.rdbms;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.tomcat.jdbc.pool.interceptor.AbstractQueryReport;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.DatabaseMetaData;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Time-Logging interceptor for JDBC pool.
+ * Logs the time taken to execute the query in each pool-ed connection.
+ */
+
+public class CorrelationLogInterceptor extends AbstractQueryReport {
+
+    private static final Log correlationLog = LogFactory.getLog("CORRELATION_LOG");
+
+    private static final String CORRELATION_LOG_TIME_TAKEN_KEY = "delta";
+    private static final String CORRELATION_LOG_TIME_TAKEN_UNIT = "ms";
+    private static final String CORRELATION_LOG_CALL_TYPE_KEY = "callType";
+    private static final String CORRELATION_LOG_CALL_TYPE_VALUE = "jdbc";
+    private static final String CORRELATION_LOG_START_TIME_KEY = "startTime";
+    private static final String CORRELATION_LOG_METHOD_NAME_KEY = "methodName";
+    private static final String CORRELATION_LOG_QUERY_KEY = "query";
+    private static final String CORRELATION_LOG_CONNECTION_URL_KEY = "connectionUrl";
+    private static final String CORRELATION_LOG_SEPARATOR = " | ";
+    private static final String CORRELATION_LOG_SYSTEM_PROPERTY = "enableCorrelationLogs";
+
+    private static Log log = LogFactory.getLog(CorrelationLogInterceptor.class);
+
+    @Override
+    public void closeInvoked() {
+
+    }
+
+    @Override
+    protected void prepareStatement(String s, long l) {
+
+    }
+
+    @Override
+    protected void prepareCall(String s, long l) {
+
+    }
+
+    @Override
+    public Object createStatement(Object proxy, Method method, Object[] args, Object statement, long time) {
+
+        try {
+            if (Boolean.parseBoolean(System.getProperty(CORRELATION_LOG_SYSTEM_PROPERTY))) {
+                return invokeProxy(method, args, statement, time);
+            } else {
+                return statement;
+            }
+
+        } catch (Exception e) {
+            log.warn("Unable to create statement proxy for slow query report.", e);
+            return statement;
+        }
+    }
+
+    private Object invokeProxy(Method method, Object[] args, Object statement, long time) throws Exception {
+
+        String name = method.getName();
+        String sql = null;
+        Constructor<?> constructor = null;
+
+        if (this.compare("prepareStatement", name)) {
+            sql = (String) args[0];
+            constructor = this.getConstructor(1, PreparedStatement.class);
+            if (sql != null) {
+                this.prepareStatement(sql, time);
+            }
+        } else if (!this.compare("prepareCall", name)) {
+            return statement;
+        }
+
+        if (constructor != null) {
+            return constructor.newInstance(new StatementProxy(statement, sql));
+        } else {
+            return null;
+        }
+    }
+
+    /**
+     * Proxy Class that is used to calculate and log the time taken for queries
+     */
+    protected class StatementProxy implements InvocationHandler {
+
+        protected boolean closed = false;
+        protected Object delegate;
+        protected final String query;
+
+        public StatementProxy(Object parent, String query) {
+
+            this.delegate = parent;
+            this.query = query;
+        }
+
+        @Override
+        public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+
+            String name = method.getName();
+            boolean close = CorrelationLogInterceptor.this.compare("close", name);
+            try {
+                if (close && this.closed) {
+                    return null;
+                } else if (CorrelationLogInterceptor.this.compare("isClosed", name)) {
+                    return this.closed;
+                } else if (this.closed) {
+                    throw new SQLException("Statement closed.");
+                } else {
+                    boolean process = false;
+                    process = CorrelationLogInterceptor.this.isExecute(method, process);
+
+                    long start = System.currentTimeMillis();
+                    Object result = null;
+
+                    if (this.delegate != null) {
+                        result = method.invoke(this.delegate, args);
+                    }
+
+                    //If the query is an execute type of query the time taken is calculated and logged
+                    if (process) {
+                        long delta = System.currentTimeMillis() - start;
+                        CorrelationLogInterceptor.this.reportQuery(this.query, args, name, start, delta);
+                        logQueryDetails(start, delta, name);
+                    }
+
+                    if (close) {
+                        this.closed = true;
+                        this.delegate = null;
+                    }
+
+                    return result;
+                }
+            } catch (Exception e) {
+                log.error("Unable get query run-time", e);
+                return null;
+            }
+        }
+
+        /**
+         * Logs the details from the query
+         *
+         * @param start      Query start time
+         * @param delta      Time taken for query
+         * @param methodName Name of the method executing
+         */
+        private void logQueryDetails(long start, long delta, String methodName) throws SQLException {
+
+            if (this.delegate instanceof PreparedStatement) {
+                PreparedStatement preparedStatement = (PreparedStatement) this.delegate;
+                if (preparedStatement.getConnection() != null) {
+                    DatabaseMetaData metaData = preparedStatement.getConnection().getMetaData();
+                    if (correlationLog.isDebugEnabled()) {
+                        Map<String, String> logPropertiesMap = new LinkedHashMap<>();
+                        logPropertiesMap.put(CORRELATION_LOG_TIME_TAKEN_KEY, Long.toString(delta) +
+                                " " + CORRELATION_LOG_TIME_TAKEN_UNIT);
+                        logPropertiesMap.put(CORRELATION_LOG_CALL_TYPE_KEY, CORRELATION_LOG_CALL_TYPE_VALUE);
+                        logPropertiesMap.put(CORRELATION_LOG_START_TIME_KEY, Long.toString(start));
+                        logPropertiesMap.put(CORRELATION_LOG_METHOD_NAME_KEY, methodName);
+                        logPropertiesMap.put(CORRELATION_LOG_QUERY_KEY, this.query);
+                        logPropertiesMap.put(CORRELATION_LOG_CONNECTION_URL_KEY, metaData.getURL());
+                        correlationLog.debug(createLogFormat(logPropertiesMap));
+                    }
+                }
+            }
+        }
+
+        /**
+         * Creates the log line that should be printed
+         *
+         * @param logPropertiesMap Contains the type and value that should be printed in the log
+         * @return The log line
+         */
+        private String createLogFormat(Map<String, String> logPropertiesMap) {
+
+            StringBuilder sb = new StringBuilder();
+            Object[] keys = logPropertiesMap.keySet().toArray();
+            for (int i = 0; i < keys.length; i++) {
+                sb.append(logPropertiesMap.get(keys[i]));
+                if (i < keys.length - 1) {
+                    sb.append(CORRELATION_LOG_SEPARATOR);
+                }
+            }
+            return sb.toString();
+        }
+    }
+}

--- a/core/org.wso2.carbon.ndatasource.rdbms/src/main/java/org/wso2/carbon/ndatasource/rdbms/RDBMSDataSource.java
+++ b/core/org.wso2.carbon.ndatasource.rdbms/src/main/java/org/wso2/carbon/ndatasource/rdbms/RDBMSDataSource.java
@@ -43,7 +43,7 @@ import org.wso2.carbon.ndatasource.rdbms.utils.RDBMSDataSourceUtils;
  */
 public class RDBMSDataSource {
 
-       private static Log log = LogFactory.getLog(RDBMSDataSource.class);
+	private static Log log = LogFactory.getLog(RDBMSDataSource.class);
 
 	private DataSource dataSource;
 

--- a/core/org.wso2.carbon.ndatasource.rdbms/src/main/java/org/wso2/carbon/ndatasource/rdbms/RDBMSDataSource.java
+++ b/core/org.wso2.carbon.ndatasource.rdbms/src/main/java/org/wso2/carbon/ndatasource/rdbms/RDBMSDataSource.java
@@ -46,25 +46,27 @@ public class RDBMSDataSource {
        private static Log log = LogFactory.getLog(RDBMSDataSource.class);
 
 	private DataSource dataSource;
-	
+
 	private Reference dataSourceFactoryReference;
-	
+
 	private PoolConfiguration poolProperties;
-	
+
 	public RDBMSDataSource(RDBMSConfiguration config) throws DataSourceException {
 		this.poolProperties = RDBMSDataSourceUtils.createPoolConfiguration(config);
 		this.populateStandardProps();
 	}
-	
+
 	private void populateStandardProps() {
 		String jdbcInterceptors = this.poolProperties.getJdbcInterceptors();
 		if (jdbcInterceptors == null) {
 			jdbcInterceptors = "";
 		}
-		jdbcInterceptors = RDBMSDataSourceConstants.STANDARD_JDBC_INTERCEPTORS + jdbcInterceptors;
+		//Correlation log interceptor is added to the interceptor chain
+		jdbcInterceptors = RDBMSDataSourceConstants.STANDARD_JDBC_INTERCEPTORS + jdbcInterceptors
+		+ RDBMSDataSourceConstants.CORRELATION_LOG_INTERCEPTOR;
 		this.poolProperties.setJdbcInterceptors(jdbcInterceptors);
 	}
-	
+
 	public DataSource getDataSource() {
 		if (this.dataSource == null) {
 			this.dataSource = new DataSource(poolProperties);
@@ -105,15 +107,15 @@ public class RDBMSDataSource {
                                + mBean + " " + e.getMessage(), e);
                 }
        }
-	
+
 	public Reference getDataSourceFactoryReference() throws DataSourceException {
 		if (dataSourceFactoryReference == null) {
 			dataSourceFactoryReference = new Reference("org.apache.tomcat.jdbc.pool.DataSource",
 	                "org.apache.tomcat.jdbc.pool.DataSourceFactory", null);
-			
+
 			Map<String, String> poolConfigMap = RDBMSDataSourceUtils.extractPrimitiveFieldNameValuePairs(poolProperties);
 			Iterator<Entry<String, String>> poolConfigMapIterator = poolConfigMap.entrySet().iterator();
-			
+
 			while (poolConfigMapIterator.hasNext()) {
 				Entry<String, String> pairs = poolConfigMapIterator.next();
 				dataSourceFactoryReference.add(new StringRefAddr(pairs.getKey(),
@@ -122,5 +124,5 @@ public class RDBMSDataSource {
 		}
 		return dataSourceFactoryReference;
 	}
-	
+
 }

--- a/core/org.wso2.carbon.ndatasource.rdbms/src/main/java/org/wso2/carbon/ndatasource/rdbms/RDBMSDataSourceConstants.java
+++ b/core/org.wso2.carbon.ndatasource.rdbms/src/main/java/org/wso2/carbon/ndatasource/rdbms/RDBMSDataSourceConstants.java
@@ -25,7 +25,9 @@ public class RDBMSDataSourceConstants {
 	public static final String DATASOURCE_PROPS_NAME = "dataSourceProps";
 
 	public static final String ROLLBACK_ON_RETURN = "rollbackOnReturn";
-	
+
+	public static final String CORRELATION_LOG_INTERCEPTOR = "org.wso2.carbon.ndatasource.rdbms.CorrelationLogInterceptor";
+
 	public static final String STANDARD_JDBC_INTERCEPTORS = "ConnectionState;StatementFinalizer;";
 	
 	public static final class TX_ISOLATION_LEVELS {

--- a/core/org.wso2.carbon.tomcat.ext/pom.xml
+++ b/core/org.wso2.carbon.tomcat.ext/pom.xml
@@ -128,6 +128,15 @@
                         </Export-Package>
                         <Import-Package>
                             org.apache.tomcat.*
+                            org.apache.commons.logging,
+                            org.slf4j,
+                            javax.servlet,
+                            javax.servlet.http,
+                            com.google.gson,
+                            org.apache.catalina.valves.*,
+                            org.apache.catalina,
+                            org.apache.catalina.connector,
+                            org.apache.commons.lang,
                         </Import-Package>
                         <Import-Package>
                             *;resolution:=optional

--- a/core/org.wso2.carbon.tomcat.ext/src/main/java/org/wso2/carbon/tomcat/ext/valves/RequestCorrelationIdValve.java
+++ b/core/org.wso2.carbon.tomcat.ext/src/main/java/org/wso2/carbon/tomcat/ext/valves/RequestCorrelationIdValve.java
@@ -1,0 +1,264 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.tomcat.ext.valves;
+
+import com.google.gson.Gson;
+import org.apache.catalina.LifecycleException;
+import org.apache.catalina.connector.Request;
+import org.apache.catalina.connector.Response;
+import org.apache.catalina.valves.ValveBase;
+import org.apache.commons.lang.StringUtils;
+import org.apache.log4j.MDC;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * Tomcat valve which adds MDC from a header value received.
+ * The header and its MDC can be configured.
+ * <p>
+ * By default a HTTP header "activityid" is added to MDC "Correlation-ID"
+ * <p>
+ * The header and MDC can be configured in tomcat valve configuration like,
+ * <code>
+ * headerToCorrelationIdMapping={'activityid':'Correlation-ID'}
+ * queryToCorrelationIdMapping={'RelayState':'Correlation-ID'}
+ * </code>
+ */
+public class RequestCorrelationIdValve extends ValveBase {
+
+    private static final String CORRELATION_ID_MDC = "Correlation-ID";
+    private Map<String, String> headerToIdMapping;
+    private Map<String, String> queryToIdMapping;
+    private static List<String> toRemoveFromThread = new ArrayList<>();
+    private String correlationIdMdc = CORRELATION_ID_MDC;
+    private String headerToCorrelationIdMapping;
+    private String queryToCorrelationIdMapping;
+    private String configuredCorrelationIdMdc;
+
+    @Override
+    protected void initInternal() throws LifecycleException {
+
+        super.initInternal();
+        Gson gson = new Gson();
+        if (StringUtils.isNotEmpty(headerToCorrelationIdMapping)) {
+            headerToIdMapping = gson.fromJson(this.headerToCorrelationIdMapping, Map.class);
+            toRemoveFromThread.addAll(headerToIdMapping.values());
+        }
+
+        if (StringUtils.isNotEmpty(queryToCorrelationIdMapping)) {
+            queryToIdMapping = gson.fromJson(this.queryToCorrelationIdMapping, Map.class);
+            toRemoveFromThread.addAll(queryToIdMapping.values());
+        }
+
+        if (StringUtils.isNotEmpty(configuredCorrelationIdMdc)) {
+            correlationIdMdc = configuredCorrelationIdMdc;
+        }
+    }
+
+    @Override
+    public void invoke(Request request, Response response) throws IOException, ServletException {
+
+        try {
+            Map<String, String> associateToThreadMap = new HashMap<>();
+            associateToThreadMap.putAll(getHeadersToAssociate(request));
+            if (associateToThreadMap.size() == 0) {
+                associateToThreadMap.putAll(getQueryParamsToAssociate(request));
+            }
+
+            if (associateToThreadMap.size() == 0) {
+                associateToThread(UUID.randomUUID().toString());
+            } else {
+                associateToThread(associateToThreadMap);
+            }
+            getNext().invoke(request, response);
+        } finally {
+            disAssociateFromThread();
+            MDC.remove(correlationIdMdc);
+        }
+    }
+
+    /**
+     * Associate all match correlation id values to thread
+     *
+     * @param toAssociate All match headers/query and values
+     */
+    private void associateToThread(Map<String, String> toAssociate) {
+
+        for (Map.Entry<String, String> entry : toAssociate.entrySet()) {
+            MDC.put(entry.getKey(), entry.getValue());
+        }
+    }
+
+    /**
+     * Associate a random correlation id value to thread
+     *
+     * @param generatedValue Randomly generated UUID
+     */
+    private void associateToThread(String generatedValue) {
+
+        MDC.put(correlationIdMdc, generatedValue);
+    }
+
+    /**
+     * Remove all headers values associated with the thread.
+     */
+    private void disAssociateFromThread() {
+
+        if (toRemoveFromThread != null) {
+            for (String correlationIdName : toRemoveFromThread) {
+                MDC.remove(correlationIdName);
+            }
+        }
+    }
+
+    /**
+     * Search through the list of query params configured against query params received.
+     *
+     * @param servletRequest Request received
+     * @return A map which contains all the query and values that should be associated to the thread
+     */
+    private Map<String, String> getQueryParamsToAssociate(ServletRequest servletRequest) {
+
+        Map<String, String> queryToAssociate = new HashMap<>();
+        if (queryToIdMapping == null || !(servletRequest instanceof HttpServletRequest)) {
+            return queryToAssociate;
+        }
+
+        HttpServletRequest httpServletRequest = (HttpServletRequest) servletRequest;
+        for (Map.Entry<String, String> entry : queryToIdMapping.entrySet()) {
+            String queryConfigured = entry.getKey();
+            String correlationIdName = entry.getValue();
+            if (StringUtils.isEmpty(queryConfigured) && StringUtils.isEmpty(correlationIdName)) {
+                continue;
+            }
+
+            Enumeration<String> parameterNames = httpServletRequest.getParameterNames();
+            while (parameterNames.hasMoreElements()) {
+                String queryReceived = parameterNames.nextElement();
+                queryToAssociate.putAll(getQueryCorrelationIdValue(queryReceived, queryConfigured,
+                        httpServletRequest, correlationIdName));
+            }
+        }
+        return queryToAssociate;
+    }
+
+    /**
+     * Search through the list of headers configured against headers received.
+     *
+     * @param servletRequest Request received
+     * @return A map which contains all the headers and values that should be associated to the thread
+     */
+    private Map<String, String> getHeadersToAssociate(ServletRequest servletRequest) {
+
+        Map<String, String> headersToAssociate = new HashMap<>();
+        if (headerToIdMapping == null || !(servletRequest instanceof HttpServletRequest)) {
+            return headersToAssociate;
+        }
+
+        HttpServletRequest httpServletRequest = (HttpServletRequest) servletRequest;
+        for (Map.Entry<String, String> entry : headerToIdMapping.entrySet()) {
+            String headerConfigured = entry.getKey();
+            String correlationIdName = entry.getValue();
+            if (StringUtils.isEmpty(headerConfigured) && StringUtils.isEmpty(correlationIdName)) {
+                continue;
+            }
+
+            Enumeration<String> headerNames = httpServletRequest.getHeaderNames();
+            while (headerNames.hasMoreElements()) {
+                String headerReceived = headerNames.nextElement();
+                headersToAssociate.putAll(getHeaderCorrelationIdValue(headerReceived, headerConfigured,
+                        httpServletRequest, correlationIdName));
+            }
+        }
+        return headersToAssociate;
+    }
+
+    /**
+     * Check if configured header for correlation Id matches the received header and get the header value
+     *
+     * @param headerReceived     Header received in request
+     * @param headerConfigured   Header configured in the valve
+     * @param httpServletRequest Request received
+     * @param correlationIdName  Correlation Id
+     * @return A map which contains a header and value that should be associated to the thread
+     */
+    private Map<String, String> getHeaderCorrelationIdValue(String headerReceived, String headerConfigured,
+                                                            HttpServletRequest httpServletRequest, String correlationIdName) {
+
+        Map<String, String> headersToAssociate = new HashMap<>();
+        if (StringUtils.isEmpty(headerReceived) || !StringUtils.equalsIgnoreCase(headerReceived, headerConfigured)) {
+            return headersToAssociate;
+        }
+
+        String headerValue = httpServletRequest.getHeader(headerReceived);
+        if (StringUtils.isNotEmpty(headerValue)) {
+            headersToAssociate.put(correlationIdName, headerValue);
+        }
+        return headersToAssociate;
+    }
+
+    /**
+     * Check if configured query for correlation Id matches the received query and get the header value
+     *
+     * @param queryReceived      Query received in request
+     * @param queryConfigured    Query configured in the valve
+     * @param httpServletRequest Request received
+     * @param correlationIdName  Correlation Id
+     * @return A map which contains a query and value that should be associated to the thread
+     */
+    private Map<String, String> getQueryCorrelationIdValue(String queryReceived, String queryConfigured,
+                                                           HttpServletRequest httpServletRequest, String correlationIdName) {
+
+        Map<String, String> queryToAssociate = new HashMap<>();
+
+        if (StringUtils.isEmpty(queryReceived) || !StringUtils.equalsIgnoreCase(queryReceived, queryConfigured)) {
+            return queryToAssociate;
+        }
+
+        String queryValue = httpServletRequest.getParameter(queryReceived);
+        if (StringUtils.isNotEmpty(queryValue)) {
+            queryToAssociate.put(correlationIdName, queryValue);
+        }
+        return queryToAssociate;
+    }
+
+    public void setHeaderToCorrelationIdMapping(String headerToCorrelationIdMapping) {
+
+        this.headerToCorrelationIdMapping = headerToCorrelationIdMapping;
+    }
+
+    public void setQueryToCorrelationIdMapping(String queryToCorrelationIdMapping) {
+
+        this.queryToCorrelationIdMapping = queryToCorrelationIdMapping;
+    }
+
+    public void setConfiguredCorrelationIdMdc(String configuredCorrelationIdMdc) {
+
+        this.configuredCorrelationIdMdc = configuredCorrelationIdMdc;
+    }
+}

--- a/core/org.wso2.carbon.tomcat.ext/src/test/java/org/wso2/carbon/tomcat/ext/valves/RequestCorrelationIdValveTest.java
+++ b/core/org.wso2.carbon.tomcat.ext/src/test/java/org/wso2/carbon/tomcat/ext/valves/RequestCorrelationIdValveTest.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.tomcat.ext.valves;
+
+import org.apache.catalina.Container;
+import org.apache.catalina.LifecycleException;
+import org.apache.catalina.Valve;
+import org.apache.catalina.connector.Request;
+import org.apache.catalina.connector.Response;
+import org.apache.log4j.MDC;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.testng.annotations.Test;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import javax.servlet.ServletException;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertNotNull;
+
+/**
+ * Test the scenarios for adding the correlation id from the valve to be used in correlationLogs
+ */
+public class RequestCorrelationIdValveTest {
+
+    private static final String HEADER_TO_ID_MAPPING_CONFIG = "{'activityid':'Correlation-ID'}";
+    private static final String QUERYPARAM_TO_ID_MAPPING_CONFIG = "{'RelayState':'Correlation-ID'}";
+    private static final String TEST_HEADER_RECEIVED = "activityid";
+    private static final String TEST_PARAM_RECEIVED = "RelayState";
+    private static final String TEST_HEADER_RECEIVED_VALUE = "activityIdValue";
+    private static final String TEST_PARAM_VALUE = "relayStateValue";
+    private static final String CORRELATION_ID_MDC = "Correlation-ID";
+    private static final Map<String, String> headerReceivedMap = new HashMap<>();
+    private static final Map<String, String> queryParamReceivedMap = new HashMap<>();
+
+    /**
+     * This case checks if the MDC is set when an correlationId is received through a header
+     *
+     * @throws LifecycleException
+     * @throws IOException
+     * @throws ServletException
+     */
+    @Test(groups = {"org.wso2.carbon.tomcat.ext.valves"})
+    public void correlationCase1() throws LifecycleException, IOException, ServletException {
+
+        Valve nextValve = mock(Valve.class);
+
+        doAnswer(new Answer() {
+            @Override
+            public Object answer(InvocationOnMock invocationOnMock) throws Throwable {
+
+                assertNotNull(MDC.get(CORRELATION_ID_MDC));
+                return null;
+            }
+        }).when(nextValve).invoke(any(Request.class), any(Response.class));
+        createValveForTesting(nextValve).invoke(createMockRequestWithHeader(), mock(Response.class));
+    }
+
+    /**
+     * This case checks if the MDC is set when the correlation id is received through query params
+     *
+     * @throws LifecycleException
+     * @throws IOException
+     * @throws ServletException
+     */
+    @Test(groups = {"org.wso2.carbon.tomcat.ext.valves"})
+    public void correlationCase2() throws LifecycleException, IOException, ServletException {
+
+        Valve nextValve = mock(Valve.class);
+
+        doAnswer(new Answer() {
+            @Override
+            public Object answer(InvocationOnMock invocationOnMock) throws Throwable {
+
+                assertNotNull(MDC.get(CORRELATION_ID_MDC));
+                return null;
+            }
+        }).when(nextValve).invoke(any(Request.class), any(Response.class));
+        createValveForTesting(nextValve).invoke(createMockRequestWithParams(), mock(Response.class));
+    }
+
+    /**
+     * This case checks whether a randomly generated MDC is set when no correlation id is received.
+     *
+     * @throws LifecycleException
+     * @throws IOException
+     * @throws ServletException
+     */
+    @Test(groups = {"org.wso2.carbon.tomcat.ext.valves"})
+    public void correlationCase3() throws LifecycleException, IOException, ServletException {
+
+        Valve nextValve = mock(Valve.class);
+
+        doAnswer(new Answer() {
+            @Override
+            public Object answer(InvocationOnMock invocationOnMock) throws Throwable {
+
+                assertNotNull(MDC.get(CORRELATION_ID_MDC));
+                return null;
+            }
+        }).when(nextValve).invoke(any(Request.class), any(Response.class));
+        createValveForTesting(nextValve).invoke(mock(Request.class), mock(Response.class));
+    }
+
+    private RequestCorrelationIdValve createValveForTesting(Valve nextValve) throws LifecycleException {
+
+        RequestCorrelationIdValve testingValve = new RequestCorrelationIdValve();
+        Container container = mock(Container.class);
+        testingValve.setNext(nextValve);
+
+        testingValve.setContainer(container);
+        testingValve.setHeaderToCorrelationIdMapping(HEADER_TO_ID_MAPPING_CONFIG);
+        testingValve.setQueryToCorrelationIdMapping(QUERYPARAM_TO_ID_MAPPING_CONFIG);
+        testingValve.init();
+        return testingValve;
+    }
+
+    private Request createMockRequestWithHeader() {
+
+        headerReceivedMap.put(TEST_HEADER_RECEIVED, TEST_HEADER_RECEIVED_VALUE);
+        Request testServletRequest = mock(Request.class);
+        when(testServletRequest.getHeaderNames()).thenReturn(Collections.enumeration(headerReceivedMap.keySet()));
+        when(testServletRequest.getHeader(TEST_HEADER_RECEIVED)).thenReturn(headerReceivedMap.get(TEST_HEADER_RECEIVED));
+        return testServletRequest;
+    }
+
+    private Request createMockRequestWithParams() {
+
+        queryParamReceivedMap.put(TEST_PARAM_RECEIVED, TEST_PARAM_VALUE);
+        Request testServletRequest = mock(Request.class);
+        when(testServletRequest.getParameterNames()).thenReturn(Collections.enumeration(queryParamReceivedMap.keySet()));
+        when(testServletRequest.getParameter(TEST_PARAM_RECEIVED)).thenReturn(queryParamReceivedMap.get(TEST_PARAM_RECEIVED));
+        return testServletRequest;
+    }
+}

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/dto/CorrelationLogDTO.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/dto/CorrelationLogDTO.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.user.core.dto;
+
+import java.util.Hashtable;
+
+public class CorrelationLogDTO {
+
+    private long startTime;
+    private long delta;
+    private Hashtable<?, ?> environment;
+    private String methodName;
+    private int argsLength;
+    private String args;
+
+    public long getStartTime() {
+
+        return startTime;
+    }
+
+    public void setStartTime(long startTime) {
+
+        this.startTime = startTime;
+    }
+
+    public long getDelta() {
+
+        return delta;
+    }
+
+    public void setDelta(long delta) {
+
+        this.delta = delta;
+    }
+
+    public Hashtable<?, ?> getEnvironment() {
+
+        return environment;
+    }
+
+    public void setEnvironment(Hashtable<?, ?> environment) {
+
+        this.environment = environment;
+    }
+
+    public String getMethodName() {
+
+        return methodName;
+    }
+
+    public void setMethodName(String methodName) {
+
+        this.methodName = methodName;
+    }
+
+    public int getArgsLength() {
+
+        return argsLength;
+    }
+
+    public void setArgsLength(int argsLength) {
+
+        this.argsLength = argsLength;
+    }
+
+    public String getArgs() {
+
+        return args;
+    }
+
+    public void setArgs(String args) {
+
+        this.args = args;
+    }
+}

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/dto/CorrelationLogDTO.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/dto/CorrelationLogDTO.java
@@ -20,6 +20,9 @@ package org.wso2.carbon.user.core.dto;
 
 import java.util.Hashtable;
 
+/**
+ * Dto used when during creating timing logs for ldap calls
+ */
 public class CorrelationLogDTO {
 
     private long startTime;

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/LDAPConnectionContext.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/LDAPConnectionContext.java
@@ -213,6 +213,7 @@ public class LDAPConnectionContext {
 
                 try {
                     context = getDirContext(environment);
+
                 } catch (Exception e1) {
                     log.error("Error obtaining connection for the second time" + e.getMessage(), e);
                     throw new UserStoreException("Error obtaining connection. " + e.getMessage(), e);
@@ -226,6 +227,7 @@ public class LDAPConnectionContext {
                 SRVRecord firstRecord = dcMap.get(firstKey);
                 //compose the connection URL
                 environment.put(Context.PROVIDER_URL, getLDAPURLFromSRVRecord(firstRecord));
+
                 context = getDirContext(environment);
 
             } catch (NamingException e) {
@@ -464,7 +466,7 @@ public class LDAPConnectionContext {
      * Creates the proxy for directory context and wrap the context.
      * Calculate the time taken for creation
      *
-     * @param environment Contains all the environment details
+     * @param environment Used to get provider url and principal
      * @return The wrapped context
      * @throws NamingException
      */
@@ -499,7 +501,7 @@ public class LDAPConnectionContext {
      * Creates the proxy for LDAP context and wrap the context.
      * Calculate the time taken for creation
      *
-     * @param environment        Contains all the environment details
+     * @param environment Used to get provider url and principal
      * @param connectionControls The wrapped context
      * @return ldap connection context
      * @throws NamingException
@@ -602,8 +604,8 @@ public class LDAPConnectionContext {
      */
     private void logDetails(CorrelationLogDTO correlationLogDTO) {
 
-        String providerUrl = " ";
-        String principal = " ";
+        String providerUrl = "No provider url found";
+        String principal = "No principal found";
 
         if (correlationLogDTO.getEnvironment().containsKey("java.naming.provider.url")) {
             providerUrl = (String) environment.get("java.naming.provider.url");
@@ -614,32 +616,32 @@ public class LDAPConnectionContext {
         }
 
         if (correlationLog.isDebugEnabled()) {
-            Map<String, String> map = new LinkedHashMap<>();
-            map.put(CORRELATION_LOG_TIME_TAKEN_KEY, Long.toString(correlationLogDTO.getDelta()) +
+            Map<String, String> logPropertiesMap = new LinkedHashMap<>();
+            logPropertiesMap.put(CORRELATION_LOG_TIME_TAKEN_KEY, Long.toString(correlationLogDTO.getDelta()) +
                     CORRELATION_LOG_TIME_TAKEN_UNIT);
-            map.put(CORRELATION_LOG_CALL_TYPE_KEY, CORRELATION_LOG_CALL_TYPE_VALUE);
-            map.put(CORRELATION_LOG_START_TIME_KEY, Long.toString(correlationLogDTO.getStartTime()));
-            map.put(CORRELATION_LOG_METHOD_NAME_KEY, correlationLogDTO.getMethodName());
-            map.put(CORRELATION_LOG_PROVIDER_URL_KEY, providerUrl);
-            map.put(CORRELATION_LOG_PRINCIPAL_KEY, principal);
-            map.put(CORRELATION_LOG_ARGS_LENGTH_KEY, Integer.toString(correlationLogDTO.getArgsLength()));
-            map.put(CORRELATION_LOG_ARGS_KEY, correlationLogDTO.getArgs());
-            correlationLog.debug(createLogFormat(map));
+            logPropertiesMap.put(CORRELATION_LOG_CALL_TYPE_KEY, CORRELATION_LOG_CALL_TYPE_VALUE);
+            logPropertiesMap.put(CORRELATION_LOG_START_TIME_KEY, Long.toString(correlationLogDTO.getStartTime()));
+            logPropertiesMap.put(CORRELATION_LOG_METHOD_NAME_KEY, correlationLogDTO.getMethodName());
+            logPropertiesMap.put(CORRELATION_LOG_PROVIDER_URL_KEY, providerUrl);
+            logPropertiesMap.put(CORRELATION_LOG_PRINCIPAL_KEY, principal);
+            logPropertiesMap.put(CORRELATION_LOG_ARGS_LENGTH_KEY, Integer.toString(correlationLogDTO.getArgsLength()));
+            logPropertiesMap.put(CORRELATION_LOG_ARGS_KEY, correlationLogDTO.getArgs());
+            correlationLog.debug(createLogFormat(logPropertiesMap));
         }
     }
 
     /**
      * Creates the log line that should be printed
      *
-     * @param map Contains the type and value that should be printed in the log
+     * @param logPropertiesMap Contains the type and value that should be printed in the log
      * @return The log line
      */
-    private String createLogFormat(Map<String, String> map) {
+    private String createLogFormat(Map<String, String> logPropertiesMap) {
 
         StringBuilder sb = new StringBuilder();
-        Object[] keys = map.keySet().toArray();
+        Object[] keys = logPropertiesMap.keySet().toArray();
         for (int i = 0; i < keys.length; i++) {
-            sb.append(map.get(keys[i]));
+            sb.append(logPropertiesMap.get(keys[i]));
             if (i < keys.length - 1) {
                 sb.append(CORRELATION_LOG_SEPARATOR);
             }

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/LDAPConnectionContext.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/LDAPConnectionContext.java
@@ -1,13 +1,13 @@
 /*
  * Copyright (c) 2005-2010, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
- * 
+ *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -22,6 +22,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.CarbonConstants;
 import org.wso2.carbon.user.api.RealmConfiguration;
+import org.wso2.carbon.user.core.dto.CorrelationLogDTO;
 import org.wso2.carbon.utils.Secret;
 import org.wso2.carbon.user.core.UserCoreConstants;
 import org.wso2.carbon.user.core.UserStoreException;
@@ -32,18 +33,17 @@ import javax.naming.AuthenticationException;
 import javax.naming.Context;
 import javax.naming.NamingEnumeration;
 import javax.naming.NamingException;
-import javax.naming.TimeLimitExceededException;
 import javax.naming.directory.Attribute;
 import javax.naming.directory.Attributes;
 import javax.naming.directory.DirContext;
 import javax.naming.directory.InitialDirContext;
+import javax.naming.ldap.Control;
 import javax.naming.ldap.InitialLdapContext;
 import javax.naming.ldap.LdapContext;
-import java.util.Arrays;
-import java.util.Hashtable;
-import java.util.Map;
-import java.util.SortedMap;
-import java.util.TreeMap;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.*;
 
 public class LDAPConnectionContext {
 
@@ -62,6 +62,33 @@ public class LDAPConnectionContext {
 
     private static final String READ_TIME_OUT = "ReadTimeout";
 
+    private static final Log correlationLog = LogFactory.getLog("CORRELATION_LOG");
+
+    private static String initialContextFactoryClass = "com.sun.jndi.dns.DnsContextFactory";
+
+    private static final String CORRELATION_LOG_TIME_TAKEN_KEY = "delta";
+    private static final String CORRELATION_LOG_TIME_TAKEN_UNIT = " ms";
+    private static final String CORRELATION_LOG_CALL_TYPE_KEY = "callType";
+    private static final String CORRELATION_LOG_CALL_TYPE_VALUE = "ldap";
+    private static final String CORRELATION_LOG_START_TIME_KEY = "startTime";
+    private static final String CORRELATION_LOG_METHOD_NAME_KEY = "methodName";
+    private static final String CORRELATION_LOG_INITIALIZATION_METHOD_NAME = "initialization";
+    private static final String CORRELATION_LOG_INITIALIZATION_ARGS = "empty";
+    private static final int CORRELATION_LOG_INITIALIZATION_ARGS_LENGTH = 0;
+    private static final String CORRELATION_LOG_ARGS_KEY = "query";
+    private static final String CORRELATION_LOG_ARGS_LENGTH_KEY = "query";
+    private static final String CORRELATION_LOG_PROVIDER_URL_KEY = "providerUrl";
+    private static final String CORRELATION_LOG_PRINCIPAL_KEY = "principal";
+    private static final String CORRELATION_LOG_SEPARATOR = " | ";
+    private static final String CORRELATION_LOG_SYSTEM_PROPERTY = "enableCorrelationLogs";
+
+    static {
+        String initialContextFactoryClassSystemProperty = System.getProperty(Context.INITIAL_CONTEXT_FACTORY);
+        if (initialContextFactoryClassSystemProperty != null && initialContextFactoryClassSystemProperty.length() > 0) {
+            initialContextFactoryClass = initialContextFactoryClassSystemProperty;
+        }
+    }
+
     @SuppressWarnings({"rawtypes", "unchecked"})
     public LDAPConnectionContext(RealmConfiguration realmConfig) throws UserStoreException {
 
@@ -73,7 +100,7 @@ public class LDAPConnectionContext {
                 throw new UserStoreException("DNS is enabled, but DNS domain name not provided.");
             } else {
                 environmentForDNS = new Hashtable();
-                environmentForDNS.put(Context.INITIAL_CONTEXT_FACTORY, "com.sun.jndi.dns.DnsContextFactory");
+                environmentForDNS.put(Context.INITIAL_CONTEXT_FACTORY, initialContextFactoryClass);
                 environmentForDNS.put("java.naming.provider.url", DNSUrl);
                 populateDCMap();
             }
@@ -167,8 +194,8 @@ public class LDAPConnectionContext {
             environment.put("com.sun.jndi.ldap.connect.timeout", "5000");
         }
 
-        if(StringUtils.isNotEmpty(readTimeout)){
-            environment.put("com.sun.jndi.ldap.read.timeout",readTimeout);
+        if (StringUtils.isNotEmpty(readTimeout)) {
+            environment.put("com.sun.jndi.ldap.read.timeout", readTimeout);
         }
     }
 
@@ -178,13 +205,14 @@ public class LDAPConnectionContext {
         //if dcMap is not populated, it is not DNS case
         if (dcMap == null) {
             try {
-                context = new InitialLdapContext(environment, null);
+                context = getDirContext(environment);
+
             } catch (NamingException e) {
                 log.error("Error obtaining connection. " + e.getMessage(), e);
                 log.error("Trying again to get connection.");
 
                 try {
-                    context = new InitialLdapContext(environment, null);
+                    context = getDirContext(environment);
                 } catch (Exception e1) {
                     log.error("Error obtaining connection for the second time" + e.getMessage(), e);
                     throw new UserStoreException("Error obtaining connection. " + e.getMessage(), e);
@@ -198,7 +226,7 @@ public class LDAPConnectionContext {
                 SRVRecord firstRecord = dcMap.get(firstKey);
                 //compose the connection URL
                 environment.put(Context.PROVIDER_URL, getLDAPURLFromSRVRecord(firstRecord));
-                context = new InitialLdapContext(environment, null);
+                context = getDirContext(environment);
 
             } catch (NamingException e) {
                 log.error("Error obtaining connection to first Domain Controller." + e.getMessage(), e);
@@ -208,7 +236,7 @@ public class LDAPConnectionContext {
                     try {
                         SRVRecord srv = dcMap.get(integer);
                         environment.put(Context.PROVIDER_URL, getLDAPURLFromSRVRecord(srv));
-                        context = new InitialLdapContext(environment, null);
+                        context = getDirContext(environment);
                         break;
                     } catch (NamingException e1) {
                         if (integer == (dcMap.lastKey())) {
@@ -220,7 +248,7 @@ public class LDAPConnectionContext {
                 }
             }
         }
-        return (context);
+        return context;
     }
 
     @SuppressWarnings("unchecked")
@@ -258,6 +286,7 @@ public class LDAPConnectionContext {
     }
 
     private void populateDCMap() throws UserStoreException {
+
         try {
             //get the directory context for DNS
             DirContext dnsContext = new InitialDirContext(environmentForDNS);
@@ -319,6 +348,7 @@ public class LDAPConnectionContext {
     }
 
     private String getLDAPURLFromSRVRecord(SRVRecord srvRecord) {
+
         String ldapURL = null;
         if (readOnly) {
             ldapURL = "ldap://" + srvRecord.getHostIP() + ":" + srvRecord.getPort();
@@ -352,9 +382,9 @@ public class LDAPConnectionContext {
     /**
      * Returns the LDAPContext for the given credentials
      *
-     * @param userDN user DN
+     * @param userDN   user DN
      * @param password user password
-     * @return returns the LdapContext instance if credentials are valid
+     * @return returns The LdapContext instance if credentials are valid
      * @throws UserStoreException
      * @throws NamingException
      */
@@ -394,7 +424,7 @@ public class LDAPConnectionContext {
         //if dcMap is not populated, it is not DNS case
         if (dcMap == null) {
             //replace environment properties with these credentials
-            context = new InitialLdapContext(tempEnv, null);
+            context = getLdapContext(tempEnv, null);
         } else if (dcMap != null && dcMap.size() != 0) {
             try {
                 //first try the first entry in dcMap, if it fails, try iteratively
@@ -402,7 +432,7 @@ public class LDAPConnectionContext {
                 SRVRecord firstRecord = dcMap.get(firstKey);
                 //compose the connection URL
                 tempEnv.put(Context.PROVIDER_URL, getLDAPURLFromSRVRecord(firstRecord));
-                context = new InitialLdapContext(tempEnv, null);
+                context = getLdapContext(tempEnv, null);
 
             } catch (AuthenticationException e) {
                 throw e;
@@ -414,7 +444,7 @@ public class LDAPConnectionContext {
                     try {
                         SRVRecord srv = dcMap.get(integer);
                         tempEnv.put(Context.PROVIDER_URL, getLDAPURLFromSRVRecord(srv));
-                        context = new InitialLdapContext(environment, null);
+                        context = getLdapContext(environment, null);
                         break;
                     } catch (AuthenticationException e1) {
                         throw e1;
@@ -428,5 +458,192 @@ public class LDAPConnectionContext {
             }
         }
         return context;
+    }
+
+    /**
+     * Creates the proxy for directory context and wrap the context.
+     * Calculate the time taken for creation
+     *
+     * @param environment Contains all the environment details
+     * @return The wrapped context
+     * @throws NamingException
+     */
+    private DirContext getDirContext(Hashtable<?, ?> environment) throws NamingException {
+
+        if (Boolean.parseBoolean(System.getProperty(CORRELATION_LOG_SYSTEM_PROPERTY))) {
+            final Class[] proxyInterfaces = new Class[]{DirContext.class};
+            long start = System.currentTimeMillis();
+
+            DirContext context = new InitialDirContext(environment);
+
+            Object proxy = Proxy.newProxyInstance(LDAPConnectionContext.class.getClassLoader(), proxyInterfaces,
+                    new LdapContextInvocationHandler(context));
+
+            long delta = System.currentTimeMillis() - start;
+
+            CorrelationLogDTO correlationLogDTO = new CorrelationLogDTO();
+            correlationLogDTO.setStartTime(start);
+            correlationLogDTO.setDelta(delta);
+            correlationLogDTO.setEnvironment(environment);
+            correlationLogDTO.setMethodName(CORRELATION_LOG_INITIALIZATION_METHOD_NAME);
+            correlationLogDTO.setArgsLength(CORRELATION_LOG_INITIALIZATION_ARGS_LENGTH);
+            correlationLogDTO.setArgs(CORRELATION_LOG_INITIALIZATION_ARGS);
+            logDetails(correlationLogDTO);
+            return (DirContext) proxy;
+        } else {
+            return new InitialDirContext(environment);
+        }
+    }
+
+    /**
+     * Creates the proxy for LDAP context and wrap the context.
+     * Calculate the time taken for creation
+     *
+     * @param environment        Contains all the environment details
+     * @param connectionControls The wrapped context
+     * @return ldap connection context
+     * @throws NamingException
+     */
+    private LdapContext getLdapContext(Hashtable<?, ?> environment, Control[] connectionControls)
+            throws NamingException {
+
+        if (Boolean.parseBoolean(System.getProperty(CORRELATION_LOG_SYSTEM_PROPERTY))) {
+            final Class[] proxyInterfaces = new Class[]{LdapContext.class};
+            long start = System.currentTimeMillis();
+
+            LdapContext context = new InitialLdapContext(environment, connectionControls);
+
+            Object proxy = Proxy.newProxyInstance(LDAPConnectionContext.class.getClassLoader(), proxyInterfaces,
+                    new LdapContextInvocationHandler(context));
+
+            long delta = System.currentTimeMillis() - start;
+
+            CorrelationLogDTO correlationLogDTO = new CorrelationLogDTO();
+            correlationLogDTO.setStartTime(start);
+            correlationLogDTO.setDelta(delta);
+            correlationLogDTO.setEnvironment(environment);
+            correlationLogDTO.setMethodName(CORRELATION_LOG_INITIALIZATION_METHOD_NAME);
+            correlationLogDTO.setArgsLength(CORRELATION_LOG_INITIALIZATION_ARGS_LENGTH);
+            correlationLogDTO.setArgs(CORRELATION_LOG_INITIALIZATION_ARGS);
+            logDetails(correlationLogDTO);
+            return (LdapContext) proxy;
+        } else {
+            return new InitialLdapContext(environment, connectionControls);
+        }
+    }
+
+    /**
+     * Proxy Class that is used to calculate and log the time taken for queries
+     */
+    private class LdapContextInvocationHandler implements InvocationHandler {
+
+        private Object previousContext;
+
+        public LdapContextInvocationHandler(Object previousContext) {
+
+            this.previousContext = previousContext;
+        }
+
+        @Override
+        public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+
+            long start = System.currentTimeMillis();
+            Object result = method.invoke(this.previousContext, args);
+            long delta = System.currentTimeMillis() - start;
+            String methodName = method.getName();
+            int argsLength = 0;
+
+            if (args != null) {
+                argsLength = args.length;
+            }
+
+            if (!StringUtils.equalsIgnoreCase("close", methodName)) {
+                CorrelationLogDTO correlationLogDTO = new CorrelationLogDTO();
+                correlationLogDTO.setStartTime(start);
+                correlationLogDTO.setDelta(delta);
+                correlationLogDTO.setEnvironment(((DirContext) this.previousContext).getEnvironment());
+                correlationLogDTO.setMethodName(methodName);
+                correlationLogDTO.setArgsLength(argsLength);
+                correlationLogDTO.setArgs(stringify(args));
+                logDetails(correlationLogDTO);
+            }
+            return result;
+        }
+
+        /**
+         * Creates a argument string by appending the values in the array
+         *
+         * @param arr Arguments
+         * @return Argument string
+         */
+        private String stringify(Object[] arr) {
+
+            StringBuilder sb = new StringBuilder();
+            if (arr == null) {
+                sb.append("null");
+            } else {
+                sb.append(" ");
+                for (int i = 0; i < arr.length; i++) {
+                    Object o = arr[i];
+                    sb.append(o.toString());
+                    if (i < arr.length - 1) {
+                        sb.append(",");
+                    }
+                }
+            }
+            return sb.toString();
+        }
+    }
+
+    /**
+     * Logs the details from the LDAP query
+     *
+     * @param correlationLogDTO Contains all details that should be to logged
+     */
+    private void logDetails(CorrelationLogDTO correlationLogDTO) {
+
+        String providerUrl = " ";
+        String principal = " ";
+
+        if (correlationLogDTO.getEnvironment().containsKey("java.naming.provider.url")) {
+            providerUrl = (String) environment.get("java.naming.provider.url");
+        }
+
+        if (environment.containsKey("java.naming.security.principal")) {
+            principal = (String) environment.get("java.naming.security.principal");
+        }
+
+        if (correlationLog.isDebugEnabled()) {
+            Map<String, String> map = new LinkedHashMap<>();
+            map.put(CORRELATION_LOG_TIME_TAKEN_KEY, Long.toString(correlationLogDTO.getDelta()) +
+                    CORRELATION_LOG_TIME_TAKEN_UNIT);
+            map.put(CORRELATION_LOG_CALL_TYPE_KEY, CORRELATION_LOG_CALL_TYPE_VALUE);
+            map.put(CORRELATION_LOG_START_TIME_KEY, Long.toString(correlationLogDTO.getStartTime()));
+            map.put(CORRELATION_LOG_METHOD_NAME_KEY, correlationLogDTO.getMethodName());
+            map.put(CORRELATION_LOG_PROVIDER_URL_KEY, providerUrl);
+            map.put(CORRELATION_LOG_PRINCIPAL_KEY, principal);
+            map.put(CORRELATION_LOG_ARGS_LENGTH_KEY, Integer.toString(correlationLogDTO.getArgsLength()));
+            map.put(CORRELATION_LOG_ARGS_KEY, correlationLogDTO.getArgs());
+            correlationLog.debug(createLogFormat(map));
+        }
+    }
+
+    /**
+     * Creates the log line that should be printed
+     *
+     * @param map Contains the type and value that should be printed in the log
+     * @return The log line
+     */
+    private String createLogFormat(Map<String, String> map) {
+
+        StringBuilder sb = new StringBuilder();
+        Object[] keys = map.keySet().toArray();
+        for (int i = 0; i < keys.length; i++) {
+            sb.append(map.get(keys[i]));
+            if (i < keys.length - 1) {
+                sb.append(CORRELATION_LOG_SEPARATOR);
+            }
+        }
+        return sb.toString();
     }
 }

--- a/distribution/kernel/carbon-home/bin/wso2server.sh
+++ b/distribution/kernel/carbon-home/bin/wso2server.sh
@@ -313,6 +313,7 @@ do
     -Djava.net.preferIPv4Stack=true \
     -Dcom.ibm.cacheLocalHost=true \
     -DworkerNode=false \
+    -DenableCorrelationLogs=false \
     -Dhttpclient.hostnameVerifier="DefaultAndLocalhost" \
     org.wso2.carbon.bootstrap.Bootstrap $*
     status=$?

--- a/distribution/kernel/carbon-home/repository/conf/log4j.properties
+++ b/distribution/kernel/carbon-home/repository/conf/log4j.properties
@@ -171,6 +171,14 @@ log4j.appender.ATOMIKOS.Append = true
 log4j.appender.ATOMIKOS.layout = org.apache.log4j.PatternLayout
 log4j.appender.ATOMIKOS.layout.ConversionPattern=%p %t %c - %m%n
 
+# Appender config to put correlation Log.
+log4j.logger.CORRELATION_LOG=DEBUG, CORRELATION_LOG
+log4j.additivity.CORRELATION_LOG=false
+log4j.appender.CORRELATION_LOG = org.apache.log4j.RollingFileAppender
+log4j.appender.CORRELATION_LOG.File = ${carbon.home}/repository/logs/${instance.log}/correlation${instance.log}.log
+log4j.appender.CORRELATION_LOG.Append = false
+log4j.appender.CORRELATION_LOG.layout = org.apache.log4j.PatternLayout
+log4j.appender.CORRELATION_LOG.layout.ConversionPattern=%d{dd MMM yyyy HH:mm:ss,SSS} | %X{Correlation-ID} | %t | %m%n
 # This file is used to override the default logger settings, and is used to remove unwanted logs from Shindig appearing on the console.
 
 # Specification of Handler used by Console Logger

--- a/distribution/kernel/carbon-home/repository/conf/tomcat/catalina-server.xml
+++ b/distribution/kernel/carbon-home/repository/conf/tomcat/catalina-server.xml
@@ -86,6 +86,8 @@
 
             <Host name="localhost" unpackWARs="true" deployOnStartup="false" autoDeploy="false"
                   appBase="${carbon.home}/repository/deployment/server/webapps/">
+                <Valve className="org.wso2.carbon.tomcat.ext.valves.RequestCorrelationIdValve"
+                       headerToCorrelationIdMapping="{'activityid':'Correlation-ID'}" queryToCorrelationIdMapping="{'RelayState':'Correlation-ID'}"/>
                 <Valve className="org.wso2.carbon.tomcat.ext.valves.CarbonContextCreatorValve"/>
                 <Valve className="org.apache.catalina.valves.AccessLogValve" directory="${carbon.home}/repository/logs"
                        prefix="http_access_" suffix=".log"


### PR DESCRIPTION
## Purpose and Goals
 To improve the observability of wso2 products this adds logs to be printed when JDBC and LDAP calls are made. 

## Details
This can be enabled by adding enableCorrelationLogs=true in system properties. By default this value is set to false.

Logs are printed in the following format in correlation.log

JDBC
timestamp | correlationID | threadID | duration | callType | startTime | methodName | query | connectionUrl

LDAP
timestamp | correlationID | threadID | duration | callType | startTime | methodName | providerUrl | principal | argsLengeth | args
