### PR TITLE
Improvement of tenant deletion

### DIFF
--- a/core/javax.cache/src/main/java/org/wso2/carbon/caching/impl/CacheManagerFactoryImpl.java
+++ b/core/javax.cache/src/main/java/org/wso2/carbon/caching/impl/CacheManagerFactoryImpl.java
@@ -115,6 +115,7 @@ public class CacheManagerFactoryImpl implements CacheManagerFactory {
                     cacheManager.shutdown();
                 }
                 cacheManagers.clear();
+                globalCacheManagerMap.remove(tenantDomain);
             }
         }
         if (cacheEvictionScheduler != null) {

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/tenant/JDBCTenantManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/tenant/JDBCTenantManager.java
@@ -740,7 +740,7 @@ public class JDBCTenantManager implements TenantManager {
 
             Caching.getCacheManagerFactory().close();
         } catch (Exception e) {
-            log.error("Unable to delete cache for tenant :"+tenantDomain);
+            log.error("Unable to delete cache for tenant : " + tenantDomain,e);
         } finally {
             PrivilegedCarbonContext.endTenantFlow();
         }

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/tenant/JDBCTenantManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/tenant/JDBCTenantManager.java
@@ -636,7 +636,7 @@ public class JDBCTenantManager implements TenantManager {
             tenantDomainIdMap.remove(tenantDomain);
         }
         clearTenantCache(tenantId);
-        clearCachemanager(tenantDomain, tenantId);
+        clearCacheManager(tenantDomain, tenantId);
 
         if (removeFromPersistentStorage) {
             Connection dbConnection = null;
@@ -735,7 +735,7 @@ public class JDBCTenantManager implements TenantManager {
      * @param tenantDomain tenant domain
      * @param tenantId  tenant id
      */
-    private void clearCachemanager(String tenantDomain, int tenantId) {
+    private void clearCacheManager(String tenantDomain, int tenantId) {
         try {
             PrivilegedCarbonContext.startTenantFlow();
             PrivilegedCarbonContext carbonContext = PrivilegedCarbonContext.getThreadLocalCarbonContext();

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/tenant/JDBCTenantManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/tenant/JDBCTenantManager.java
@@ -731,19 +731,16 @@ public class JDBCTenantManager implements TenantManager {
     }
 
     private void clearCachemanager(String tenantDomain, int tenantId) {
-
         try {
             PrivilegedCarbonContext.startTenantFlow();
             PrivilegedCarbonContext carbonContext = PrivilegedCarbonContext.getThreadLocalCarbonContext();
             carbonContext.setTenantDomain(tenantDomain);
             carbonContext.setTenantId(tenantId);
-
             Caching.getCacheManagerFactory().close();
         } catch (Exception e) {
             log.error("Unable to delete cache for tenant : " + tenantDomain,e);
         } finally {
             PrivilegedCarbonContext.endTenantFlow();
         }
-
     }
 }

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/tenant/JDBCTenantManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/tenant/JDBCTenantManager.java
@@ -636,7 +636,7 @@ public class JDBCTenantManager implements TenantManager {
             tenantDomainIdMap.remove(tenantDomain);
         }
         clearTenantCache(tenantId);
-        deleteCachemanager(tenantDomain, tenantId);
+        clearCachemanager(tenantDomain, tenantId);
 
         if (removeFromPersistentStorage) {
             Connection dbConnection = null;
@@ -730,7 +730,7 @@ public class JDBCTenantManager implements TenantManager {
         tenantCacheManager.clearCacheEntry(new TenantIdKey(tenantId));
     }
 
-    private void deleteCachemanager(String tenantDomain, int tenantId) {
+    private void clearCachemanager(String tenantDomain, int tenantId) {
 
         try {
             PrivilegedCarbonContext.startTenantFlow();

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/tenant/JDBCTenantManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/tenant/JDBCTenantManager.java
@@ -730,6 +730,11 @@ public class JDBCTenantManager implements TenantManager {
         tenantCacheManager.clearCacheEntry(new TenantIdKey(tenantId));
     }
 
+    /**
+     * Clear all caches and shutdown all cache managers for a particular tenant.
+     * @param tenantDomain tenant domain
+     * @param tenantId  tenant id
+     */
     private void clearCachemanager(String tenantDomain, int tenantId) {
         try {
             PrivilegedCarbonContext.startTenantFlow();

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/tenant/JDBCTenantManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/tenant/JDBCTenantManager.java
@@ -738,7 +738,7 @@ public class JDBCTenantManager implements TenantManager {
             carbonContext.setTenantId(tenantId);
             Caching.getCacheManagerFactory().close();
         } catch (Exception e) {
-            log.error("Unable to delete cache for tenant : " + tenantDomain,e);
+            log.error("Unable to delete cache for tenant : " + tenantDomain, e);
         } finally {
             PrivilegedCarbonContext.endTenantFlow();
         }


### PR DESCRIPTION
## Purpose
When we delete a tenant(with existing methods) we didn't delete the caches and the entry in globalCacheManagerMap. So when ever we try to create a new tenant with same domain name it checks with map and instead of creating new cache managers it returns existing entry value which owns by previous tenant. This cause the error mentioned in issue given below.

## Goals
Fix for the Issue :- [Security exception occurred when try to create a tenant with deleted tenant's domain name](https://github.com/wso2/carbon-kernel/issues/1878)

## Approach
While deleting a tenant delete
- clear all the caches
- shutdown all the cachemanagers
- remove the entry from globalCacheManagerMap

## Documentation
[Tenant Deletion Doc](https://docs.google.com/document/d/135FtnCyehrMKi7IL92NbKDwkdu4xZjeJOCJsst_hUTw/edit?usp=sharing)
