### PR TITLE
Check whether directories are not empty during first run

### DIFF
--- a/tools/tools-core/src/main/java/org/wso2/carbon/tools/InstallJarsTool.java
+++ b/tools/tools-core/src/main/java/org/wso2/carbon/tools/InstallJarsTool.java
@@ -98,7 +98,8 @@ public class InstallJarsTool implements CarbonTool {
                     isReverted = true;
                 }
 
-                if (jars != null && (isJarDirectoryUpdated || !jarMetaFile.exists() || isReverted)) {
+                if (jars != null && (isJarDirectoryUpdated || (!jarMetaFile.exists() && jars.length > 0)
+                        || isReverted)) {
                     backupLibDirectory(outputDir);
                     for (File jar : jars) {
                         BundleGeneratorUtils.convertFromJarToBundle(
@@ -106,8 +107,9 @@ public class InstallJarsTool implements CarbonTool {
                     }
                     updateMetaFile(jarsDir, jarMetaFile);
                 }
-                if (bundles != null && (isJarDirectoryUpdated || !bundleMetaFile.exists()
+                if (bundles != null && (isJarDirectoryUpdated || (!bundleMetaFile.exists() && bundles.length > 0)
                         || isReverted)) {
+                    backupLibDirectory(outputDir);
                     for (File bundle : bundles) {
                         String bundleName = bundle.getName();
                         Matcher matcher = EXTRACT_JAR_NAME_PATTERN.matcher(bundleName);


### PR DESCRIPTION
## Purpose
> Update install-jars tool to check whether bundles and jars directories are not empty during first run.