### PR TITLE
Fix error when trying out deploy tenant client out service with same name when multiple tenants exists

### DIFF
--- a/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/internal/MultitenantTransportOutServiceComponent.java
+++ b/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/internal/MultitenantTransportOutServiceComponent.java
@@ -1,0 +1,108 @@
+/*
+ *  Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.core.internal;
+
+import org.apache.axis2.AxisFault;
+import org.apache.axis2.context.ConfigurationContext;
+import org.apache.axis2.description.AxisService;
+import org.apache.axis2.description.AxisServiceGroup;
+import org.apache.axis2.description.InOutAxisOperation;
+import org.apache.axis2.description.OutOnlyAxisOperation;
+import org.apache.axis2.engine.AxisConfiguration;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.wso2.carbon.CarbonConstants;
+import org.wso2.carbon.core.multitenancy.MultitenantMessageReceiver;
+import org.wso2.carbon.utils.ConfigurationContextService;
+import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
+
+/**
+ * This service component is responsible for loading the `tenantOutClientService` Axis2 service and two operations for
+ * that service which is used in sending the message out in tenant mode.
+ * The Two operations are In-Out axis operation and Out-Only operation. The operation context for
+ * the individual requests will be set dynamically in the TenantTransportSender.invoke() method depending on the
+ * incoming msgContext message exchange pattern. Same operation will be shared only with the similar MEPs.
+ */
+@Component(name = "org.wso2.carbon.core.internal.MultitenantTransportOutServiceComponent", immediate = true)
+public class MultitenantTransportOutServiceComponent {
+
+    private static final Log log = LogFactory.getLog(MultitenantTransportOutServiceComponent.class);
+    private ConfigurationContext configCtx;
+
+    protected void activate(ComponentContext context) {
+        try {
+            deployMultiTenantClientOutService(configCtx.getAxisConfiguration());
+        } catch (AxisFault axisFault) {
+            log.error("Failed to activate the MultitenantTransportOutServiceComponent", axisFault);
+        }
+    }
+
+    protected void deactivate(ComponentContext context) {
+    }
+
+    /**
+     * In this method, We create a new Axis2 service named `tenantClientService` with two operations OUT_ONLY_OPERATION
+     * and IN_OUT_OPERATION. This
+     * service is added to the super tenant's configuration context. This service is used by TenantTransportSender
+     * when sending messages out from the axis engine.
+     * server.
+     *
+     * @param axisCfg Super Tenant's axis configurations
+     * @throws AxisFault
+     */
+    private void deployMultiTenantClientOutService(AxisConfiguration axisCfg) throws AxisFault {
+        AxisServiceGroup superTenantSenderServiceGroup = new AxisServiceGroup(axisCfg);
+        superTenantSenderServiceGroup.setServiceGroupName(MultitenantConstants.MULTITENANT_CLIENT_OUT_SERVICE);
+        AxisService superTenantSenderClientService = new AxisService(MultitenantConstants.MULTITENANT_CLIENT_OUT_SERVICE);
+        superTenantSenderClientService.addParameter(CarbonConstants.HIDDEN_SERVICE_PARAM_NAME, "true");
+        superTenantSenderServiceGroup.addService(superTenantSenderClientService);
+
+        superTenantSenderClientService.addOperation(new InOutAxisOperation(
+                MultitenantConstants.MULTITENANT_CLIENT_SERVICE_IN_OUT_OPERATION));
+        superTenantSenderClientService.getOperation(MultitenantConstants.MULTITENANT_CLIENT_SERVICE_IN_OUT_OPERATION)
+                .setMessageReceiver(new MultitenantMessageReceiver());
+
+        superTenantSenderClientService.addOperation(new OutOnlyAxisOperation(
+                MultitenantConstants.MULTITENANT_CLIENT_SERVICE_OUT_ONLY_OPERATION));
+        superTenantSenderClientService.getOperation(MultitenantConstants.MULTITENANT_CLIENT_SERVICE_OUT_ONLY_OPERATION)
+                .setMessageReceiver(new MultitenantMessageReceiver());
+        axisCfg.addServiceGroup(superTenantSenderServiceGroup);
+
+        superTenantSenderClientService.setClientSide(true);
+        if (log.isDebugEnabled()) {
+            log.debug("Deployed " + MultitenantConstants.MULTITENANT_CLIENT_OUT_SERVICE);
+        }
+    }
+
+    @Reference(name = "org.wso2.carbon.configCtx", cardinality = ReferenceCardinality.MANDATORY, policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetConfigurationContext")
+    protected void setConfigurationContext(ConfigurationContextService configCtx) {
+        this.configCtx = configCtx.getServerConfigContext();
+    }
+
+    protected void unsetConfigurationContext(ConfigurationContextService configCtx) {
+        this.configCtx = null;
+    }
+
+}

--- a/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/multitenancy/MultitenantConstants.java
+++ b/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/multitenancy/MultitenantConstants.java
@@ -25,6 +25,9 @@ public class MultitenantConstants {
 
     public static final String MULTITENANT_DISPATCHER_SERVICE = "__MultitenantDispatcherService";
     public static final QName MULTITENANT_DISPATCHER_OPERATION = new QName("dispatch");
+    public static final String MULTITENANT_CLIENT_OUT_SERVICE = "tenantClientService";
+    public static final QName MULTITENANT_CLIENT_SERVICE_IN_OUT_OPERATION = new QName("anonInOutOp");
+    public static final QName MULTITENANT_CLIENT_SERVICE_OUT_ONLY_OPERATION = new QName("anonOutonlyOp");
 
     public static final String TENANT_MR_STARTED_FAULT = "tenantMRStartedFault";
     public static final String TENANT_DOMAIN = "tenantDomain";


### PR DESCRIPTION
## Purpose
When multiple tenants are there 2 or more, after the first tenant is loaded, when trying to load the second tenant, the service registration of tenantOutClientService fails as the same service name is used.

```
[2019-09-20 16:29:13,054] ERROR - TenantTransportSender Error while setting up tenant client out service in TenantTransportSender
org.apache.axis2.AxisFault: Two services cannot have same name.  A service with the tenantClientService [null] name already exists in the system.
	at org.apache.axis2.engine.AxisConfiguration.addToAllServicesMap(AxisConfiguration.java:510)
	at org.apache.axis2.description.AxisServiceGroup.addService(AxisServiceGroup.java:110)
	at org.wso2.carbon.core.multitenancy.transports.TenantTransportSender.setupTenantClientOutService(TenantTransportSender.java:332)
	at org.wso2.carbon.core.multitenancy.transports.TenantTransportSender.<init>(TenantTransportSender.java:80)
	at org.wso2.carbon.core.multitenancy.utils.TenantAxisUtils.createTenantConfigurationContext(TenantAxisUtils.java:328)
	at org.wso2.carbon.core.multitenancy.utils.TenantAxisUtils.getTenantConfigurationContext(TenantAxisUtils.java:148)
	at org.wso2.carbon.core.services.util.CarbonAuthenticationUtil.onSuccessAdminLogin(CarbonAuthenticationUtil.java:120)
	at org.wso2.carbon.core.services.authentication.AuthenticationAdmin.login(AuthenticationAdmin.java:119)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.apache.axis2.rpc.receivers.RPCUtil.invokeServiceClass(RPCUtil.java:212)
	at org.apache.axis2.rpc.receivers.RPCMessageReceiver.invokeBusinessLogic(RPCMessageReceiver.java:117)
	at org.apache.axis2.receivers.AbstractInOutMessageReceiver.invokeBusinessLogic(AbstractInOutMessageReceiver.java:40)
	at org.apache.axis2.receivers.AbstractMessageReceiver.receive(AbstractMessageReceiver.java:110)
	at org.apache.axis2.engine.AxisEngine.receive(AxisEngine.java:180)
	at org.apache.axis2.transport.local.LocalTransportReceiver.processMessage(LocalTransportReceiver.java:170)
	at org.apache.axis2.transport.local.LocalTransportReceiver.processMessage(LocalTransportReceiver.java:82)
	at org.wso2.carbon.core.transports.local.CarbonLocalTransportSender.finalizeSendWithToAddress(CarbonLocalTransportSender.java:45)
	at org.apache.axis2.transport.local.LocalTransportSender.invoke(LocalTransportSender.java:77)
	at org.apache.axis2.engine.AxisEngine.send(AxisEngine.java:442)
	at org.apache.axis2.description.OutInAxisOperationClient.send(OutInAxisOperation.java:442)
	at org.apache.axis2.description.OutInAxisOperationClient.executeImpl(OutInAxisOperation.java:228)
	at org.apache.axis2.client.OperationClient.execute(OperationClient.java:149)
	at org.wso2.carbon.authenticator.stub.AuthenticationAdminStub.login(AuthenticationAdminStub.java:1343)
	at org.wso2.carbon.authenticator.proxy.AuthenticationAdminClient.login(AuthenticationAdminClient.java:66)
	at org.wso2.carbon.ui.DefaultCarbonAuthenticator.doAuthentication(DefaultCarbonAuthenticator.java:119)
	at org.wso2.carbon.ui.AbstractCarbonUIAuthenticator.handleSecurity(AbstractCarbonUIAuthenticator.java:218)
	at org.wso2.carbon.ui.BasicAuthUIAuthenticator.authenticate(BasicAuthUIAuthenticator.java:83)
	at org.wso2.carbon.ui.CarbonUILoginUtil.handleLogin(CarbonUILoginUtil.java:405)
	at org.wso2.carbon.ui.CarbonSecuredHttpContext.handleSecurity(CarbonSecuredHttpContext.java:246)
	at org.eclipse.equinox.http.servlet.internal.ServletRegistration.service(ServletRegistration.java:60)
	at org.eclipse.equinox.http.servlet.internal.ProxyServlet.processAlias(ProxyServlet.java:128)
	at org.eclipse.equinox.http.servlet.internal.ProxyServlet.service(ProxyServlet.java:68)
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:731)
	at org.wso2.carbon.tomcat.ext.servlet.DelegationServlet.service(DelegationServlet.java:68)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:303)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:208)
	at org.apache.tomcat.websocket.server.WsFilter.doFilter(WsFilter.java:52)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:241)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:208)
	at org.owasp.csrfguard.CsrfGuardFilter.doFilter(CsrfGuardFilter.java:88)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:241)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:208)
	at org.apache.catalina.filters.HttpHeaderSecurityFilter.doFilter(HttpHeaderSecurityFilter.java:126)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:241)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:208)
	at org.wso2.carbon.tomcat.ext.filter.CharacterSetFilter.doFilter(CharacterSetFilter.java:65)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:241)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:208)
	at org.apache.catalina.filters.HttpHeaderSecurityFilter.doFilter(HttpHeaderSecurityFilter.java:126)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:241)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:208)
	at org.apache.catalina.core.StandardWrapperValve.invoke(StandardWrapperValve.java:219)
	at org.apache.catalina.core.StandardContextValve.invoke(StandardContextValve.java:110)
	at org.apache.catalina.authenticator.AuthenticatorBase.invoke(AuthenticatorBase.java:494)
	at org.apache.catalina.core.StandardHostValve.invoke(StandardHostValve.java:169)
	at org.apache.catalina.valves.ErrorReportValve.invoke(ErrorReportValve.java:104)
	at org.wso2.carbon.identity.context.rewrite.valve.TenantContextRewriteValve.invoke(TenantContextRewriteValve.java:80)
	at org.wso2.carbon.identity.authz.valve.AuthorizationValve.invoke(AuthorizationValve.java:100)
	at org.wso2.carbon.identity.auth.valve.AuthenticationValve.invoke(AuthenticationValve.java:65)
	at org.wso2.carbon.tomcat.ext.valves.CompositeValve.continueInvocation(CompositeValve.java:99)
	at org.wso2.carbon.tomcat.ext.valves.CarbonTomcatValve$1.invoke(CarbonTomcatValve.java:47)
	at org.wso2.carbon.webapp.mgt.TenantLazyLoaderValve.invoke(TenantLazyLoaderValve.java:57)
	at org.wso2.carbon.event.receiver.core.internal.tenantmgt.TenantLazyLoaderValve.invoke(TenantLazyLoaderValve.java:48)
	at org.wso2.carbon.tomcat.ext.valves.TomcatValveContainer.invokeValves(TomcatValveContainer.java:47)
	at org.wso2.carbon.tomcat.ext.valves.CompositeValve.invoke(CompositeValve.java:62)
	at org.wso2.carbon.tomcat.ext.valves.CarbonStuckThreadDetectionValve.invoke(CarbonStuckThreadDetectionValve.java:159)
	at org.apache.catalina.valves.AccessLogValve.invoke(AccessLogValve.java:1025)
	at org.wso2.carbon.tomcat.ext.valves.CarbonContextCreatorValve.invoke(CarbonContextCreatorValve.java:57)
	at org.wso2.carbon.tomcat.ext.valves.RequestCorrelationIdValve.invoke(RequestCorrelationIdValve.java:112)
	at org.apache.catalina.core.StandardEngineValve.invoke(StandardEngineValve.java:116)
	at org.apache.catalina.connector.CoyoteAdapter.service(CoyoteAdapter.java:445)
	at org.apache.coyote.http11.AbstractHttp11Processor.process(AbstractHttp11Processor.java:1137)
	at org.apache.coyote.AbstractProtocol$AbstractConnectionHandler.process(AbstractProtocol.java:637)
	at org.apache.tomcat.util.net.NioEndpoint$SocketProcessor.doRun(NioEndpoint.java:1780)
	at org.apache.tomcat.util.net.NioEndpoint$SocketProcessor.run(NioEndpoint.java:1739)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at org.apache.tomcat.util.threads.TaskThread$WrappingRunnable.run(TaskThread.java:61)
	at java.lang.Thread.run(Thread.java:748)
```

## Goals
Add MultitenantTransportOutServiceComponent to deploy tenantOutClientService axis2 service and in-out, out-only operations( which sends messages out in tenant mode).
Set relevant axis operation context dynamically in TenantTransportSender based on message incoming pattern.

## Release Notes
Fix bug https://github.com/wso2/product-apim/issues/4641

## Related PRs
Follow up fix for https://github.com/wso2/carbon-kernel/pull/2050