### PR TITLE
Fix nullpointer in HandlerManager when debug is enabled.

### DIFF
--- a/core/org.wso2.carbon.registry.core/src/main/java/org/wso2/carbon/registry/core/jdbc/handlers/HandlerManager.java
+++ b/core/org.wso2.carbon.registry.core/src/main/java/org/wso2/carbon/registry/core/jdbc/handlers/HandlerManager.java
@@ -500,8 +500,10 @@ public class HandlerManager {
             methodInfo = sb.toString();
         }
         if (log.isDebugEnabled()) {
-            log.debug("Registered the handler " + filter.getClass().getName() +
-                    " --> " + handler.getClass().getName() + " for" + methodInfo + " methods.");
+            if (filter != null && handler != null) {
+                log.debug("Registered the handler " + filter.getClass().getName() +
+                        " --> " + handler.getClass().getName() + " for" + methodInfo + " methods.");
+            }
         }
     }
 


### PR DESCRIPTION
## Purpose

- Fix null pointer in `HandlerManager `when debug is enabled.

Fixing: https://github.com/wso2/carbon-kernel/issues/2099

