### PR TITLE
Fix a bug realtes to tenant deletion cache inconsistency.

### DIFF
--- a/core/javax.cache/src/main/java/javax/cache/CacheManagerFactory.java
+++ b/core/javax.cache/src/main/java/javax/cache/CacheManagerFactory.java
@@ -73,4 +73,12 @@ public interface CacheManagerFactory {
      * @throws javax.cache.CachingShutdownException if there is a problem shutting down a CacheManager
      */
     boolean close(ClassLoader classLoader, String name) throws CachingShutdownException;
+
+    /**
+     * Remove cache manager stored for a tenant domain. This can be used for special requirements such as tenant
+     * deletion
+     *
+     * @param tenantDomain tenant domain. Value should not be null
+     */
+    void removeCacheManagerMap(String tenantDomain);
 }

--- a/core/javax.cache/src/main/java/javax/cache/CacheManagerFactory.java
+++ b/core/javax.cache/src/main/java/javax/cache/CacheManagerFactory.java
@@ -73,12 +73,4 @@ public interface CacheManagerFactory {
      * @throws javax.cache.CachingShutdownException if there is a problem shutting down a CacheManager
      */
     boolean close(ClassLoader classLoader, String name) throws CachingShutdownException;
-
-    /**
-     * Remove cache manager stored for a tenant domain. This can be used for special requirements such as tenant
-     * deletion
-     *
-     * @param tenantDomain tenant domain. Value should not be null
-     */
-    void removeCacheManagerMap(String tenantDomain);
 }

--- a/core/javax.cache/src/main/java/org/wso2/carbon/caching/impl/CacheManagerFactoryImpl.java
+++ b/core/javax.cache/src/main/java/org/wso2/carbon/caching/impl/CacheManagerFactoryImpl.java
@@ -31,7 +31,7 @@ import javax.cache.CachingShutdownException;
  * Carbon implementation of java cache.
  *
  */
-public class CacheManagerFactoryImpl implements CacheManagerFactory {
+public class CacheManagerFactoryImpl implements CacheManagerFactory, TenantCacheManager {
 
     private static CacheCleanupTask cacheCleanupTask = new CacheCleanupTask();
     private ScheduledExecutorService cacheEvictionScheduler;

--- a/core/javax.cache/src/main/java/org/wso2/carbon/caching/impl/CacheManagerFactoryImpl.java
+++ b/core/javax.cache/src/main/java/org/wso2/carbon/caching/impl/CacheManagerFactoryImpl.java
@@ -148,12 +148,8 @@ public class CacheManagerFactoryImpl implements CacheManagerFactory {
         }
     }
 
-    /**
-     * remove cache manager map from global cache manager map
-     *
-     * @param tenantDomain - Tenant Domain	
-     */
     public void removeCacheManagerMap(String tenantDomain) {
+
         globalCacheManagerMap.remove(tenantDomain);
     }
 

--- a/core/javax.cache/src/main/java/org/wso2/carbon/caching/impl/TenantCacheManager.java
+++ b/core/javax.cache/src/main/java/org/wso2/carbon/caching/impl/TenantCacheManager.java
@@ -1,0 +1,33 @@
+/*
+ *  Copyright (c) 2005-2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ *
+ */
+package org.wso2.carbon.caching.impl;
+
+/**
+ * This is used for tenant related caching operations
+ */
+public interface TenantCacheManager {
+
+    /**
+     * Remove cache manager stored for a tenant domain. This can be used for special requirements such as tenant
+     * deletion.
+     *
+     * @param tenantDomain tenant domain. Value should not be null
+     */
+    void removeCacheManagerMap(String tenantDomain);
+}

--- a/core/javax.cache/src/main/java/org/wso2/carbon/caching/impl/TenantCacheManager.java
+++ b/core/javax.cache/src/main/java/org/wso2/carbon/caching/impl/TenantCacheManager.java
@@ -1,12 +1,12 @@
 /*
- *  Copyright (c) 2005-2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *  Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  *  WSO2 Inc. licenses this file to you under the Apache License,
  *  Version 2.0 (the "License"); you may not use this file except
  *  in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *  http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing,
  *  software distributed under the License is distributed on an
@@ -14,7 +14,6 @@
  *  KIND, either express or implied.  See the License for the
  *  specific language governing permissions and limitations
  *  under the License.
- *
  */
 package org.wso2.carbon.caching.impl;
 

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/tenant/JDBCTenantManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/tenant/JDBCTenantManager.java
@@ -22,7 +22,6 @@ import org.apache.axiom.om.OMElement;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.osgi.framework.BundleContext;
-import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.user.api.RealmConfiguration;
 import org.wso2.carbon.user.core.UserCoreConstants;
 import org.wso2.carbon.user.core.UserStoreException;
@@ -34,7 +33,6 @@ import org.wso2.carbon.utils.CarbonUtils;
 import org.wso2.carbon.utils.DBUtils;
 import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 
-import javax.sql.DataSource;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FilenameFilter;
@@ -50,6 +48,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import javax.sql.DataSource;
 
 public class JDBCTenantManager implements TenantManager {
     private static Log log = LogFactory.getLog(TenantManager.class);
@@ -633,7 +632,9 @@ public class JDBCTenantManager implements TenantManager {
         String tenantDomain = (String) tenantIdDomainMap.remove(tenantId);
         if (tenantDomain != null) {
             tenantDomainIdMap.remove(tenantDomain);
+            tenantCacheManager.removeGlobalCacheEntry(tenantDomain);
         }
+
         clearTenantCache(tenantId);
 
         if (removeFromPersistentStorage) {

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/tenant/TenantCache.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/tenant/TenantCache.java
@@ -20,11 +20,13 @@ package org.wso2.carbon.user.core.tenant;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.caching.impl.TenantCacheManager;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 
 import javax.cache.Cache;
 import javax.cache.CacheManager;
+import javax.cache.CacheManagerFactory;
 import javax.cache.Caching;
 
 public class TenantCache {
@@ -205,7 +207,13 @@ public class TenantCache {
      */
     public void removeGlobalCacheEntry(String tenantDomain) {
 
-        Caching.getCacheManagerFactory().removeCacheManagerMap(tenantDomain);
+        CacheManagerFactory cacheManagerFactory = Caching.getCacheManagerFactory();
+
+        if(cacheManagerFactory instanceof TenantCacheManager){
+            TenantCacheManager tenantCacheManager = (TenantCacheManager) cacheManagerFactory;
+            tenantCacheManager.removeCacheManagerMap(tenantDomain);
+        }
+
     }
 
 }

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/tenant/TenantCache.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/tenant/TenantCache.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2005-2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *  Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  *  WSO2 Inc. licenses this file to you under the Apache License,
  *  Version 2.0 (the "License"); you may not use this file except
@@ -8,12 +8,12 @@
  *
  *    http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
  */
 package org.wso2.carbon.user.core.tenant;
 

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/tenant/TenantCache.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/tenant/TenantCache.java
@@ -6,15 +6,14 @@
  *  in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *  http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing,
- *  software distributed under the License is distributed on an
- *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- *  KIND, either express or implied.  See the License for the
- *  specific language governing permissions and limitations
- *  under the License.
- *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 package org.wso2.carbon.user.core.tenant;
 
@@ -83,7 +82,7 @@ public class TenantCache {
                 cache.put(key, entry);
                 if (log.isDebugEnabled()) {
                     log.debug(TENANT_CACHE + " which is under " + TENANT_CACHE_MANAGER + ", added the entry : " + entry
-                        + " for the key : " + key + " successfully");
+                            + " for the key : " + key + " successfully");
                 }
             } else {
                 if (log.isDebugEnabled()) {

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/tenant/TenantCache.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/tenant/TenantCache.java
@@ -1,3 +1,21 @@
+/*
+ *  Copyright (c) 2005-2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ *
+ */
 package org.wso2.carbon.user.core.tenant;
 
 
@@ -183,5 +201,12 @@ public class TenantCache {
         }
     }
 
+    /**
+     * Remove cache manager relevant to tenant domain
+     */
+    public void removeGlobalCacheEntry(String tenantDomain) {
+
+        Caching.getCacheManagerFactory().removeCacheManagerMap(tenantDomain);
+    }
 
 }

--- a/distribution/kernel/carbon-home/repository/conf/carbon.xml
+++ b/distribution/kernel/carbon-home/repository/conf/carbon.xml
@@ -260,6 +260,15 @@
                    <Include>*,!foo.com,!bar.com</Include>
             </EagerLoading>-->
         </LoadingPolicy>
+
+        <!-- Flag to enable or disable tenant deletion. By default tenant deletion is enabled-->
+        <TenantDelete>true</TenantDelete>
+
+        <!-- Configurations related to listener invocation by tenant admin service-->
+        <ListenerInvocationPolicy>
+            <!-- Flag to enable or disable listener invocation on tenant delete. This is disabled by default-->
+            <InvokeOnDelete>false</InvokeOnDelete>
+        </ListenerInvocationPolicy>
     </Tenant>
 
     <!--


### PR DESCRIPTION
This also contains carbon.xml flag additions to control the behavior of TenantMgtAdminService.

## Purpose
Tenant deletion is a feature that we do not recommend by WSO2. But there are valid business cases to support this requirement. This PR contains a fix for cache cleaning related to tenant deletion.

Also, there is a property addition to carbon.xml which control the tenant deletion behavior of TenantMgtAdminService. 

Note that tenant deletion using TenantMgtAdminService does not clear some tenant related persisted information (ex:- Service providers , tokens). This is a future improvement we must do.

## Goals

- Fix caching 
- Improve configurations for TenantMgtAdminService 

## Approach
N/A

## User stories
N/A

## Release note
N/A

## Documentation
We need to include tenant deletion related properties that were include in this PR

`Tenant.TenantDelete` - This property must be set to true to use TenantMgtAdminService for tenant deletion
`Tenant.ListenerInvocationPolicy.InvokeOnDelete` - This property must be set to true to enable listener invocation when a tenant get deleted

Sample carbon.xml property

```
<Tenant>
    ...
    ... 
    <!-- Flag to enable or disable tenant deletion. By default tenant deletion is enabled-->
    <TenantDelete>true</TenantDelete>
        
    <!-- Configurations related to listener invocation by tenant admin service-->
    <ListenerInvocationPolicy>
           <!-- Flag to enable or disable listener invocation on tenant delete. This is disabled by default-->
           <InvokeOnDelete>false</InvokeOnDelete>
    </ListenerInvocationPolicy>
    ...
    ...
</Tenant>
```

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
N/A

## Security checks
N/A

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
N/A
 
## Learning
N/A