### PR TITLE
Fix tenantClientService become faulty in server startup

### DIFF
--- a/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/internal/MultitenantTransportOutServiceComponent.java
+++ b/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/internal/MultitenantTransportOutServiceComponent.java
@@ -37,6 +37,9 @@ import org.wso2.carbon.core.multitenancy.MultitenantMessageReceiver;
 import org.wso2.carbon.utils.ConfigurationContextService;
 import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 
+import java.util.Arrays;
+import java.util.List;
+
 /**
  * This service component is responsible for loading the `tenantOutClientService` Axis2 service and two operations for
  * that service which is used in sending the message out in tenant mode.
@@ -90,6 +93,8 @@ public class MultitenantTransportOutServiceComponent {
         axisCfg.addServiceGroup(superTenantSenderServiceGroup);
 
         superTenantSenderClientService.setClientSide(true);
+        List exposedTransportList = Arrays.asList("http","https","local");
+        superTenantSenderClientService.setExposedTransports(exposedTransportList);
         if (log.isDebugEnabled()) {
             log.debug("Deployed " + MultitenantConstants.MULTITENANT_CLIENT_OUT_SERVICE);
         }

--- a/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/multitenancy/transports/TenantTransportSender.java
+++ b/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/multitenancy/transports/TenantTransportSender.java
@@ -73,6 +73,7 @@ public class TenantTransportSender extends AbstractHandler implements TransportS
         try {
             this.superTenantSenderClientService = superTenantConfigurationContext.getAxisConfiguration()
                     .getService(MultitenantConstants.MULTITENANT_CLIENT_OUT_SERVICE);
+            this.superTenantSenderClientService.setEnableAllTransports(true);
         } catch (AxisFault axisFault) {
             log.error("Can't find the " + MultitenantConstants.MULTITENANT_CLIENT_OUT_SERVICE + " service!", axisFault);
         }


### PR DESCRIPTION

## Purpose
Axis2 service tenantClientService becomes faulty in server startup,due to this the APIs deployed in tenants cannot be invoked. The reason for this is tenantClientService uses the SuperTenants
Axis2 Configuration so VFS listener is added to transport-ins but the required parameters are not defined.
Fix this by setting exposed transports until transport initialization in tenantClientService and then in tenantLoading state add allTransports.

Fixes: https://github.com/wso2/product-ei/issues/4730
