### PR TITLE
Pack commons-text and its transitive dependency commons-lang3

### DIFF
--- a/features/org.wso2.carbon.core.common.feature/pom.xml
+++ b/features/org.wso2.carbon.core.common.feature/pom.xml
@@ -116,6 +116,9 @@
                                 <bundleDef>org.wso2.orbit.org.apache.tomcat:jdbc-pool:${jdbc-pool.version}</bundleDef>
                                 <bundleDef>org.eclipse.jdt.core.compiler:ecj:${version.eclipse.ecj}</bundleDef>
                                 <bundleDef>com.google.code.gson:gson:${version.com.google.code.gson}</bundleDef>
+                                <!--commons-text and commons-lang3 required for axiom-->
+                                <bundleDef>org.wso2.orbit.commons-text:commons-text:${commons-text.orbit.version}</bundleDef>
+                                <bundleDef>org.wso2.orbit.org.apache.commons:commons-lang3:${commons-lang3.orbit.version}</bundleDef>
 
                                 <!--Kernel bundles-->
                                 <bundleDef>org.wso2.carbon:org.wso2.carbon.utils:${carbon.kernel.version}</bundleDef>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -447,6 +447,8 @@
         <version.axiom>1.2.11.wso2v13</version.axiom>
         <axiom.osgi.version>1.2.11.wso2v13</axiom.osgi.version>
         <axiom.osgi.version.range>[1.2.11, 1.3.0)</axiom.osgi.version.range>
+        <commons-text.orbit.version>1.6.wso2v1</commons-text.orbit.version>
+        <commons-lang3.orbit.version>3.4.0.wso2v1</commons-lang3.orbit.version>
 
 
         <!-- Spring Framework -->


### PR DESCRIPTION
Commons-text is used in axiom to fix the issue https://github.com/wso2/product-ei/issues/3789.
Therefore packing commons-text and its transitive dependency, while packing the axiom itself in the kernel.

