### PR TITLE
Fix issue in single quoted keys inside an array.

### DIFF
--- a/core/org.wso2.carbon.nextgen.config/src/main/java/org/wso2/carbon/nextgen/config/TomlParser.java
+++ b/core/org.wso2.carbon.nextgen.config/src/main/java/org/wso2/carbon/nextgen/config/TomlParser.java
@@ -85,6 +85,10 @@ class TomlParser {
         Map<String, Object> finalMap = new LinkedHashMap<>();
         Set<String> dottedKeySet = tomlTable.dottedKeySet();
         for (String key : dottedKeySet) {
+            // To support single quoted keys in the toml inside an array.
+            // Eg: [[a.b]]
+            //     'c.d' = "value"
+            key = key.replaceAll("\"", "'");
             Object value = tomlTable.get(key);
             if (value instanceof TomlArray) {
                 finalMap.put(key, processTomlArray((TomlArray) value));

--- a/core/org.wso2.carbon.nextgen.config/src/test/java/org/wso2/carbon/nextgen/config/TomlParserTest.java
+++ b/core/org.wso2.carbon.nextgen.config/src/test/java/org/wso2/carbon/nextgen/config/TomlParserTest.java
@@ -26,7 +26,9 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import org.wso2.carbon.nextgen.config.model.Context;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
@@ -60,13 +62,18 @@ public class TomlParserTest {
 
     @DataProvider(name = "flatKeySetProvider")
     public Object[][] flatKeyDataSet() {
+        LinkedHashMap<String, String> data = new LinkedHashMap<String, String>();
+        ArrayList<Object> result = new ArrayList<Object>();
+        data.put("'a.b'", "value6");
+        result.add(data);
         return new Object[][]{
                 {"header_test.b.c", "value1"},
                 {"header_test.b.d", "value2"},
                 {"key", "value3"},
                 {"a.'b.c'", "value4"},
                 {"a.'d.e'", "value5"},
-                };
+                {"single_quote_test", result},
+        };
     }
 
 }

--- a/core/org.wso2.carbon.nextgen.config/src/test/resources/test.toml
+++ b/core/org.wso2.carbon.nextgen.config/src/test/resources/test.toml
@@ -20,3 +20,6 @@ a.b.d = "datasources value 3"
 [[datasource]]
 a.b.c = "datasource value 2"
 a.b.d = "data 4"
+
+[[single_quote_test]]
+'a.b' = "value6"


### PR DESCRIPTION
## Purpose
> To support single quoted keys in the toml inside an array.
```
   [[a.b]]
   'c.d' = "value"
```