### PR TITLE
Fix issue when splitting multiple dotted key arrays.

### DIFF
--- a/core/org.wso2.carbon.nextgen.config/src/main/java/org/wso2/carbon/nextgen/config/JinjaParser.java
+++ b/core/org.wso2.carbon.nextgen.config/src/main/java/org/wso2/carbon/nextgen/config/JinjaParser.java
@@ -101,10 +101,16 @@ class JinjaParser {
     }
 
     static List<String> getDottedKeyArray(String dottedFlatKey) throws ConfigParserException {
+
         List<String> list = new ArrayList<>();
         int lastMatchedIndex = 0;
         while (lastMatchedIndex != -1) {
-            int startIndex = dottedFlatKey.indexOf('\'', lastMatchedIndex + 1);
+            int startIndex = 0;
+            if (lastMatchedIndex == 0) {
+                startIndex = dottedFlatKey.indexOf('\'', lastMatchedIndex);
+            } else {
+                startIndex = dottedFlatKey.indexOf('\'', lastMatchedIndex + 1);
+            }
             if (startIndex == -1) {
                 int beginIndx = lastMatchedIndex == 0 ? 0 : lastMatchedIndex + 1;
                 splitAndAddToList(dottedFlatKey, list, beginIndx, dottedFlatKey.length());
@@ -113,9 +119,13 @@ class JinjaParser {
                 int endIndex = dottedFlatKey.indexOf('\'', startIndex + 1);
                 if (endIndex == -1) {
                     throw new ConfigParserException("Couldn't find matching ending \"'\" for sub key in flat key "
-                                                    + dottedFlatKey);
+                            + dottedFlatKey);
                 }
-                splitAndAddToList(dottedFlatKey, list, lastMatchedIndex, startIndex);
+                if (lastMatchedIndex == 0) {
+                    splitAndAddToList(dottedFlatKey, list, lastMatchedIndex, startIndex);
+                } else {
+                    splitAndAddToList(dottedFlatKey, list, lastMatchedIndex + 1, startIndex);
+                }
                 list.add(dottedFlatKey.substring(startIndex + 1, endIndex));
                 lastMatchedIndex = endIndex;
             }

--- a/core/org.wso2.carbon.nextgen.config/src/test/java/org/wso2/carbon/nextgen/config/JinjaParserTest.java
+++ b/core/org.wso2.carbon.nextgen.config/src/test/java/org/wso2/carbon/nextgen/config/JinjaParserTest.java
@@ -84,6 +84,22 @@ public class JinjaParserTest {
                 {".one.'two.three'.four", new String[]{"one", "two.three", "four"}},
                 {".one.two.'three.four'.five.six", new String[]{"one", "two", "three.four", "five", "six"}},
                 {".one.two.'three.four.five'.six.seven", new String[]{"one", "two", "three.four.five", "six", "seven"}},
+                {"one.two.'three.four.five'.six.'seven.eight'", new String[]{"one", "two", "three.four.five", "six",
+                        "seven.eight"}},
+                {".one.two.'three.four.five'.six.'seven.eight'", new String[]{"one", "two", "three.four.five", "six",
+                        "seven.eight"}},
+                {"'one.two'.three.four.five.'six.seven'.eight", new String[]{"one.two", "three", "four", "five",
+                        "six.seven", "eight"}},
+                {".'one.two'.three.four.five.'six.seven'.eight", new String[]{"one.two", "three", "four", "five",
+                        "six.seven", "eight"}},
+                {"one.'two.three'.four.'five.six'.seven.'eight.nine'", new String[]{"one", "two.three", "four",
+                        "five.six", "seven", "eight.nine"}},
+                {".one.'two.three'.four.'five.six'.seven.'eight.nine'", new String[]{"one", "two.three", "four",
+                        "five.six", "seven", "eight.nine"}},
+                {"'one.two'.'three.four'.'five.six'.seven.'eight.nine'", new String[]{"one.two", "three.four",
+                        "five.six", "seven", "eight.nine"}},
+                {".'one.two'.'three.four'.'five.six'.seven.'eight.nine'", new String[]{"one.two", "three.four",
+                        "five.six", "seven", "eight.nine"}},
                 };
     }
 


### PR DESCRIPTION
## Purpose
> When there are multiple single quoted dotted key arrays, all of them should be considered when splitting.

Eg: 

Input : "one.two.**'three.four.five'**.six.**'seven.eight'**"
Output : {"one", "two", "three.four.five", "six", "seven.eight"}

