### PR TITLE
Disable doclint for javadoc plugin in samples

### DIFF
--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -19,4 +19,25 @@
     <modules>
         <module>student-manager</module>
     </modules>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>2.9</version>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                        <configuration>
+                            <!--This parameter disables doclint-->
+                            <additionalparam>-Xdoclint:none</additionalparam>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>


### PR DESCRIPTION
## Purpose
> Disable doclint for javadoc plugin in module-samples, to eliminate java 8 related java doc errors 
