### PR TITLE
Add classpath of commons.lang to wrapper.conf

### DIFF
--- a/distribution/kernel/carbon-home/bin/yajsw/wrapper.conf
+++ b/distribution/kernel/carbon-home/bin/yajsw/wrapper.conf
@@ -75,6 +75,7 @@ placeHolderSoGenPropsComeHere=
 wrapper.java.command = ${java_home}\\bin\\java
 wrapper.java.classpath.1 = ${java_home}\\lib\\tools.jar
 wrapper.java.classpath.2 = ${carbon_home}\\bin\\*.jar
+wrapper.java.classpath.3 = ${carbon_home}\\lib\\commons-lang-*.jar
 wrapper.app.parameter.1 = org.wso2.carbon.bootstrap.Bootstrap
 wrapper.app.parameter.2 = RUN
 wrapper.java.additional.1 = -Xbootclasspath\/a:${carbon_home}\\lib\\xboot\\*.jar


### PR DESCRIPTION
There were some reported issues related with ClassNotFoundException related with commons-lang. For example running IS as a service does not allow to edit service provider (empty page). Running IS as stand alone by wso2service.bat works well. The reason is that wso2service.bat adds commons lang into classpath.

## Purpose
> Remove ClassNotFoundException errors when running as a service e.g. `java.lang.ClassNotFoundException: org.apache.commons.lang.StringUtils`

## Goals
> adds commons-lang into classpath

## Approach
> adds a line info wrapper.conf
