### PR TITLE
Fix default value overriding issue

### DIFF
--- a/distribution/kernel/carbon-home/repository/resources/conf/default.json
+++ b/distribution/kernel/carbon-home/repository/resources/conf/default.json
@@ -6,14 +6,12 @@
   "server.file_upload.file_size_limit": "100",
   "user_store.type": "database",
   "super_admin.admin_role": "admin",
-  "authorization_manager": {
-    "class": "org.wso2.carbon.user.core.authorization.JDBCAuthorizationManager",
-    "properties": {
-      "AdminRoleManagementPermissions": "/permission",
-      "AuthorizationCacheEnabled": "true",
-      "GetAllRolesOfUserEnabled": "false"
-    }
-  },
+
+  "authorization_manager.class": "org.wso2.carbon.user.core.authorization.JDBCAuthorizationManager",
+  "authorization_manager.properties.AdminRoleManagementPermissions": "/permission",
+  "authorization_manager.properties.AuthorizationCacheEnabled": true,
+  "authorization_manager.properties.GetAllRolesOfUserEnabled": false,
+
   "realm_manager": {
     "data_source": "SHARED_DB",
     "properties": {
@@ -174,9 +172,8 @@
   "tasks.server_password": "admin",
   "tasks.resolver_class": "org.wso2.carbon.ntask.core.impl.RoundRobinTaskLocationResolver",
   "server.base_path" : "${carbon.protocol}://${carbon.host}:${carbon.management.port}",
-  "system.parameter": {
-    "org.wso2.CipherTransformation": "RSA/ECB/OAEPwithSHA1andMGF1Padding"
-  },
+
+  "system.parameter.'org.wso2.CipherTransformation'": "RSA/ECB/OAEPwithSHA1andMGF1Padding",
 
   "admin_service.wsdl.enable": false,
   "monitoring.jmx.rmi_registry_port": "9999",

--- a/distribution/kernel/carbon-home/repository/resources/conf/key-mappings.json
+++ b/distribution/kernel/carbon-home/repository/resources/conf/key-mappings.json
@@ -79,6 +79,10 @@
   "user_store.kdc_enabled": "user_store.properties.kdcEnabled",
   "user_store.membership_attribute_range": "user_store.properties.MembershipAttributeRange",
 
+  "authorization_manager.admin_role_management_permissions": "authorization_manager.properties.AdminRoleManagementPermissions",
+  "authorization_manager.enable_authorization_cache": "authorization_manager.properties.AuthorizationCacheEnabled",
+  "authorization_manager.get_all_roles_user_enable": "authorization_manager.properties.GetAllRolesOfUserEnabled",
+
   "transport.https.properties.certificate_verification": "transport.https.sslHostConfig.properties.certificateVerification",
   "transport.https.properties.protocols": "transport.https.sslHostConfig.properties.protocols",
   "transport.https.properties.ssl_protocol": "transport.https.sslHostConfig.properties.sslProtocol",


### PR DESCRIPTION
## Purpose
- Fix default value overriding issue in config mapper
Related issues https://github.com/wso2/config-mapper/issues/11
- Add new mapping for the authorization manager as follows(previous configuration can be used as it is).
```toml
[authorization_manager]
class = "org.wso2.micro.integrator.security.user.core.authorization.JDBCAuthorizationManager"   # inferred
admin_role_management_permissions = "/permission"   # inferred
enable_authorization_cache = true                   # inferred
get_all_roles_user_enable = false                   # inferred
```