### PR TITLE
 Upgrade activation orbit version and Enable registry.core to attach fragment bundles

### DIFF
--- a/core/org.wso2.carbon.registry.core/pom.xml
+++ b/core/org.wso2.carbon.registry.core/pom.xml
@@ -54,6 +54,7 @@
                             org.wso2.carbon.user.*,
                             org.wso2.carbon.utils.*,
                             !javax.xml.namespace,
+                            javax.activation.*;version="[0.0.0, 1.0.0)",
                             org.apache.abdera.*; version="${imp.pkg.version.abdera}",
                             javax.xml.namespace; version=0.0.0,
                             javax.servlet; version="${imp.pkg.version.javax.servlet}",
@@ -66,7 +67,6 @@
                             org.wso2.carbon.caching.impl.*,
                             *;resolution:=optional
                         </Import-Package>
-                        <DynamicImport-Package>*</DynamicImport-Package>
                         <Embed-Dependency>
                             acegi-security;scope=compile|runtime;inline=false
                         </Embed-Dependency>

--- a/core/org.wso2.carbon.registry.core/pom.xml
+++ b/core/org.wso2.carbon.registry.core/pom.xml
@@ -54,7 +54,6 @@
                             org.wso2.carbon.user.*,
                             org.wso2.carbon.utils.*,
                             !javax.xml.namespace,
-                            javax.activation.*;version="[0.0.0, 1.0.0)",
                             org.apache.abdera.*; version="${imp.pkg.version.abdera}",
                             javax.xml.namespace; version=0.0.0,
                             javax.servlet; version="${imp.pkg.version.javax.servlet}",
@@ -67,6 +66,7 @@
                             org.wso2.carbon.caching.impl.*,
                             *;resolution:=optional
                         </Import-Package>
+                        <DynamicImport-Package>*</DynamicImport-Package>
                         <Embed-Dependency>
                             acegi-security;scope=compile|runtime;inline=false
                         </Embed-Dependency>

--- a/core/org.wso2.carbon.registry.core/pom.xml
+++ b/core/org.wso2.carbon.registry.core/pom.xml
@@ -32,6 +32,21 @@
 
     <build>
         <plugins>
+             <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-scr-plugin</artifactId>
+                <version>${maven.felix.scr.plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>generate-scr-scrdescriptor</id>
+                        <goals>
+                            <goal>scr</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
@@ -73,6 +88,8 @@
                         <Include-Resource>
                             META-INF/services/org.apache.abdera.factory.ExtensionFactory=src/main/resources/META-INF/services/org.apache.abdera.factory.ExtensionFactory
                         </Include-Resource>
+                        <!-- Enable fragment components to expose theri service description -->
+                        <Service-Component>OSGI-INF/*.xml</Service-Component>
                     </instructions>
                 </configuration>
             </plugin>
@@ -468,6 +485,11 @@
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.compendium</artifactId>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.apache.felix.scr.ds-annotations</artifactId>
+            <version>${version.org.apache.felix.scr.ds-annotations}</version>
         </dependency>
     </dependencies>
 

--- a/core/org.wso2.carbon.registry.core/src/main/java/org/wso2/carbon/registry/core/internal/RegistryCoreServiceComponent.java
+++ b/core/org.wso2.carbon.registry.core/src/main/java/org/wso2/carbon/registry/core/internal/RegistryCoreServiceComponent.java
@@ -102,7 +102,7 @@ public class RegistryCoreServiceComponent {
      * @param context the OSGi component context.
      */
     @SuppressWarnings("unused")
-    @Activate
+
     protected void activate(ComponentContext context) {
         // for new cahing, every thread should has its own populated CC. During the deployment time we assume super tenant
         PrivilegedCarbonContext carbonContext = PrivilegedCarbonContext.getThreadLocalCarbonContext();
@@ -199,7 +199,7 @@ public class RegistryCoreServiceComponent {
      * @param context the OSGi component context.
      */
     @SuppressWarnings("unused")
-    @Deactivate
+
     protected void deactivate(ComponentContext context) {
         while (!registrations.empty()) {
             registrations.pop().unregister();

--- a/core/org.wso2.carbon.user.core/pom.xml
+++ b/core/org.wso2.carbon.user.core/pom.xml
@@ -172,7 +172,6 @@
                             javax.xml.namespace; version=0.0.0,
                             *;resolution:=optional
                         </Import-Package>
-                        <DynamicImport-Package>*</DynamicImport-Package>
                     </instructions>
                 </configuration>
             </plugin>

--- a/core/org.wso2.carbon.user.core/pom.xml
+++ b/core/org.wso2.carbon.user.core/pom.xml
@@ -172,6 +172,7 @@
                             javax.xml.namespace; version=0.0.0,
                             *;resolution:=optional
                         </Import-Package>
+                        <DynamicImport-Package>*</DynamicImport-Package>
                     </instructions>
                 </configuration>
             </plugin>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -602,6 +602,7 @@
         <version.org.osgi.service.metatype.annotations>1.3.0</version.org.osgi.service.metatype.annotations>
         <version.org.osgi.annotation>6.0.0</version.org.osgi.annotation>
         <version.org.osgi.compendium>4.2.0</version.org.osgi.compendium>
+        <version.org.wso2.orbit.javax.activation>1.1.1.wso2v1</version.org.wso2.orbit.javax.activation>
     </properties>
 
     <dependencyManagement>
@@ -1742,6 +1743,11 @@
                 <artifactId>org.osgi.compendium</artifactId>
                 <version>${version.org.osgi.compendium}</version>
                 <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.orbit.javax.activation</groupId>
+                <artifactId>activation</artifactId>
+                <version>${version.org.wso2.orbit.javax.activation}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -602,6 +602,8 @@
         <version.org.osgi.service.metatype.annotations>1.3.0</version.org.osgi.service.metatype.annotations>
         <version.org.osgi.annotation>6.0.0</version.org.osgi.annotation>
         <version.org.osgi.compendium>4.2.0</version.org.osgi.compendium>
+        <version.org.apache.felix.scr.ds-annotations>1.2.10</version.org.apache.felix.scr.ds-annotations>
+        <maven.felix.scr.plugin.version>1.25.0</maven.felix.scr.plugin.version>
     </properties>
 
     <dependencyManagement>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -602,7 +602,6 @@
         <version.org.osgi.service.metatype.annotations>1.3.0</version.org.osgi.service.metatype.annotations>
         <version.org.osgi.annotation>6.0.0</version.org.osgi.annotation>
         <version.org.osgi.compendium>4.2.0</version.org.osgi.compendium>
-        <version.org.wso2.orbit.javax.activation>1.1.1.wso2v1</version.org.wso2.orbit.javax.activation>
     </properties>
 
     <dependencyManagement>
@@ -1743,11 +1742,6 @@
                 <artifactId>org.osgi.compendium</artifactId>
                 <version>${version.org.osgi.compendium}</version>
                 <scope>provided</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.wso2.orbit.javax.activation</groupId>
-                <artifactId>activation</artifactId>
-                <version>${version.org.wso2.orbit.javax.activation}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -551,7 +551,7 @@
         <wagon.ssh.version>2.1</wagon.ssh.version>
         <version.org.wso2.orbit.javax.xml.bind.jaxb-api>2.3.1.wso2v1</version.org.wso2.orbit.javax.xml.bind.jaxb-api>
         <version.org.wso2.orbit.javax.xml.bind.jaxb>2.3.2.wso2v1</version.org.wso2.orbit.javax.xml.bind.jaxb>
-        <version.org.wso2.orbit.javax.activation>1.1.1.wso2v1</version.org.wso2.orbit.javax.activation>
+        <version.org.wso2.orbit.javax.activation>1.1.1.wso2v2</version.org.wso2.orbit.javax.activation>
         <version.org.wso2.orbit.com.sun.xml.ws.jaxws>2.3.2.wso2v1</version.org.wso2.orbit.com.sun.xml.ws.jaxws>
         <version.org.wso2.orbit.javax.jta>1.1.0.wso2v1</version.org.wso2.orbit.javax.jta>
         <verion.javax.annotation.annotation-api>1.3.2</verion.javax.annotation.annotation-api>


### PR DESCRIPTION
## Purpose
> Upgrade activity orbit version

> Fragment bundles (ie org.wso2.carbon.registry.extensions) could not register their services . As a fix enable exposing service descriptor from the host bundle