### PR TITLE
Fix 'Attention :: Permission issue in Menu item add_scope_menu' error

### DIFF
--- a/core/org.wso2.carbon.ui/src/main/java/org/wso2/carbon/ui/deployment/beans/CarbonUIDefinitions.java
+++ b/core/org.wso2.carbon.ui/src/main/java/org/wso2/carbon/ui/deployment/beans/CarbonUIDefinitions.java
@@ -232,6 +232,8 @@ public class CarbonUIDefinitions {
                                 grantCount++;
                                 break;
                             } else {
+                                //remove whitespaces before the text
+                                requiredPermission = requiredPermission.replaceAll("\\s","");
                                 if (!requiredPermission.startsWith("/")) {
                                     grantCount = requiredPermissions.length;
                                     log.error(" Attention :: Permission issue in Menu item "


### PR DESCRIPTION
## Purpose
> When login to the carbon console, following error log is printed continuously 
`ERROR - CarbonUIDefinitions  Attention :: Permission issue in Menu item add_scope_menu`

Reason for this is that some of the permissions have whitespace in front of the test. This effects the permission check

