### PR TITLE
Enable h2 database config.

### DIFF
--- a/distribution/kernel/carbon-home/repository/resources/conf/default.json
+++ b/distribution/kernel/carbon-home/repository/resources/conf/default.json
@@ -95,6 +95,7 @@
     "127.0.0.1:4000"
   ],
   "clustering.local_member_port": "4000",
+  "database_configuration.enable_h2_db": false,
   "database.shared_db.id": "SHARED_DB",
   "database.shared_db.pool_options.maxActive": "50",
   "database.shared_db.pool_options.maxWait": "60000",

--- a/distribution/kernel/carbon-home/repository/resources/conf/templates/repository/conf/carbon.xml.j2
+++ b/distribution/kernel/carbon-home/repository/resources/conf/templates/repository/conf/carbon.xml.j2
@@ -715,6 +715,15 @@
         <property name="trace" />
         <property name="baseDir">${carbon.home}</property>
     </H2DatabaseConfiguration-->
+
+    {% if database_configuration.enable_h2_db %}
+    <H2DatabaseConfiguration>
+        <property name="web"/>
+        <property name="webPort">8082</property>
+        <property name="webAllowOthers"/>
+    </H2DatabaseConfiguration>
+    {% endif %}
+
     <!--Disabling statistics reporter by default-->
     <StatisticsReporterDisabled>true</StatisticsReporterDisabled>
 


### PR DESCRIPTION
## Purpose
Template enabling h2 database config.

```
<H2DatabaseConfiguration>
        <property name="web"/>
        <property name="webPort">8082</property>
        <property name="webAllowOthers"/>       
</H2DatabaseConfiguration>
```

To enable this add the below property to `deployment.toml`file

```
[database_configuration]
enable_h2_db = true
```
Refernece to:https://github.com/wso2/product-is/issues/5828

