### PR TITLE
Fix an incorrect exception handle during server initialization

### DIFF
--- a/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/init/JMXServerManager.java
+++ b/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/init/JMXServerManager.java
@@ -83,7 +83,7 @@ public class JMXServerManager {
 
         int rmiRegistryPort = jmxProperties.getRmiRegistryPort();
         if (rmiRegistryPort == -1) {
-            throw new RuntimeException("RMIRegistry port has not been properly defined in the " +
+            throw new ServerException("RMIRegistry port has not been properly defined in the " +
                                            "jmx.xml or carbon.xml files");
         }
         MBeanServer mbs = ManagementFactory.getMBeanServer();


### PR DESCRIPTION
## Purpose
> To replace the existing RuntimeException to a ServerException and facilitate a proper exception handle in a scenario where the RMIRegistry port has not been properly defined in the jmx.xml or carbon.xml files.  

## Goals
> Currently the exception is not handled properly and therefore the server initialization remains incomplete without adequate logs depicting the problem. This is fixed through this PR. 

Fixes issue: https://github.com/wso2/product-ei/issues/4065
