### PR TITLE
Revert m1 versions to SNAPSHOT

### DIFF
--- a/core/org.wso2.carbon.ui/src/main/resources/web/docs/about.html
+++ b/core/org.wso2.carbon.ui/src/main/resources/web/docs/about.html
@@ -21,7 +21,7 @@
 <link href="../admin/css/documentation.css" rel="stylesheet" type="text/css" media="all"/>
 </head>
 <body>
-<h1>Version 4.5.0-M1</h1>
+<h1>Version 4.5.0-SNAPSHOT</h1>
 <h2>About WSO2 Carbon </h2>
 <p>WSO2 Carbon is a component based Enterprise SOA platform. The
 design of

--- a/distribution/kernel/carbon.product
+++ b/distribution/kernel/carbon.product
@@ -2,7 +2,7 @@
 <?pde version="3.5"?>
 
 <product name="Carbon Product" uid="carbon.product.id" id="carbon.product" application="carbon.application"
-version="4.5.0.m1" useFeatures="true" includeLaunchers="true">
+version="4.5.0.SNAPSHOT" useFeatures="true" includeLaunchers="true">
 
    <configIni use="default">
    </configIni>
@@ -14,7 +14,7 @@ version="4.5.0.m1" useFeatures="true" includeLaunchers="true">
    </plugins>
 
    <features>
-      <feature id="org.wso2.carbon.core.runtime" version="4.5.0.m1"/>
+      <feature id="org.wso2.carbon.core.runtime" version="4.5.0.SNAPSHOT"/>
    </features>
 
   <configurations>

--- a/distribution/kernel/src/assembly/filter.properties
+++ b/distribution/kernel/src/assembly/filter.properties
@@ -1,2 +1,2 @@
-carbon.version=4.5.0-M1
+carbon.version=4.5.0-SNAPSHOT
 p2.repo.url=http://product-dist.wso2.com/p2/carbon/releases/wilkes/

--- a/distribution/product/modules/distribution/src/assembly/filter.properties
+++ b/distribution/product/modules/distribution/src/assembly/filter.properties
@@ -1,8 +1,8 @@
 product.name=WSO2 Carbon
-product.version=4.5.0-M1
+product.version=4.5.0-SNAPSHOT
 product.key=Carbon
-carbon.product.version=4.5.0-M1
-carbon.version=4.5.0-M1
+carbon.product.version=4.5.0-SNAPSHOT
+carbon.version=4.5.0-SNAPSHOT
 default.server.role=CarbonServer
 hotdeployment=true
 hotupdate=true


### PR DESCRIPTION
## Purpose
Setting the M1 versions back to SNAPSHOTs

## Goals
Stabilize the master branch build

## Approach
Setting the M1 versions back to SNAPSHOTs

## User stories
N/A

## Release note
N/A

## Documentation
N/A

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
N/A

## Security checks
N/A

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
N/A
 
## Learning
N/A