### PR TITLE
Add unitOfWork pattern for handling database transaction

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/util/UnitOfWork.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/util/UnitOfWork.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.user.core.util;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.SQLException;
+
+/**
+ * Support class to implement Unit of work patter.
+ */
+public class UnitOfWork {
+
+    private static Log log = LogFactory.getLog(UnitOfWork.class);
+    private boolean errorOccurred = false;
+    private static ThreadLocal<UnitOfWorkTransactionContext> transactionContextThreadLocal = new ThreadLocal<>();
+
+    public UnitOfWork() {
+
+        super();
+    }
+
+    /**
+     * Begin the transaction process.
+     */
+    public static UnitOfWork beginTransaction() {
+
+        UnitOfWorkTransactionContext UnitOfWorkTransactionContext = transactionContextThreadLocal.get();
+        if (UnitOfWorkTransactionContext == null) {
+            UnitOfWorkTransactionContext = new UnitOfWorkTransactionContext();
+            transactionContextThreadLocal.set(UnitOfWorkTransactionContext);
+        }
+        UnitOfWorkTransactionContext.incrementTransactionDepth();
+        return new UnitOfWork();
+    }
+
+    /**
+     * Returns an database connection.
+     *
+     * @param dataSource dataSource of the connection.
+     * @return current connection
+     * @throws SQLException
+     * @Deprecated The getDBConnection should handle both transaction and non-transaction connection. Earlier it
+     * handle only the transactionConnection. Therefore this method was deprecated and changed as handle both
+     * transaction and non-transaction connection. getDBConnection(DataSource dataSource, boolean autoCommit) method
+     * used as alternative of this method.
+     */
+    @Deprecated
+    public Connection getDBConnection(DataSource dataSource) throws SQLException {
+
+        return getDBConnection(dataSource, true);
+    }
+
+    /**
+     * Returns an database connection.
+     *
+     * @param dataSource dataSource of the connection.
+     * @param autoCommit autocommit state of the connection.
+     * @return current connection
+     * @throws SQLException
+     */
+    public Connection getDBConnection(DataSource dataSource, boolean autoCommit) throws SQLException {
+
+        UnitOfWorkTransactionContext unitOfWorkTransactionContext = transactionContextThreadLocal.get();
+        if (unitOfWorkTransactionContext == null) {
+            throw new UnitOfWorkException("There is no transaction getting started");
+        }
+        Connection connection = unitOfWorkTransactionContext.getDBConnection(dataSource);
+
+        if (!autoCommit) {
+            //We need only set "autocommit==false", which indicate start of database transaction.
+            connection.setAutoCommit(autoCommit);
+        }
+        return connection;
+    }
+
+    /**
+     * End the transaction by committing to the transaction.
+     */
+    public void commitTransaction() {
+
+        try {
+            UnitOfWorkTransactionContext unitOfWorkTransactionContext = transactionContextThreadLocal.get();
+            if (unitOfWorkTransactionContext == null) {
+                throw new UnitOfWorkException("There is no transaction getting started");
+
+            }
+            unitOfWorkTransactionContext.decrementTransactionDepth();
+            if (unitOfWorkTransactionContext.getTransactionDepth() == 0 && !errorOccurred) {
+                unitOfWorkTransactionContext.commitAllConnection();
+            }
+        } catch (SQLException e) {
+            log.error("Error occurred while commit connection", e);
+        }
+    }
+
+    /**
+     * Revoke the transaction when catch then sql transaction errors.
+     */
+    public void rollbackTransaction() {
+
+        try {
+            errorOccurred = true;
+            UnitOfWorkTransactionContext unitOfWorkTransactionContext = transactionContextThreadLocal.get();
+            if (unitOfWorkTransactionContext == null) {
+                throw new UnitOfWorkException("There is no transaction getting started");
+
+            }
+            unitOfWorkTransactionContext.decrementTransactionDepth();
+            if (unitOfWorkTransactionContext.getTransactionDepth() == 0 && errorOccurred) {
+                unitOfWorkTransactionContext.rollbackAllConnection();
+            }
+        } catch (SQLException e) {
+            log.error("Error occurred while rollback connection", e);
+        }
+
+    }
+
+    /**
+     * close all the remaining transaction and the connections
+     */
+    public void closeTransaction() {
+
+        try {
+            UnitOfWorkTransactionContext unitOfWorkTransactionContext = transactionContextThreadLocal.get();
+            if (unitOfWorkTransactionContext == null) {
+                throw new UnitOfWorkException("There is no transaction getting started");
+            }
+            unitOfWorkTransactionContext.closeConnection();
+            transactionContextThreadLocal.remove();
+
+        } catch (SQLException e) {
+            log.error("Error occurred while close all the transaction and connection", e);
+        }
+    }
+
+}

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/util/UnitOfWorkException.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/util/UnitOfWorkException.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.user.core.util;
+
+import java.sql.SQLException;
+
+public class UnitOfWorkException extends SQLException {
+
+    public UnitOfWorkException() {
+        super();
+    }
+
+    public UnitOfWorkException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public UnitOfWorkException(String message, boolean convertMessage) {
+        super(message);
+    }
+
+    public UnitOfWorkException(String message) {
+        super(message);
+    }
+
+    public UnitOfWorkException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/util/UnitOfWorkException.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/util/UnitOfWorkException.java
@@ -19,6 +19,9 @@ package org.wso2.carbon.user.core.util;
 
 import java.sql.SQLException;
 
+/**
+ * Support class to handle the exceptions throw by the Unit of work patten.
+ */
 public class UnitOfWorkException extends SQLException {
 
     public UnitOfWorkException() {

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/util/UnitOfWorkTransactionContext.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/util/UnitOfWorkTransactionContext.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.user.core.util;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import javax.sql.DataSource;
+
+public class UnitOfWorkTransactionContext {
+
+    private static Log log = LogFactory.getLog(UnitOfWorkTransactionContext.class);
+    private HashMap<DataSource, Connection> activeConnection = new HashMap();
+    private int transactionDepth = 0;
+
+    /**
+     * Commit all the transaction, if something happened at the middle then it print all the commit and uncommitted
+     * transaction.
+     */
+    public void commitAllConnection() {
+
+        List<DataSource> listOfDataSource = new ArrayList<>();
+        for (DataSource dataSource : activeConnection.keySet()) {
+            try {
+                Connection connection = activeConnection.get(dataSource);
+                if (connection != null) {
+                    listOfDataSource.add(dataSource);
+                    connection.commit();
+                }
+            } catch (SQLException e) {
+
+                log.error("Error occurred while committing the connection. Connection: " + activeConnection
+                        .get(dataSource) + ". We have committed few transaction before error occurs. Committed "
+                        + "dataSource are: " + listOfDataSource.toString(), e);
+            }
+        }
+    }
+
+    /**
+     * Rollback all the transaction, if something happened at the middle then it will continue and rollback all the
+     * connection as much as possible.
+     */
+    public void rollbackAllConnection() {
+        for (DataSource dataSource : activeConnection.keySet()) {
+            try {
+                Connection connection = activeConnection.get(dataSource);
+                if (connection != null) {
+                    connection.rollback();
+                }
+            } catch (SQLException e) {
+                log.error("Error occurred while rollback the connection for dataSource: " + dataSource, e);
+                continue;
+            }
+        }
+    }
+
+    /**
+     * Set and return the connection.
+     *
+     * @param dataSource dataSource of the connection
+     * @return the current connection
+     * @throws SQLException
+     */
+    public Connection getDBConnection(DataSource dataSource) throws SQLException {
+
+        Connection currentConnectionForDataSource = activeConnection.get(dataSource);
+        if (currentConnectionForDataSource == null) {
+            currentConnectionForDataSource = dataSource.getConnection();
+            activeConnection.put(dataSource, currentConnectionForDataSource);
+        }
+        return currentConnectionForDataSource;
+    }
+
+    /**
+     * Get the transaction level.
+     *
+     * @return transaction level
+     */
+    public int getTransactionDepth() {
+
+        return transactionDepth;
+    }
+
+    /**
+     * Increment the transaction depth by one to store the level of a transaction.
+     */
+    public void incrementTransactionDepth() {
+
+        transactionDepth++;
+    }
+
+    /**
+     * Decrement the transaction depth by one to notice the remaining levels of a transaction.
+     */
+    public void decrementTransactionDepth() {
+
+        transactionDepth--;
+    }
+
+    /**
+     * Close all the db connection.
+     */
+    public void closeConnection() {
+
+        for (DataSource dataSource : activeConnection.keySet()) {
+            Connection connection = activeConnection.get(dataSource);
+            try {
+                connection.close();
+            } catch (SQLException e) {
+                log.error("Error occurred while close the connection:  " + connection, e);
+                continue;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Purpose
Currently, we are maintaining JDBC transaction using connection.commit() to commit the SQL statements and if either one of the SQL statement within the transaction block is failed, abort and rollback everything using the connection.rollback() within transaction block.
Multiple time we are starting a transaction and commit/rollback it to end the transaction within a method. We notice that rather than execute the SQL statement it will take more time to commit the transaction. Therefore when we start the transaction in multiple places, it will take more execution time and increase the concurrent issue. To overcome this kind of issue we plan to apply the UnitOfWork design pattern and restructure the JDBC transaction.
When we apply UnitOfWork design pattern, First it will maintain a list of objects in-memory which have been changed (SQL operation) during a transaction then once all the transaction is completed, all these updates are sent as one unit of work to be persisted physically and commit it as a single transaction. If something happens within this internal commit process then it will rollback all the action taken within that unit of work.

## Approach
Whenever the user wants to get the database connection he can call getDBConnection() to get their connection and when he gets the connection, the backend will maintain a map with connection and data source. 
At the same time, the user can start the transaction by calling beginTransaction(). It will start the create a new threatLocal and increase the transaction depth count. He can able to create multiple transactions within the same method. 
In the end, he can end the transaction by calling commitTransaction()/rollbackTransaction(). it will decrease the transaction depth count. When the transaction depth count is getting zero it will commit or rollback all connection maintained by the threadLocal. 
Finally we can call closeTransaction() to close all the threatLocal and database connections.
eg : 
-->begin new Transaction 1 (depth =0 => 0+1)
                              --> begin new Transaction 2 (depth =1 => 1+1)
                                                                    --> begin new Transaction3 (depth =2 => 2+1)
                                                                     ---------------
                                                                    <-- end the Transaction 3 (depth =2 => 3-1)
                               <--end the Transaction 2 (depth =1 => 2-1)
--> end the Transaction 1 (depth =0 => 1-1) ( this is the place the actual commit / rolback occurs)
--> finally close all the threatLocal and connections.




