### PR TITLE
Set pax-logging start level to three

### DIFF
--- a/distribution/kernel/carbon.product
+++ b/distribution/kernel/carbon.product
@@ -21,6 +21,9 @@ version="4.5.0.SNAPSHOT" useFeatures="true" includeLaunchers="true">
       <plugin id="org.eclipse.core.runtime" autoStart="true" startLevel="4" />
       <plugin id="org.eclipse.equinox.common" autoStart="true" startLevel="2" />
       <plugin id="org.eclipse.equinox.ds" autoStart="true" startLevel="2" />
+      <plugin id="org.ops4j.pax.logging.pax-logging-api" autoStart="true" startLevel="3" />
+      <plugin id="org.ops4j.pax.logging.pax-logging-log4j2" autoStart="true" startLevel="3" />
+      <plugin id="org.wso2.carbon.pax-logging-log4j2-plugins" autoStart="true" startLevel="3" />
       <plugin id="org.eclipse.equinox.p2.reconciler.dropins" autoStart="true" startLevel="4" />
       <plugin id="org.eclipse.equinox.simpleconfigurator" autoStart="true" startLevel="1" />
       


### PR DESCRIPTION
## Purpose
Set pax-logging start level to three

## Goals
Make all logs to be routed to pax logging

## Approach
Set pax-logging start level to three

## User stories
N/A

## Release note
N/A

## Documentation
N/A

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
N/A

## Security checks
N/A

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
N/A
 
## Learning
N/A