### PR TITLE
Add carbon.xml configurations required for carbon-crypto-provider-hsm component

### DIFF
--- a/distribution/kernel/carbon-home/repository/conf/carbon.xml
+++ b/distribution/kernel/carbon-home/repository/conf/carbon.xml
@@ -373,6 +373,34 @@
             <KeyResolver className="org.wso2.carbon.crypto.defaultProvider.resolver.ContextIndependentKeyResolver" priority="-1"/>
         </KeyResolvers>
 
+        <!--
+            Uncomment the following configuration to use hardware security module for cryptographic operations.
+            Provide configurations as detailed in each tag.
+        -->
+
+        <!--
+            <HSMBasedCryptoProviderConfig>
+                <HSMConfiguration>
+                    <PKCS11Module>#AbsolutePathToHSMModule</PKCS11Module>
+                    <SlotConfiguration>
+                        <Slot id="#SlotID" pin="#UserPIN"/>
+                    </SlotConfiguration>
+                </HSMConfiguration>
+
+                <InternalProvider>
+                    <InternalProviderSlotID>#SlotIDOfInternalProvider</InternalProviderSlotID>
+                    <KeyAlias>#KeyAlias</KeyAlias>
+                </InternalProvider>
+
+                <ExternalProvider>
+                    <ExternalProviderSlotID>#SlotIDOfExternalProvider</ExternalProviderSlotID>
+                </ExternalProvider>
+
+                <HSMStore>
+                    <Enabled>false</Enabled>
+                </HSMStore>
+            </HSMBasedCryptoProviderConfig>
+        -->
     </CryptoService>
 
     <!-- 


### PR DESCRIPTION
## Purpose
> This PR contains the required carbon.xml configurations to carbon-crypto-provider-hsm component :- https://github.com/wso2-extensions/carbon-crypto-provider-hsm