### PR TITLE
Fix issue when resolving property placeholders for boolean values.

### DIFF
--- a/core/org.wso2.carbon.nextgen.config/src/main/java/org/wso2/carbon/nextgen/config/ReferenceResolver.java
+++ b/core/org.wso2.carbon.nextgen.config/src/main/java/org/wso2/carbon/nextgen/config/ReferenceResolver.java
@@ -260,6 +260,8 @@ public class ReferenceResolver {
             if (value instanceof List) {
                 //todo $ref-someOtherString when $ref is a list
                 context.put(k, value);
+            } else if (value instanceof Boolean) {
+                context.put(k, value);
             } else if (existingValue instanceof String) {
                 existingValue = ((String) existingValue).replaceAll(Pattern.quote(
                         CONF_PLACEHOLDER_PREFIX + key + PLACEHOLDER_SUFFIX),

--- a/core/org.wso2.carbon.nextgen.config/src/test/java/org/wso2/carbon/nextgen/config/ReferenceResolverTest.java
+++ b/core/org.wso2.carbon.nextgen.config/src/test/java/org/wso2/carbon/nextgen/config/ReferenceResolverTest.java
@@ -108,6 +108,9 @@ public class ReferenceResolverTest {
         fileContextPlaceholders.put("fb", "BBB");
         fileContextPlaceholders.put("fb1", "$ref{fa}-$ref{fb}");
         fileContextPlaceholders.put("fb2", "$ref{fa1}-$ref{fb}");
+        fileContextPlaceholders.put("fc", true);
+        fileContextPlaceholders.put("fc1", "$ref{fc}");
+        fileContextPlaceholders.put("fc2", "$ref{fc1}");
         systemContextPlaceholders.put("sa", "$sys{syskey1}");
         systemContextPlaceholders.put("sb", "$sys{syskey1}-AAA");
         systemContextPlaceholders.put("sc", "$sys{syskey1}-$sys{syskey2}");
@@ -117,6 +120,8 @@ public class ReferenceResolverTest {
                 {fileContextPlaceholders, "fa2", "AAA"},
                 {fileContextPlaceholders, "fb1", "AAA-BBB"},
                 {fileContextPlaceholders, "fb2", "AAA-BBB"},
+                {fileContextPlaceholders, "fc1", true},
+                {fileContextPlaceholders, "fc2", true},
                 {systemContextPlaceholders, "sa", "sysval1"},
                 {systemContextPlaceholders, "sb", "sysval1-AAA"},
                 {systemContextPlaceholders, "sc", "sysval1-sysval2"},


### PR DESCRIPTION
## Purpose
> When we refer a boolean value using $ref{}, the value should be returned as a boolean not converted to a string.

```
Eg : 
"a" : true
"b" : $ref{a}"
Then the value of b should be true and type boolean.
```

