### PR TITLE
 Disable password trim over a server configuration

### DIFF
--- a/core/org.wso2.carbon.ui/src/main/resources/web/admin/js/main.js
+++ b/core/org.wso2.carbon.ui/src/main/resources/web/admin/js/main.js
@@ -1665,6 +1665,20 @@ function isEmpty(fldname) {
     return false;
 }
 
+function isEmptyCheckWithoutTrim(fldname) {
+    var fld = document.getElementsByName(fldname)[0];
+    if (fld.value.length == 0) {
+        return true;
+    }
+    var tempFieldValue = fld.value;
+    tempFieldValue = tempFieldValue.replace(/^\s\s*/, '').replace(/\s\s*$/, '');
+    if (tempFieldValue.length == 0) {
+        return true;
+    }
+
+    return false;
+}
+
 function validateText(e) {
     var key = String.fromCharCode(getkey(e));
     if (key == null) {

--- a/core/org.wso2.carbon.ui/src/main/resources/web/admin/login.jsp
+++ b/core/org.wso2.carbon.ui/src/main/resources/web/admin/login.jsp
@@ -65,8 +65,8 @@ if (CharacterEncoder.getSafeText(request.getParameter("skipLoginPage"))!=null){
         function doValidation() {
             var reason = "";
 
-            var userNameEmpty = isEmpty("username");
-            var passwordEmpty = isEmpty("password");
+            var userNameEmpty = isEmptyCheckWithoutTrim("username");
+            var passwordEmpty = isEmptyCheckWithoutTrim("password");
 
             if (userNameEmpty || passwordEmpty) {
                 CARBON.showWarningDialog('<fmt:message key="empty.credentials"/>');

--- a/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/CarbonConstants.java
+++ b/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/CarbonConstants.java
@@ -52,6 +52,8 @@ public final class CarbonConstants {
     public static final String UI_PERMISSION_ACTION = "ui.execute";
     public static final String UI_USER_PERMISSIONS = "user-permissions";
 
+    public static final String IS_PASSWORD_TRIM_ENABLED = "EnablePasswordTrim";
+
     public static final String AUTHZ_FAULT_CODE = "WSO2CarbonAuthorizationFailure";
     public static final String MODULE_NOT_FOUND_FAULT_CODE = "Axis2ModuleNotFound";
 

--- a/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/Secret.java
+++ b/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/Secret.java
@@ -19,12 +19,16 @@
 package org.wso2.carbon.utils;
 
 import org.apache.commons.lang.ArrayUtils;
+import org.apache.commons.lang.StringUtils;
+import org.wso2.carbon.base.ServerConfiguration;
 
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+
+import static org.wso2.carbon.CarbonConstants.IS_PASSWORD_TRIM_ENABLED;
 
 /**
  * This class wraps a character array to be used to handle sensitive data like passwords.
@@ -153,6 +157,10 @@ public class Secret {
                 char[] secretChars = (char[]) secret;
                 return new Secret(Arrays.copyOf(secretChars, secretChars.length));
             } else if (secret instanceof String) {
+
+                if (!isPasswordTrimEnabled()) {
+                    return new Secret(((String) secret).toCharArray());
+                }
                 return new Secret(((String) secret).trim().toCharArray());
             } else {
                 throw new UnsupportedSecretTypeException(
@@ -161,6 +169,17 @@ public class Secret {
         }
 
         return new Secret(ArrayUtils.EMPTY_CHAR_ARRAY);
+    }
+
+    private static boolean isPasswordTrimEnabled() {
+        boolean isPasswordTrimEnabled = true;
+        ServerConfiguration serverConfiguration = CarbonUtils.getServerConfiguration();
+        if (serverConfiguration != null && StringUtils.isNotEmpty(serverConfiguration.getFirstProperty
+                (IS_PASSWORD_TRIM_ENABLED))) {
+            isPasswordTrimEnabled = Boolean.parseBoolean(serverConfiguration.getFirstProperty
+                    (IS_PASSWORD_TRIM_ENABLED));
+        }
+        return isPasswordTrimEnabled;
     }
 
     private void clearChars(char[] chars) {

--- a/distribution/kernel/carbon-home/repository/conf/carbon.xml
+++ b/distribution/kernel/carbon-home/repository/conf/carbon.xml
@@ -415,8 +415,8 @@
     <!-- 
       Enable following config to allow Emails as usernames. 	
     -->	    	
-    <!--EnableEmailUserName>true</EnableEmailUserName-->	
-
+    <!--EnableEmailUserName>true</EnableEmailUserName-->
+    <!--EnablePasswordTrim>false</EnablePasswordTrim-->
     <!--
       Security configurations
     -->


### PR DESCRIPTION
* Leading and Trailing white-spaces in the password will not be trimmed at the server level if the following configuration is enabled in [HOME]/repository/conf/carbon.xml

```
<Server ...
 <EnablePasswordTrim >false</EnablePasswordTrim>
 
```