### PR TITLE
Add bcpkix orbit dependency

### DIFF
--- a/features/org.wso2.carbon.core.server.feature/pom.xml
+++ b/features/org.wso2.carbon.core.server.feature/pom.xml
@@ -70,6 +70,8 @@
                                 </bundleDef>
                                 <bundleDef>org.wso2.orbit.org.bouncycastle:bcprov-jdk15on:${bouncycastle.version}
                                 </bundleDef>
+                                <bundleDef>org.wso2.orbit.org.bouncycastle:bcpkix-jdk15on:${bouncycastle.version}
+                                </bundleDef>
                                 <bundleDef>org.wso2.orbit.org.apache.poi:poi-ooxml:${orbit.version.poi.ooxml}
                                 </bundleDef>
                             </bundles>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -494,8 +494,8 @@
         <hibernate.orbit.version>3.2.5.ga-wso2v1</hibernate.orbit.version>
 
         <!-- bouncycastle -->
-        <bouncycastle.version>1.52.0.wso2v1</bouncycastle.version>
-        <imp.pkg.version.bcp>[1.52.0, 1.60.0)</imp.pkg.version.bcp>
+        <bouncycastle.version>1.60.0.wso2v1</bouncycastle.version>
+        <imp.pkg.version.bcp>[1.52.0, 2.0.0)</imp.pkg.version.bcp>
 
         <!--BPS specific-->
         <saxon-bps.wso2.version.human-task>9.0.0.x-wso2v1</saxon-bps.wso2.version.human-task>
@@ -936,6 +936,11 @@
             <dependency>
                 <groupId>org.wso2.orbit.org.bouncycastle</groupId>
                 <artifactId>bcprov-jdk15on</artifactId>
+                <version>${bouncycastle.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.orbit.org.bouncycastle</groupId>
+                <artifactId>bcpkix-jdk15on</artifactId>
                 <version>${bouncycastle.version}</version>
             </dependency>
             <dependency>


### PR DESCRIPTION
## Purpose
> To add BouncyCastle bcpkix orbit dependency as a feature into plugins.

## Goals
> To remove embedded BouncyCastle bcpkix dependencies in synapse-nhttp-transport and org.wso2.carbon.tenant.keystore.mgt jars.
