### PR TITLE
Cluster cache invalidation for AuthenticationContextCache is not properly working

### DIFF
--- a/core/javax.cache/src/main/java/org/wso2/carbon/caching/impl/clustering/ClusterCacheInvalidationRequestSender.java
+++ b/core/javax.cache/src/main/java/org/wso2/carbon/caching/impl/clustering/ClusterCacheInvalidationRequestSender.java
@@ -27,6 +27,7 @@ import org.wso2.carbon.caching.impl.DataHolder;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 
+import javax.cache.event.CacheEntryCreatedListener;
 import javax.cache.event.CacheEntryEvent;
 import javax.cache.event.CacheEntryListenerException;
 import javax.cache.event.CacheEntryRemovedListener;
@@ -39,7 +40,8 @@ import javax.cache.event.CacheEntryUpdatedListener;
  * This is feature intended only when separate local caches are maintained by each node
  * in the cluster.
  */
-public class ClusterCacheInvalidationRequestSender implements CacheEntryRemovedListener, CacheEntryUpdatedListener {
+public class ClusterCacheInvalidationRequestSender implements CacheEntryRemovedListener, CacheEntryUpdatedListener,
+        CacheEntryCreatedListener {
 
     private static final Log log = LogFactory.getLog(ClusterCacheInvalidationRequestSender.class);
 
@@ -50,6 +52,11 @@ public class ClusterCacheInvalidationRequestSender implements CacheEntryRemovedL
 
     @Override
     public void entryUpdated(CacheEntryEvent event) throws CacheEntryListenerException {
+        send(event);
+    }
+
+    @Override
+    public void entryCreated(CacheEntryEvent event) throws CacheEntryListenerException {
         send(event);
     }
 


### PR DESCRIPTION
issue: wso2/product-is#6179

There is a two-node IS cluster by enabling forceLocalCache and temporary data persistent as well. There we have two auth steps, basic and TOTP. Then I send requests as follows

Step1:- node1: authorize GET request
Step2:- node2: common-auth POST for basic auth
Step3:- node1: common-auth POST for TOTP

But the flow breaks at the 3rd step and node1 throws following.

ERROR {org.wso2.carbon.identity.application.authentication.framework.handler.request.impl.DefaultRequestCoordinator} -  Exception in Authentication Framework
org.wso2.carbon.identity.application.authentication.framework.exception.FrameworkException: No authenticator can handle the request in step :  1
The issue is occurring due to the AuthenticationContextCache of node1 is not getting invalidate while we complete the basic authentication step in the node2. At the 3rd step, node1 still have an old context in the cache and it tries to authenticate the user for the first authentication step. Because Node1 does not receive any cache invalidation message when the other node completes the basic auth step. If disable "AuthenticationContextCache", everything works fine.

Note the three methods put(), notifyCacheEntryCreated() and notifyCacheEntryUpdated() in CacheImpl [1]. If the entry is already in the cache it goes to notifyCacheEntryUpdated() otherwise it goes to notifyCacheEntryCreated().

In our case, when the second request goes to node2, it directly reads the context from DB and tries to put the updated context into the cache. Since the context is not available in its local cache, it goes to notifyCacheEntryCreated(). There we check for "cacheEntryListener instanceof CacheEntryCreatedListener". Here the cacheEntryListener is "ClusterCacheInvalidationRequestSender" [2]. This check fails because it does not implement "CacheEntryCreatedListener".
When we try to implement "ClusterCacheInvalidationRequestSender" to "CacheEntryCreatedListener" then the flow worked fine.