### PR TITLE
Fix JMS attribute issue in master datasource

### DIFF
--- a/distribution/kernel/carbon-home/repository/resources/conf/templates/repository/conf/datasources/master-datasources.xml.j2
+++ b/distribution/kernel/carbon-home/repository/resources/conf/templates/repository/conf/datasources/master-datasources.xml.j2
@@ -42,7 +42,9 @@
                     {% for property_name,property_value in database.shared_db.pool_options.items() %}
                     <{{property_name}}>{{property_value}}</{{property_name}}>
                         {% endfor %}
+                    {% if database.shared_db.jmx_enable is defined %}
                     <jmxEnabled>{{database.shared_db.jmx_enable}}</jmxEnabled>
+                    {% endif %}
                  </configuration>
             </definition>
         </datasource>
@@ -63,7 +65,9 @@
                     {% for property_name,property_value in database.user.pool_options.items() %}
                     <{{property_name}}>{{property_value}}</{{property_name}}>
                         {% endfor %}
+                    {% if database.user.jmx_enable is defined %}
                     <jmxEnabled>{{database.user.jmx_enable}}</jmxEnabled>
+                    {% endif %}
                  </configuration>
             </definition>
         </datasource>
@@ -85,7 +89,9 @@
                     {% for property_name,property_value in database.config.pool_options.items() %}
                     <{{property_name}}>{{property_value}}</{{property_name}}>
                         {% endfor %}
+                    {% if database.config.jmx_enable is defined %}
                     <jmxEnabled>{{database.config.jmx_enable}}</jmxEnabled>
+                    {% endif %}
                  </configuration>
             </definition>
         </datasource>
@@ -107,7 +113,9 @@
                     {% for property_name,property_value in data.pool_options.items() %}
                      <{{property_name}}>{{property_value}}</{{property_name}}>
                     {% endfor %}
+                    {% if data.jmx_enable is defined %}
                      <jmxEnabled>{{data.jmx_enable}}</jmxEnabled>
+                    {% endif %}
                 </configuration>
             </definition>
         </datasource>


### PR DESCRIPTION
## Purpose
Disable JMS monitoring section from master-datasource.xml, if it is not defined.