### PR TITLE
update pax.logging.x from 1.10.0 to 1.10.1

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -677,8 +677,8 @@
         <org.eclipse.equinox.p2.metadata.version>2.2.0.v20131211-1531</org.eclipse.equinox.p2.metadata.version>
 
         <!--PAX Logging related dependency versions-->
-        <pax.logging.api.version>1.10.0</pax.logging.api.version>
-        <pax.logging.log4j2.version>1.10.0</pax.logging.log4j2.version>
+        <pax.logging.api.version>1.10.1</pax.logging.api.version>
+        <pax.logging.log4j2.version>1.10.1</pax.logging.log4j2.version>
 
         <!--Maven Plugins -->
         <maven.wagon.ssh.version>2.1</maven.wagon.ssh.version>


### PR DESCRIPTION
https://ops4j1.jira.com/wiki/spaces/paxlogging/blog/2017/06/19/132412348/Pax+Logging+1.10.1+Released Jun 19, 2017

## Purpose
update library