### PR TITLE
Template HideAdminServiceWSDLs config in carbon.xml

### DIFF
--- a/distribution/kernel/carbon-home/repository/resources/conf/default.json
+++ b/distribution/kernel/carbon-home/repository/resources/conf/default.json
@@ -162,5 +162,7 @@
   "server.base_path" : "${carbon.protocol}://${carbon.host}:${carbon.management.port}",
   "system.parameter": {
     "org.wso2.CipherTransformation": "RSA/ECB/OAEPwithSHA1andMGF1Padding"
-  }
+  },
+
+  "admin_service.wsdl.enable": false
 }

--- a/distribution/kernel/carbon-home/repository/resources/conf/templates/repository/conf/carbon.xml.j2
+++ b/distribution/kernel/carbon-home/repository/resources/conf/templates/repository/conf/carbon.xml.j2
@@ -330,7 +330,11 @@
          calling to BE server -->
         <clientAxis2XmlLocation>${carbon.home}/repository/conf/axis2/axis2_client.xml</clientAxis2XmlLocation>
         <!-- If this parameter is set, the ?wsdl on an admin service will not give the admin service wsdl. -->
+        {% if admin_service.wsdl.enable is sameas true %}
+        <HideAdminServiceWSDLs>false</HideAdminServiceWSDLs>
+        {% else %}
         <HideAdminServiceWSDLs>true</HideAdminServiceWSDLs>
+        {% endif %}
 
 	<!--WARNING-Use With Care! Uncommenting bellow parameter would expose all AdminServices in HTTP transport.
 	With HTTP transport your credentials and data routed in public channels are vulnerable for sniffing attacks.


### PR DESCRIPTION
## Purpose

- Template HideAdminServiceWSDLs config in carbon.xml

Fixing: https://github.com/wso2/carbon-kernel/issues/2123

Related Toml key :
```
[admin_service.wsdl]
enable = true
```

