### PR TITLE
Add install-jars tool 

### DIFF
--- a/features/org.wso2.carbon.runtime.feature/pom.xml
+++ b/features/org.wso2.carbon.runtime.feature/pom.xml
@@ -90,6 +90,7 @@
                                     <directory>resources</directory>
                                     <includes>
                                         <include>conf/**</include>
+                                        <include>client-jars/**</include>
                                         <include>wso2/default/**</include>
                                         <include>wso2/lib/**</include>
                                         <include>build.properties</include>

--- a/features/org.wso2.carbon.runtime.feature/pom.xml
+++ b/features/org.wso2.carbon.runtime.feature/pom.xml
@@ -91,6 +91,7 @@
                                     <includes>
                                         <include>conf/**</include>
                                         <include>jars/**</include>
+                                        <include>bundles/**</include>
                                         <include>wso2/default/**</include>
                                         <include>wso2/lib/**</include>
                                         <include>build.properties</include>

--- a/features/org.wso2.carbon.runtime.feature/pom.xml
+++ b/features/org.wso2.carbon.runtime.feature/pom.xml
@@ -90,7 +90,7 @@
                                     <directory>resources</directory>
                                     <includes>
                                         <include>conf/**</include>
-                                        <include>client-jars/**</include>
+                                        <include>jars/**</include>
                                         <include>wso2/default/**</include>
                                         <include>wso2/lib/**</include>
                                         <include>build.properties</include>

--- a/features/org.wso2.carbon.runtime.feature/resources/bundles/README.txt
+++ b/features/org.wso2.carbon.runtime.feature/resources/bundles/README.txt
@@ -1,0 +1,3 @@
+You can include OSGI bundles and Siddhi Extensions in this directory.
+All bundles within this directory will be copied to <CARBON_HOME>/lib directory when install-jars.sh/install-jars.bat tool is executed.
+Siddhi extension JARs bundled in <CARBON_HOME>/lib will be updated by the extensions available within this directory.

--- a/features/org.wso2.carbon.runtime.feature/resources/jars/README.txt
+++ b/features/org.wso2.carbon.runtime.feature/resources/jars/README.txt
@@ -1,3 +1,2 @@
-You can include all third party JARs and extensions to this directory.
-Non-osgi JARs will be converted to OSGI bundles and copied to ../lib directory.
-Siddhi extension JARs bundled in the vanilla pack will be updated by the extensions available within this directory.
+You can include all third party non-OSGI JARs to this directory.
+Non-osgi JARs will be converted to OSGI bundles and copied to <CARBON_HOME>/lib directory when install-jars.sh/install-jars.bat tool is executed.

--- a/features/org.wso2.carbon.runtime.feature/resources/jars/README.txt
+++ b/features/org.wso2.carbon.runtime.feature/resources/jars/README.txt
@@ -1,0 +1,3 @@
+You can include all third party JARs and extensions to this directory.
+Non-osgi JARs will be converted to OSGI bundles and copied to ../lib directory.
+Siddhi extension JARs bundled in the vanilla pack will be updated by the extensions available within this directory.

--- a/features/org.wso2.carbon.runtime.feature/resources/p2.inf
+++ b/features/org.wso2.carbon.runtime.feature/resources/p2.inf
@@ -4,11 +4,13 @@ metaRequirements.0.optional=true
 instructions.configure = \
 org.wso2.carbon.extensions.touchpoint.copy(source:${installFolder}/../lib/features/org.wso2.carbon.runtime_${feature.version}/conf,target:${installFolder}/../../conf/{runtime},overwrite:true);\
 org.wso2.carbon.extensions.touchpoint.copy(source:${installFolder}/../lib/features/org.wso2.carbon.runtime_${feature.version}/jars,target:${installFolder}/../../jars/,overwrite:true);\
+org.wso2.carbon.extensions.touchpoint.copy(source:${installFolder}/../lib/features/org.wso2.carbon.runtime_${feature.version}/bundles,target:${installFolder}/../../bundles/,overwrite:true);\
 org.wso2.carbon.extensions.touchpoint.copy(source:${installFolder}/../lib/features/org.wso2.carbon.runtime_${feature.version}/wso2/default/bin,target:${installFolder}/../{runtime}/bin/,overwrite:true);\
 org.wso2.carbon.extensions.touchpoint.copy(source:${installFolder}/../lib/features/org.wso2.carbon.runtime_${feature.version}/wso2/default/logs,target:${installFolder}/../{runtime}/logs/,overwrite:true);\
 org.eclipse.equinox.p2.touchpoint.natives.copy(source:${installFolder}/../lib/features/org.wso2.carbon.runtime_${feature.version}/wso2/lib,target:${installFolder}/../../wso2/lib/,overwrite:true);\
 org.wso2.carbon.extensions.touchpoint.chmod(targetDir:${installFolder}/../{runtime}/bin,targetFile:carbon.sh,permissions:755);\
 org.wso2.carbon.extensions.touchpoint.chmod(targetDir:${installFolder}/../../jars,targetFile:README.txt,permissions:644);\
+org.wso2.carbon.extensions.touchpoint.chmod(targetDir:${installFolder}/../../bundles,targetFile:README.txt,permissions:644);\
 org.wso2.carbon.extensions.touchpoint.chmod(targetDir:${installFolder}/../../conf/{runtime},targetFile:log4j2.xml,permissions:644);\
 org.wso2.carbon.extensions.touchpoint.chmod(targetDir:${installFolder}/../../conf/{runtime}/etc,targetFile:pax-logging.properties,permissions:644);\
 org.wso2.carbon.extensions.touchpoint.chmod(targetDir:${installFolder}/../../conf/{runtime}/osgi,targetFile:launch.properties,permissions:644);\

--- a/features/org.wso2.carbon.runtime.feature/resources/p2.inf
+++ b/features/org.wso2.carbon.runtime.feature/resources/p2.inf
@@ -3,10 +3,12 @@ metaRequirements.0.name = org.wso2.carbon.extensions.touchpoint
 metaRequirements.0.optional=true
 instructions.configure = \
 org.wso2.carbon.extensions.touchpoint.copy(source:${installFolder}/../lib/features/org.wso2.carbon.runtime_${feature.version}/conf,target:${installFolder}/../../conf/{runtime},overwrite:true);\
+org.wso2.carbon.extensions.touchpoint.copy(source:${installFolder}/../lib/features/org.wso2.carbon.runtime_${feature.version}/jars,target:${installFolder}/../../jars/,overwrite:true);\
 org.wso2.carbon.extensions.touchpoint.copy(source:${installFolder}/../lib/features/org.wso2.carbon.runtime_${feature.version}/wso2/default/bin,target:${installFolder}/../{runtime}/bin/,overwrite:true);\
 org.wso2.carbon.extensions.touchpoint.copy(source:${installFolder}/../lib/features/org.wso2.carbon.runtime_${feature.version}/wso2/default/logs,target:${installFolder}/../{runtime}/logs/,overwrite:true);\
 org.eclipse.equinox.p2.touchpoint.natives.copy(source:${installFolder}/../lib/features/org.wso2.carbon.runtime_${feature.version}/wso2/lib,target:${installFolder}/../../wso2/lib/,overwrite:true);\
 org.wso2.carbon.extensions.touchpoint.chmod(targetDir:${installFolder}/../{runtime}/bin,targetFile:carbon.sh,permissions:755);\
+org.wso2.carbon.extensions.touchpoint.chmod(targetDir:${installFolder}/../../jars,targetFile:README.txt,permissions:644);\
 org.wso2.carbon.extensions.touchpoint.chmod(targetDir:${installFolder}/../../conf/{runtime},targetFile:log4j2.xml,permissions:644);\
 org.wso2.carbon.extensions.touchpoint.chmod(targetDir:${installFolder}/../../conf/{runtime}/etc,targetFile:pax-logging.properties,permissions:644);\
 org.wso2.carbon.extensions.touchpoint.chmod(targetDir:${installFolder}/../../conf/{runtime}/osgi,targetFile:launch.properties,permissions:644);\

--- a/features/org.wso2.carbon.server.feature/resources/bin/install-jars.bat
+++ b/features/org.wso2.carbon.server.feature/resources/bin/install-jars.bat
@@ -1,0 +1,81 @@
+@echo off
+
+REM ---------------------------------------------------------------------------
+REM   Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+REM
+REM   Licensed under the Apache License, Version 2.0 (the "License");
+REM   you may not use this file except in compliance with the License.
+REM   You may obtain a copy of the License at
+REM
+REM   http://www.apache.org/licenses/LICENSE-2.0
+REM
+REM   Unless required by applicable law or agreed to in writing, software
+REM   distributed under the License is distributed on an "AS IS" BASIS,
+REM   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+REM   See the License for the specific language governing permissions and
+REM   limitations under the License.
+
+rem ----- if JAVA_HOME is not set we're not happy ------------------------------
+:checkJava
+
+if "%JAVA_HOME%" == "" goto noJavaHome
+if not exist "%JAVA_HOME%\bin\java.exe" goto noJavaHome
+goto checkServer
+
+:noJavaHome
+echo "You must set the JAVA_HOME variable before running CARBON."
+goto end
+
+rem ----- Only set CARBON_HOME if not already set ----------------------------
+:checkServer
+rem %~sdp0 is expanded pathname of the current script under NT with spaces in the path removed
+if "%CARBON_HOME%"=="" set CARBON_HOME=%~sdp0..
+SET curDrive=%cd:~0,1%
+SET wsasDrive=%CARBON_HOME:~0,1%
+if not "%curDrive%" == "%wsasDrive%" %wsasDrive%:
+
+rem find CARBON_HOME if it does not exist due to either an invalid value passed
+rem by the user or the %0 problem on Windows 9x
+if not exist "%CARBON_HOME%\bin\kernel-version.txt" goto noServerHome
+
+goto commandLifecycle
+
+:noServerHome
+echo CARBON_HOME is set incorrectly or CARBON could not be located. Please set CARBON_HOME.
+goto end
+
+:commandLifecycle
+goto findJdk
+
+:findJdk
+
+set CMD=RUN %*
+
+:checkJdk16
+"%JAVA_HOME%\bin\java" -version 2>&1 | findstr /r "1.[8]" >NUL
+IF ERRORLEVEL 1 goto unknownJdk
+goto jdk16
+
+:unknownJdk
+echo Starting WSO2 Carbon (in unsupported JDK)
+echo [ERROR] CARBON is supported only on JDK 1.8
+goto jdk16
+
+:jdk16
+goto runTool
+
+:runTool
+
+set CURRENT_DIR=%cd%
+
+cd %CARBON_HOME%\bin
+echo JAVA_HOME environment variable is set to %JAVA_HOME%
+echo CARBON_HOME environment variable is set to %CARBON_HOME%
+java -cp ".\*;..\bin\tools\*" -Dwso2.carbon.tool="install-jars" org.wso2.carbon.tools.CarbonToolExecutor "%CURRENT_DIR%"
+
+:end
+goto endlocal
+
+:endlocal
+
+:END

--- a/features/org.wso2.carbon.server.feature/resources/bin/install-jars.sh
+++ b/features/org.wso2.carbon.server.feature/resources/bin/install-jars.sh
@@ -121,4 +121,4 @@ echo CARBON_HOME environment variable is set to $CARBON_HOME
 CURRENT_DIR=${PWD};
 cd "$CARBON_HOME/bin/";
 
-java -cp "../bin/tools/*" -Dwso2.carbon.tool="install-jars" org.wso2.carbon.tools.CarbonToolExecutor "$CURRENT_DIR"
+java -cp "../bin/tools/*" -Dwso2.carbon.tool="install-jars" org.wso2.carbon.tools.CarbonToolExecutor "$CARBON_HOME"

--- a/features/org.wso2.carbon.server.feature/resources/bin/install-jars.sh
+++ b/features/org.wso2.carbon.server.feature/resources/bin/install-jars.sh
@@ -1,0 +1,124 @@
+#!/bin/sh
+# ---------------------------------------------------------------------------
+#  Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+# ----------------------------------------------------------------------------
+
+cygwin=false;
+darwin=false;
+os400=false;
+mingw=false;
+case "`uname`" in
+CYGWIN*) cygwin=true;;
+MINGW*) mingw=true;;
+OS400*) os400=true;;
+Darwin*) darwin=true
+        if [ -z "$JAVA_VERSION" ] ; then
+             JAVA_VERSION="CurrentJDK"
+           else
+             echo "Using Java version: $JAVA_VERSION"
+           fi
+           if [ -z "$JAVA_HOME" ] ; then
+             JAVA_HOME=/System/Library/Frameworks/JavaVM.framework/Versions/${JAVA_VERSION}/Home
+           fi
+           ;;
+esac
+
+# resolve links - $0 may be a softlink
+PRG="$0"
+
+while [ -h "$PRG" ]; do
+  ls=`ls -ld "$PRG"`
+  link=`expr "$ls" : '.*-> \(.*\)$'`
+  if expr "$link" : '.*/.*' > /dev/null; then
+    PRG="$link"
+  else
+    PRG=`dirname "$PRG"`/"$link"
+  fi
+done
+
+# Get standard environment variables
+PRGDIR=`dirname "$PRG"`
+
+# Only set CARBON_HOME if not already set
+[ -z "$CARBON_HOME" ] && CARBON_HOME=`cd "$PRGDIR/.." ; pwd`
+
+# For Cygwin, ensure paths are in UNIX format before anything is touched
+if $cygwin; then
+  [ -n "$JAVA_HOME" ] && JAVA_HOME=`cygpath --unix "$JAVA_HOME"`
+  [ -n "$CARBON_HOME" ] && CARBON_HOME=`cygpath --unix "$CARBON_HOME"`
+fi
+
+# For OS400
+if $os400; then
+  # Set job priority to standard for interactive (interactive - 6) by using
+  # the interactive priority - 6, the helper threads that respond to requests
+  # will be running at the same priority as interactive jobs.
+  COMMAND='chgjob job('$JOBNAME') runpty(6)'
+  system $COMMAND
+
+  # Enable multi threading
+  QIBM_MULTI_THREADED=Y
+  export QIBM_MULTI_THREADED
+fi
+
+# For Migwn, ensure paths are in UNIX format before anything is touched
+if $mingw ; then
+  [ -n "$CARBON_HOME" ] &&
+    CARBON_HOME="`(cd "$CARBON_HOME"; pwd)`"
+  [ -n "$JAVA_HOME" ] &&
+    JAVA_HOME="`(cd "$JAVA_HOME"; pwd)`"
+fi
+
+if [ -z "$JAVACMD" ] ; then
+  if [ -n "$JAVA_HOME"  ] ; then
+    if [ -x "$JAVA_HOME/jre/sh/java" ] ; then
+      # IBM's JDK on AIX uses strange locations for the executables
+      JAVACMD="$JAVA_HOME/jre/sh/java"
+    else
+      JAVACMD="$JAVA_HOME/bin/java"
+    fi
+  else
+    JAVACMD=java
+  fi
+fi
+
+if [ ! -x "$JAVACMD" ] ; then
+  echo "Error: JAVA_HOME is not defined correctly."
+  echo " CARBON cannot execute $JAVACMD"
+  exit 1
+fi
+
+# if JAVA_HOME is not set we're not happy
+if [ -z "$JAVA_HOME" ]; then
+  echo "You must set the JAVA_HOME variable before running CARBON."
+  exit 1
+fi
+
+jdk_18=`$JAVA_HOME/bin/java -version 2>&1 | grep "1.[8]"`
+if [ "$jdk_18" = "" ]; then
+   echo " Starting WSO2 Carbon (in unsupported JDK)"
+   echo " [ERROR] CARBON is supported only on JDK 1.8"
+   exit 1
+fi
+
+echo JAVA_HOME environment variable is set to $JAVA_HOME
+echo CARBON_HOME environment variable is set to $CARBON_HOME
+
+# get the current directory from which the script is executed
+CURRENT_DIR=${PWD};
+cd "$CARBON_HOME/bin/";
+
+java -cp "../bin/tools/*" -Dwso2.carbon.tool="install-jars" org.wso2.carbon.tools.CarbonToolExecutor "$CURRENT_DIR"

--- a/tools/tools-core/src/main/java/org/wso2/carbon/tools/CarbonToolExecutor.java
+++ b/tools/tools-core/src/main/java/org/wso2/carbon/tools/CarbonToolExecutor.java
@@ -62,25 +62,28 @@ public class CarbonToolExecutor {
      * @throws CarbonToolException if the tool cannot be identified for execution
      */
     private static void executeTool(String toolIdentifier, String... toolArgs) throws CarbonToolException {
+
         if (toolIdentifier == null) {
             throw new CarbonToolException("The Carbon tool identifier cannot be null");
         }
 
         CarbonTool carbonTool;
         switch (toolIdentifier) {
-        case "jar-to-bundle-converter":
-            carbonTool = new BundleGeneratorTool();
-            break;
-        case "osgi-lib-deployer":
-            carbonTool = new OSGiLibDeployerTool();
-            break;
-        case "icf-provider":
-            carbonTool = new ICFProviderTool();
-            break;
-        default:
-            carbonTool = null;
+            case "jar-to-bundle-converter":
+                carbonTool = new BundleGeneratorTool();
+                break;
+            case "osgi-lib-deployer":
+                carbonTool = new OSGiLibDeployerTool();
+                break;
+            case "icf-provider":
+                carbonTool = new ICFProviderTool();
+                break;
+            case "install-jars":
+                carbonTool = new InstallJarsTool();
+                break;
+            default:
+                carbonTool = null;
         }
-
         if (carbonTool != null) {
             carbonTool.execute(toolArgs);
         }

--- a/tools/tools-core/src/main/java/org/wso2/carbon/tools/CarbonToolExecutor.java
+++ b/tools/tools-core/src/main/java/org/wso2/carbon/tools/CarbonToolExecutor.java
@@ -62,7 +62,6 @@ public class CarbonToolExecutor {
      * @throws CarbonToolException if the tool cannot be identified for execution
      */
     private static void executeTool(String toolIdentifier, String... toolArgs) throws CarbonToolException {
-
         if (toolIdentifier == null) {
             throw new CarbonToolException("The Carbon tool identifier cannot be null");
         }
@@ -84,6 +83,7 @@ public class CarbonToolExecutor {
             default:
                 carbonTool = null;
         }
+
         if (carbonTool != null) {
             carbonTool.execute(toolArgs);
         }

--- a/tools/tools-core/src/main/java/org/wso2/carbon/tools/InstallJarsTool.java
+++ b/tools/tools-core/src/main/java/org/wso2/carbon/tools/InstallJarsTool.java
@@ -1,0 +1,78 @@
+/*
+ *  Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.wso2.carbon.tools;
+
+import org.wso2.carbon.tools.converter.utils.BundleGeneratorUtils;
+import org.wso2.carbon.tools.exception.CarbonToolException;
+
+import java.io.File;
+import java.io.FilenameFilter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.jar.Manifest;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * This class defines a tool which can automatically installs jars as OSGI bundles
+ * in WSO2 Carbon Server.
+ *
+ * @since 5.1.0
+ */
+public class InstallJarsTool implements CarbonTool {
+
+    private static final Logger logger = Logger.getLogger(InstallJarsTool.class.getName());
+
+    /**
+     * Executes the WSO2 Carbon OSGi-lib deployer tool based on the specified arguments.
+     *
+     * @param toolArgs the {@link String} argument specifying the Carbon Runtime and CARBON_HOME
+     */
+    @Override
+    public void execute(String... toolArgs) {
+        String carbonHome = toolArgs[0];
+        Path sourcePath = Paths.get(carbonHome.concat("/jars"));
+        Path outputPath = Paths.get(carbonHome.concat("/lib"));
+        File jarsDir = sourcePath.toFile();
+
+        if ((Files.isReadable(sourcePath)) && (Files.isWritable(outputPath))) {
+            try {
+                File[] files = jarsDir.listFiles(new FilenameFilter() {
+                    @Override
+                    public boolean accept(File dir, String name) {
+                        return name.endsWith(".jar");
+                    }
+                });
+                if (files != null && files.length > 0) {
+                    for (File jar : files) {
+                        BundleGeneratorUtils.convertFromJarToBundle(
+                                jar.toPath(), outputPath, new Manifest(), "");
+                    }
+
+                }
+            } catch (IOException | CarbonToolException e) {
+                logger.log(Level.SEVERE,
+                        "An error occurred when making the JAR (Java Archive) to OSGi bundle conversion", e);
+            }
+        } else {
+            String message = "The source location and/or bundle destination does not have appropriate " +
+                    "read/write permissions.";
+            logger.log(Level.WARNING, message);
+        }
+    }
+}


### PR DESCRIPTION
## Purpose
>  Add **install-jars tool** to perform automatic OSGI conversions and bundling them in the **CARBON_HOME/lib** directory.

## Goals
> Support adding & updating third-party JARs to WSO2 Carbon Server.

## Approach
> Below is the flow followed while installing the JARs in the WSO2 Server.
1. Creates a backup at **CARBON_HOME/_lib** and backup all the bundles in the **CARBON_HOME/lib** directory.
2. Converts the Jars inside **CARBON_HOME/jars** directory as OSGI bundles and copy them to **CARBON_HOME/lib** directory and writes the last directory updated timestamp to a meta file at **CARBON_HOME/.meta**
3. Copies the bundles in the **CARBON_HOME/bundles** directory to **CARBON_HOME/lib** directory and writes the last directory updated timestamp to a meta file at **CARBON_HOME/.meta**
5.  When the **CARBON_HOME/jars** or/and **CARBON_HOME/bundles** directory is updated,  the default **CARBON_HOME/lib** is restored and the JAR installation process is performed again.