### PR TITLE
skip role check when user is wso2.anonymous.user and resource allowed role list has SYSTEM/wso2.anonymous role.

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/authorization/JDBCAuthorizationManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/authorization/JDBCAuthorizationManager.java
@@ -296,6 +296,14 @@ public class JDBCAuthorizationManager implements AuthorizationManager {
                 AbstractUserStoreManager manager = (AbstractUserStoreManager) userRealm.getUserStoreManager();
                 for (String role : allowedRoles) {
                     try {
+                        if (CarbonConstants.REGISTRY_ANONNYMOUS_USERNAME.equalsIgnoreCase(userName)) {
+                            if (CarbonConstants.REGISTRY_ANONNYMOUS_ROLE_NAME.equalsIgnoreCase(role)) {
+                                userAllowed = true;
+                                break;
+                            } else {
+                                continue;
+                            }
+                        }
                         if (manager.isUserInRole(userName, role)) {
                             if (log.isDebugEnabled()) {
                                 log.debug(userName + " user is in role :  " + role);


### PR DESCRIPTION
## Purpose
When checking the roles for wso2.anonymous.user, we need to check whether the roles list of the resource has "SYSTEM/wso2.anonymous" role and if the user is "wso2.anonymous.user", we should allow access and skip checking the other roles and return.

## Release note
Fix https://github.com/wso2/product-apim/issues/5008
