### PR TITLE
Update wrapper.conf

### DIFF
--- a/distribution/kernel/carbon-home/bin/yajsw/wrapper.conf
+++ b/distribution/kernel/carbon-home/bin/yajsw/wrapper.conf
@@ -77,7 +77,7 @@ wrapper.java.classpath.1 = ${java_home}\\lib\\tools.jar
 wrapper.java.classpath.2 = ${carbon_home}\\bin\\*.jar
 wrapper.app.parameter.1 = org.wso2.carbon.bootstrap.Bootstrap
 wrapper.app.parameter.2 = RUN
-wrapper.java.additional.1 = -Xbootclasspath\/a:${carbon_home}\\lib\\xboot\\*.jar
+wrapper.java.additional.1 = -Xbootclasspath/a:${carbon_home}\\lib\\xboot\\*.jar
 wrapper.java.additional.2 = -Xms256m
 wrapper.java.additional.3 = -Xmx1024m
 wrapper.java.additional.4 = -XX:MaxPermSize=256m


### PR DESCRIPTION
Removing backslash in -Xbootclasspath parameters allows to run WSO2 in yajsw-stable-12.13a. Somehow "\\/" is not decoded to "/" and end up in error:
`Unrecognized option: -Xbootclasspath\/a:`
