### PR TITLE
Support quoted dotted parameters for deployment.toml

### DIFF
--- a/core/org.wso2.carbon.nextgen.config/src/main/java/org/wso2/carbon/nextgen/config/TomlParser.java
+++ b/core/org.wso2.carbon.nextgen.config/src/main/java/org/wso2/carbon/nextgen/config/TomlParser.java
@@ -57,6 +57,7 @@ class TomlParser {
 
             Set<String> dottedKeySet = result.dottedKeySet();
             for (String dottedKey: dottedKeySet) {
+                dottedKey = dottedKey.replaceAll("\"", "'");
                 context.put(dottedKey, getValue(result.get(dottedKey)));
             }
         } catch (IOException e) {

--- a/core/org.wso2.carbon.nextgen.config/src/test/java/org/wso2/carbon/nextgen/config/TomlParserTest.java
+++ b/core/org.wso2.carbon.nextgen.config/src/test/java/org/wso2/carbon/nextgen/config/TomlParserTest.java
@@ -60,6 +60,8 @@ public class TomlParserTest {
                 {"header_test.b.c", "value1"},
                 {"header_test.b.d", "value2"},
                 {"key", "value3"},
+                {"a.'b.c'", "value4"},
+                {"a.'d.e'", "value5"},
                 };
     }
 

--- a/core/org.wso2.carbon.nextgen.config/src/test/resources/test.toml
+++ b/core/org.wso2.carbon.nextgen.config/src/test/resources/test.toml
@@ -1,5 +1,8 @@
 key = "value3"
 
+a."b.c" = "value4"
+a.'d.e' = "value5"
+
 [header_test]
 b.c = "value1"
 b.d = "value2"


### PR DESCRIPTION
## Purpose
> Support dotted parameter keys within quote or double quotes in deployment toml file so that parameters with dotted keys can be passed into the template.

Related https://github.com/wso2/product-ei/issues/3339