### PR TITLE
Enable registry.core to attach fragment bundles

### DIFF
--- a/core/org.wso2.carbon.registry.core/pom.xml
+++ b/core/org.wso2.carbon.registry.core/pom.xml
@@ -32,6 +32,21 @@
 
     <build>
         <plugins>
+             <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-scr-plugin</artifactId>
+                <version>${maven.felix.scr.plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>generate-scr-scrdescriptor</id>
+                        <goals>
+                            <goal>scr</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
@@ -73,6 +88,8 @@
                         <Include-Resource>
                             META-INF/services/org.apache.abdera.factory.ExtensionFactory=src/main/resources/META-INF/services/org.apache.abdera.factory.ExtensionFactory
                         </Include-Resource>
+                        <!-- Enable fragment components to expose theri service description -->
+                        <Service-Component>OSGI-INF/*.xml</Service-Component>
                     </instructions>
                 </configuration>
             </plugin>
@@ -468,6 +485,11 @@
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.compendium</artifactId>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.apache.felix.scr.ds-annotations</artifactId>
+            <version>${version.org.apache.felix.scr.ds-annotations}</version>
         </dependency>
     </dependencies>
 

--- a/core/org.wso2.carbon.registry.core/src/main/java/org/wso2/carbon/registry/core/internal/RegistryCoreServiceComponent.java
+++ b/core/org.wso2.carbon.registry.core/src/main/java/org/wso2/carbon/registry/core/internal/RegistryCoreServiceComponent.java
@@ -102,7 +102,7 @@ public class RegistryCoreServiceComponent {
      * @param context the OSGi component context.
      */
     @SuppressWarnings("unused")
-    @Activate
+
     protected void activate(ComponentContext context) {
         // for new cahing, every thread should has its own populated CC. During the deployment time we assume super tenant
         PrivilegedCarbonContext carbonContext = PrivilegedCarbonContext.getThreadLocalCarbonContext();
@@ -199,7 +199,7 @@ public class RegistryCoreServiceComponent {
      * @param context the OSGi component context.
      */
     @SuppressWarnings("unused")
-    @Deactivate
+
     protected void deactivate(ComponentContext context) {
         while (!registrations.empty()) {
             registrations.pop().unregister();

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -602,6 +602,8 @@
         <version.org.osgi.service.metatype.annotations>1.3.0</version.org.osgi.service.metatype.annotations>
         <version.org.osgi.annotation>6.0.0</version.org.osgi.annotation>
         <version.org.osgi.compendium>4.2.0</version.org.osgi.compendium>
+        <version.org.apache.felix.scr.ds-annotations>1.2.10</version.org.apache.felix.scr.ds-annotations>
+        <maven.felix.scr.plugin.version>1.25.0</maven.felix.scr.plugin.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
## Purpose
> Fragment bundles (ie org.wso2.carbon.registry.extensions) could not register their services . As a fix enable exposing service descriptor from the host bundle