### PR TITLE
Add support for converting jars required for Oracle CDC

### DIFF
--- a/features/org.wso2.carbon.server.feature/resources/bin/ba-provider.bat
+++ b/features/org.wso2.carbon.server.feature/resources/bin/ba-provider.bat
@@ -1,0 +1,81 @@
+@echo off
+
+REM ---------------------------------------------------------------------------
+REM   Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+REM
+REM   Licensed under the Apache License, Version 2.0 (the "License");
+REM   you may not use this file except in compliance with the License.
+REM   You may obtain a copy of the License at
+REM
+REM   http://www.apache.org/licenses/LICENSE-2.0
+REM
+REM   Unless required by applicable law or agreed to in writing, software
+REM   distributed under the License is distributed on an "AS IS" BASIS,
+REM   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+REM   See the License for the specific language governing permissions and
+REM   limitations under the License.
+
+rem ----- if JAVA_HOME is not set we're not happy ------------------------------
+:checkJava
+
+if "%JAVA_HOME%" == "" goto noJavaHome
+if not exist "%JAVA_HOME%\bin\java.exe" goto noJavaHome
+goto checkServer
+
+:noJavaHome
+echo "You must set the JAVA_HOME variable before running CARBON."
+goto end
+
+rem ----- Only set CARBON_HOME if not already set ----------------------------
+:checkServer
+rem %~sdp0 is expanded pathname of the current script under NT with spaces in the path removed
+if "%CARBON_HOME%"=="" set CARBON_HOME=%~sdp0..
+SET curDrive=%cd:~0,1%
+SET wsasDrive=%CARBON_HOME:~0,1%
+if not "%curDrive%" == "%wsasDrive%" %wsasDrive%:
+
+rem find CARBON_HOME if it does not exist due to either an invalid value passed
+rem by the user or the %0 problem on Windows 9x
+if not exist "%CARBON_HOME%\bin\kernel-version.txt" goto noServerHome
+
+goto commandLifecycle
+
+:noServerHome
+echo CARBON_HOME is set incorrectly or CARBON could not be located. Please set CARBON_HOME.
+goto end
+
+:commandLifecycle
+goto findJdk
+
+:findJdk
+
+set CMD=RUN %*
+
+:checkJdk16
+"%JAVA_HOME%\bin\java" -version 2>&1 | findstr /r "1.[8]" >NUL
+IF ERRORLEVEL 1 goto unknownJdk
+goto jdk16
+
+:unknownJdk
+echo Starting WSO2 Carbon (in unsupported JDK)
+echo [ERROR] CARBON is supported only on JDK 1.8
+goto jdk16
+
+:jdk16
+goto runTool
+
+:runTool
+
+set CURRENT_DIR=%cd%
+
+cd %CARBON_HOME%\bin
+echo JAVA_HOME environment variable is set to %JAVA_HOME%
+echo CARBON_HOME environment variable is set to %CARBON_HOME%
+java -cp ".\*;..\bin\tools\*" -Dcarbon.home="%CARBON_HOME" -Dwso2.carbon.tool="ba-provider" org.wso2.carbon.tools.CarbonToolExecutor %1 %2 %3
+
+:end
+goto endlocal
+
+:endlocal
+
+:END

--- a/features/org.wso2.carbon.server.feature/resources/bin/ba-provider.sh
+++ b/features/org.wso2.carbon.server.feature/resources/bin/ba-provider.sh
@@ -1,0 +1,124 @@
+#!/bin/sh
+# ---------------------------------------------------------------------------
+#  Copyright (c) 2019, WSO7 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+# ----------------------------------------------------------------------------
+
+cygwin=false;
+darwin=false;
+os400=false;
+mingw=false;
+case "`uname`" in
+CYGWIN*) cygwin=true;;
+MINGW*) mingw=true;;
+OS400*) os400=true;;
+Darwin*) darwin=true
+        if [ -z "$JAVA_VERSION" ] ; then
+             JAVA_VERSION="CurrentJDK"
+           else
+             echo "Using Java version: $JAVA_VERSION"
+           fi
+           if [ -z "$JAVA_HOME" ] ; then
+             JAVA_HOME=/System/Library/Frameworks/JavaVM.framework/Versions/${JAVA_VERSION}/Home
+           fi
+           ;;
+esac
+
+# resolve links - $0 may be a softlink
+PRG="$0"
+
+while [ -h "$PRG" ]; do
+  ls=`ls -ld "$PRG"`
+  link=`expr "$ls" : '.*-> \(.*\)$'`
+  if expr "$link" : '.*/.*' > /dev/null; then
+    PRG="$link"
+  else
+    PRG=`dirname "$PRG"`/"$link"
+  fi
+done
+
+# Get standard environment variables
+PRGDIR=`dirname "$PRG"`
+
+# Only set CARBON_HOME if not already set
+[ -z "$CARBON_HOME" ] && CARBON_HOME=`cd "$PRGDIR/.." ; pwd`
+
+# For Cygwin, ensure paths are in UNIX format before anything is touched
+if $cygwin; then
+  [ -n "$JAVA_HOME" ] && JAVA_HOME=`cygpath --unix "$JAVA_HOME"`
+  [ -n "$CARBON_HOME" ] && CARBON_HOME=`cygpath --unix "$CARBON_HOME"`
+fi
+
+# For OS400
+if $os400; then
+  # Set job priority to standard for interactive (interactive - 6) by using
+  # the interactive priority - 6, the helper threads that respond to requests
+  # will be running at the same priority as interactive jobs.
+  COMMAND='chgjob job('$JOBNAME') runpty(6)'
+  system $COMMAND
+
+  # Enable multi threading
+  QIBM_MULTI_THREADED=Y
+  export QIBM_MULTI_THREADED
+fi
+
+# For Migwn, ensure paths are in UNIX format before anything is touched
+if $mingw ; then
+  [ -n "$CARBON_HOME" ] &&
+    CARBON_HOME="`(cd "$CARBON_HOME"; pwd)`"
+  [ -n "$JAVA_HOME" ] &&
+    JAVA_HOME="`(cd "$JAVA_HOME"; pwd)`"
+fi
+
+if [ -z "$JAVACMD" ] ; then
+  if [ -n "$JAVA_HOME"  ] ; then
+    if [ -x "$JAVA_HOME/jre/sh/java" ] ; then
+      # IBM's JDK on AIX uses strange locations for the executables
+      JAVACMD="$JAVA_HOME/jre/sh/java"
+    else
+      JAVACMD="$JAVA_HOME/bin/java"
+    fi
+  else
+    JAVACMD=java
+  fi
+fi
+
+if [ ! -x "$JAVACMD" ] ; then
+  echo "Error: JAVA_HOME is not defined correctly."
+  echo " CARBON cannot execute $JAVACMD"
+  exit 1
+fi
+
+# if JAVA_HOME is not set we're not happy
+if [ -z "$JAVA_HOME" ]; then
+  echo "You must set the JAVA_HOME variable before running CARBON."
+  exit 1
+fi
+
+jdk_18=`$JAVA_HOME/bin/java -version 2>&1 | grep "1.[8]"`
+if [ "$jdk_18" = "" ]; then
+   echo " Starting WSO2 Carbon (in unsupported JDK)"
+   echo " [ERROR] CARBON is supported only on JDK 1.8"
+   exit 1
+fi
+
+echo JAVA_HOME environment variable is set to $JAVA_HOME
+echo CARBON_HOME environment variable is set to $CARBON_HOME
+
+# get the current directory from which the script is executed
+CURRENT_DIR=${PWD};
+
+cd "$CARBON_HOME/bin/";
+java -cp "../bin/tools/*" -Dcarbon.home="$CARBON_HOME" -Dwso2.carbon.tool="ba-provider" org.wso2.carbon.tools.CarbonToolExecutor $1 $2 $3

--- a/features/org.wso2.carbon.server.feature/resources/bin/jdbc-provider.bat
+++ b/features/org.wso2.carbon.server.feature/resources/bin/jdbc-provider.bat
@@ -1,0 +1,81 @@
+@echo off
+
+REM ---------------------------------------------------------------------------
+REM   Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+REM
+REM   Licensed under the Apache License, Version 2.0 (the "License");
+REM   you may not use this file except in compliance with the License.
+REM   You may obtain a copy of the License at
+REM
+REM   http://www.apache.org/licenses/LICENSE-2.0
+REM
+REM   Unless required by applicable law or agreed to in writing, software
+REM   distributed under the License is distributed on an "AS IS" BASIS,
+REM   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+REM   See the License for the specific language governing permissions and
+REM   limitations under the License.
+
+rem ----- if JAVA_HOME is not set we're not happy ------------------------------
+:checkJava
+
+if "%JAVA_HOME%" == "" goto noJavaHome
+if not exist "%JAVA_HOME%\bin\java.exe" goto noJavaHome
+goto checkServer
+
+:noJavaHome
+echo "You must set the JAVA_HOME variable before running CARBON."
+goto end
+
+rem ----- Only set CARBON_HOME if not already set ----------------------------
+:checkServer
+rem %~sdp0 is expanded pathname of the current script under NT with spaces in the path removed
+if "%CARBON_HOME%"=="" set CARBON_HOME=%~sdp0..
+SET curDrive=%cd:~0,1%
+SET wsasDrive=%CARBON_HOME:~0,1%
+if not "%curDrive%" == "%wsasDrive%" %wsasDrive%:
+
+rem find CARBON_HOME if it does not exist due to either an invalid value passed
+rem by the user or the %0 problem on Windows 9x
+if not exist "%CARBON_HOME%\bin\kernel-version.txt" goto noServerHome
+
+goto commandLifecycle
+
+:noServerHome
+echo CARBON_HOME is set incorrectly or CARBON could not be located. Please set CARBON_HOME.
+goto end
+
+:commandLifecycle
+goto findJdk
+
+:findJdk
+
+set CMD=RUN %*
+
+:checkJdk16
+"%JAVA_HOME%\bin\java" -version 2>&1 | findstr /r "1.[8]" >NUL
+IF ERRORLEVEL 1 goto unknownJdk
+goto jdk16
+
+:unknownJdk
+echo Starting WSO2 Carbon (in unsupported JDK)
+echo [ERROR] CARBON is supported only on JDK 1.8
+goto jdk16
+
+:jdk16
+goto runTool
+
+:runTool
+
+set CURRENT_DIR=%cd%
+
+cd %CARBON_HOME%\bin
+echo JAVA_HOME environment variable is set to %JAVA_HOME%
+echo CARBON_HOME environment variable is set to %CARBON_HOME%
+java -cp ".\*;..\bin\tools\*" -Dcarbon.home="%CARBON_HOME" -Dwso2.carbon.tool="jdbc-provider" org.wso2.carbon.tools.CarbonToolExecutor %1 %2 %3 %4
+
+:end
+goto endlocal
+
+:endlocal
+
+:END

--- a/features/org.wso2.carbon.server.feature/resources/bin/jdbc-provider.sh
+++ b/features/org.wso2.carbon.server.feature/resources/bin/jdbc-provider.sh
@@ -1,0 +1,124 @@
+#!/bin/sh
+# ---------------------------------------------------------------------------
+#  Copyright (c) 2019, WSO7 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+# ----------------------------------------------------------------------------
+
+cygwin=false;
+darwin=false;
+os400=false;
+mingw=false;
+case "`uname`" in
+CYGWIN*) cygwin=true;;
+MINGW*) mingw=true;;
+OS400*) os400=true;;
+Darwin*) darwin=true
+        if [ -z "$JAVA_VERSION" ] ; then
+             JAVA_VERSION="CurrentJDK"
+           else
+             echo "Using Java version: $JAVA_VERSION"
+           fi
+           if [ -z "$JAVA_HOME" ] ; then
+             JAVA_HOME=/System/Library/Frameworks/JavaVM.framework/Versions/${JAVA_VERSION}/Home
+           fi
+           ;;
+esac
+
+# resolve links - $0 may be a softlink
+PRG="$0"
+
+while [ -h "$PRG" ]; do
+  ls=`ls -ld "$PRG"`
+  link=`expr "$ls" : '.*-> \(.*\)$'`
+  if expr "$link" : '.*/.*' > /dev/null; then
+    PRG="$link"
+  else
+    PRG=`dirname "$PRG"`/"$link"
+  fi
+done
+
+# Get standard environment variables
+PRGDIR=`dirname "$PRG"`
+
+# Only set CARBON_HOME if not already set
+[ -z "$CARBON_HOME" ] && CARBON_HOME=`cd "$PRGDIR/.." ; pwd`
+
+# For Cygwin, ensure paths are in UNIX format before anything is touched
+if $cygwin; then
+  [ -n "$JAVA_HOME" ] && JAVA_HOME=`cygpath --unix "$JAVA_HOME"`
+  [ -n "$CARBON_HOME" ] && CARBON_HOME=`cygpath --unix "$CARBON_HOME"`
+fi
+
+# For OS400
+if $os400; then
+  # Set job priority to standard for interactive (interactive - 6) by using
+  # the interactive priority - 6, the helper threads that respond to requests
+  # will be running at the same priority as interactive jobs.
+  COMMAND='chgjob job('$JOBNAME') runpty(6)'
+  system $COMMAND
+
+  # Enable multi threading
+  QIBM_MULTI_THREADED=Y
+  export QIBM_MULTI_THREADED
+fi
+
+# For Migwn, ensure paths are in UNIX format before anything is touched
+if $mingw ; then
+  [ -n "$CARBON_HOME" ] &&
+    CARBON_HOME="`(cd "$CARBON_HOME"; pwd)`"
+  [ -n "$JAVA_HOME" ] &&
+    JAVA_HOME="`(cd "$JAVA_HOME"; pwd)`"
+fi
+
+if [ -z "$JAVACMD" ] ; then
+  if [ -n "$JAVA_HOME"  ] ; then
+    if [ -x "$JAVA_HOME/jre/sh/java" ] ; then
+      # IBM's JDK on AIX uses strange locations for the executables
+      JAVACMD="$JAVA_HOME/jre/sh/java"
+    else
+      JAVACMD="$JAVA_HOME/bin/java"
+    fi
+  else
+    JAVACMD=java
+  fi
+fi
+
+if [ ! -x "$JAVACMD" ] ; then
+  echo "Error: JAVA_HOME is not defined correctly."
+  echo " CARBON cannot execute $JAVACMD"
+  exit 1
+fi
+
+# if JAVA_HOME is not set we're not happy
+if [ -z "$JAVA_HOME" ]; then
+  echo "You must set the JAVA_HOME variable before running CARBON."
+  exit 1
+fi
+
+jdk_18=`$JAVA_HOME/bin/java -version 2>&1 | grep "1.[8]"`
+if [ "$jdk_18" = "" ]; then
+   echo " Starting WSO2 Carbon (in unsupported JDK)"
+   echo " [ERROR] CARBON is supported only on JDK 1.8"
+   exit 1
+fi
+
+echo JAVA_HOME environment variable is set to $JAVA_HOME
+echo CARBON_HOME environment variable is set to $CARBON_HOME
+
+# get the current directory from which the script is executed
+CURRENT_DIR=${PWD};
+
+cd "$CARBON_HOME/bin/";
+java -cp "../bin/tools/*" -Dcarbon.home="$CARBON_HOME" -Dwso2.carbon.tool="jdbc-provider" org.wso2.carbon.tools.CarbonToolExecutor $1 $2 $3 $4

--- a/tools/tools-core/src/main/java/org/wso2/carbon/tools/CarbonToolExecutor.java
+++ b/tools/tools-core/src/main/java/org/wso2/carbon/tools/CarbonToolExecutor.java
@@ -75,7 +75,13 @@ public class CarbonToolExecutor {
                 carbonTool = new OSGiLibDeployerTool();
                 break;
             case "icf-provider":
-                carbonTool = new ICFProviderTool();
+                carbonTool = new ICFProviderTool(toolIdentifier);
+                break;
+            case "ba-provider":
+                carbonTool = new ICFProviderTool(toolIdentifier);
+                break;
+            case "jdbc-provider":
+                carbonTool = new ICFProviderTool(toolIdentifier);
                 break;
             case "install-jars":
                 carbonTool = new InstallJarsTool();

--- a/tools/tools-core/src/main/java/org/wso2/carbon/tools/spi/ICFProviderTool.java
+++ b/tools/tools-core/src/main/java/org/wso2/carbon/tools/spi/ICFProviderTool.java
@@ -33,6 +33,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
+import java.sql.Driver;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -70,13 +71,13 @@ public class ICFProviderTool implements CarbonTool {
             "import org.osgi.framework.BundleContext;\n" +
             "import %s;\n" +
             "\n" +
-            "import javax.naming.spi.InitialContextFactory;\n" +
+            "import java.sql.Driver;\n" +
             "\n" +
             "public class CustomBundleActivator implements BundleActivator {\n" +
             "\n" + "    " +
             "@Override\n" +
             "    public void start(BundleContext bundleContext) throws Exception {\n" +
-            "        bundleContext.registerService(new String[] { \"" + InitialContextFactory.class.getName() +
+            "        bundleContext.registerService(new String[] { \"" + Driver.class.getName() +
             "\", \"%s\" }, new %s(), null);\n" +
             "    }\n" +
             "\n" +

--- a/tools/tools-core/src/main/java/org/wso2/carbon/tools/spi/ICFProviderTool.java
+++ b/tools/tools-core/src/main/java/org/wso2/carbon/tools/spi/ICFProviderTool.java
@@ -1,18 +1,18 @@
 /*
-* Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.wso2.carbon.tools.spi;
 
 import org.wso2.carbon.tools.CarbonTool;
@@ -64,46 +64,122 @@ public class ICFProviderTool implements CarbonTool {
     private static final String ACTIVATOR_JAVA_FILE = "CustomBundleActivator.java";
     private static final String INTERNAL_PKG_NAME = "internal";
     private static final String ACTIVATOR_FULL_QUALIFIED_NAME = "internal.CustomBundleActivator";
+    private boolean activatorInjector = false;
 
-    private static final String CLASS_TEMPLATE =
-            "package internal;\n" +
-            "import org.osgi.framework.BundleActivator;\n" +
-            "import org.osgi.framework.BundleContext;\n" +
-            "import %s;\n" +
-            "\n" +
-            "import java.sql.Driver;\n" +
-            "\n" +
-            "public class CustomBundleActivator implements BundleActivator {\n" +
-            "\n" + "    " +
-            "@Override\n" +
-            "    public void start(BundleContext bundleContext) throws Exception {\n" +
-            "        bundleContext.registerService(new String[] { \"" + Driver.class.getName() +
-            "\", \"%s\" }, new %s(), null);\n" +
-            "    }\n" +
-            "\n" +
-            "    @Override\n" +
-            "    public void stop(BundleContext bundleContext) throws Exception {\n" +
-            "\n" +
-            "    " +
-            "}\n" +
-            "}\n";
+    private String classTemplate = "";
+
+    public ICFProviderTool(String provider) {
+        logger.log(Level.INFO, String.format("Provider ::: %s", provider));
+        switch (provider) {
+            case "ba-provider":
+                activatorInjector = true;
+                classTemplate = "package internal;\n" +
+                        "import org.osgi.framework.BundleActivator;\n" +
+                        "import org.osgi.framework.BundleContext;\n" +
+                        "\n" +
+                        "public class CustomBundleActivator implements BundleActivator {\n" +
+                        "\n" + "    " +
+                        "    @Override\n" +
+                        "    public void start(BundleContext bundleContext) throws Exception {\n" +
+                        "        System.loadLibrary(\"clntsh\");\n" +
+                        "    }\n" +
+                        "\n" +
+                        "    @Override\n" +
+                        "    public void stop(BundleContext bundleContext) throws Exception {\n" +
+                        "\n" +
+                        "    " +
+                        "}\n" +
+                        "}\n";
+                break;
+            case "jdbc-provider":
+                classTemplate =
+                        "package internal;\n" +
+                                "import org.osgi.framework.BundleActivator;\n" +
+                                "import org.osgi.framework.BundleContext;\n" +
+                                "import %s;\n" +
+                                "\n" +
+                                "import java.sql.Driver;\n" +
+                                "\n" +
+                                "public class CustomBundleActivator implements BundleActivator {\n" +
+                                "\n" + "    " +
+                                "    @Override\n" +
+                                "    public void start(BundleContext bundleContext) throws Exception {\n" +
+                                "        bundleContext.registerService(new String[] { \"" + Driver.class.getName() +
+                                "\", \"%s\" }, new %s(), null);\n" +
+                                "    }\n" +
+                                "\n" +
+                                "    @Override\n" +
+                                "    public void stop(BundleContext bundleContext) throws Exception {\n" +
+                                "\n" +
+                                "    " +
+                                "}\n" +
+                                "}\n";
+                break;
+            case "icf-provider":
+                classTemplate = "package internal;\n" +
+                        "import org.osgi.framework.BundleActivator;\n" +
+                        "import org.osgi.framework.BundleContext;\n" +
+                        "import %s;\n" +
+                        "\n" +
+                        "import javax.naming.spi.InitialContextFactory;\n" +
+                        "\n" +
+                        "public class CustomBundleActivator implements BundleActivator {\n" +
+                        "\n" + "    " +
+                        "    @Override\n" +
+                        "    public void start(BundleContext bundleContext) throws Exception {\n" +
+                        "        bundleContext.registerService(new String[] { \"" + InitialContextFactory.class.getName() +
+                        "\", \"%s\" }, new %s(), null);\n" +
+                        "    }\n" +
+                        "\n" +
+                        "    @Override\n" +
+                        "    public void stop(BundleContext bundleContext) throws Exception {\n" +
+                        "\n" +
+                        "    " +
+                        "}\n" +
+                        "}\n";
+                break;
+        }
+    }
 
     @Override
     public void execute(String... toolArgs) {
-        if (toolArgs.length < 3 || toolArgs.length > 4) {
-            String message = "Improper usage detected. " +
-                             "Usage: icf-provider.sh|bat [ICF Impl class] [jar file] [destination] [OSGi jar path]" +
-                             "First 3 arguments are compulsory.";
-            logger.log(Level.INFO, message);
-            return;
-        }
+        String spiImpl;
+        Path jarFile;
+        Path destination;
+        String osgiJar;
 
-        String spiImpl = toolArgs[0];
-        Path jarFile = Paths.get(toolArgs[1]);
-        Path destination = Paths.get(toolArgs[2]);
-        String osgiJar = (toolArgs.length == 4 && !toolArgs[3].isEmpty()) ? toolArgs[3] :
-                         Paths.get(System.getProperty("carbon.home"), "wso2", "lib", "plugins",
-                                   "org.eclipse.osgi_3.11.0.v20160603-1336.jar").toString();
+        if (!activatorInjector) {
+            if (toolArgs.length < 3 || toolArgs.length > 4) {
+                String message = "Improper usage detected. " +
+                        "Usage: jdbc-provider/icf-provider.sh|bat [ICF Impl class] [jar file] [destination] [OSGi jar path]" +
+                        "First 3 arguments are compulsory.";
+                logger.log(Level.INFO, message);
+                return;
+            }
+
+            spiImpl = toolArgs[0];
+            jarFile = Paths.get(toolArgs[1]);
+            destination = Paths.get(toolArgs[2]);
+            osgiJar = (toolArgs.length == 4 && !toolArgs[3].isEmpty()) ? toolArgs[3] :
+                    Paths.get(System.getProperty("carbon.home"), "wso2", "lib", "plugins",
+                            "org.eclipse.osgi_3.11.0.v20160603-1336.jar").toString();
+        } else {
+
+            if (toolArgs.length < 2 || toolArgs.length > 3) {
+                String message = "Improper usage detected. " +
+                        "Usage: ba-provider.sh|bat [jar file] [destination] [OSGi jar path]" +
+                        "First 3 arguments are compulsory.";
+                logger.log(Level.INFO, message);
+                return;
+            }
+
+            spiImpl = "";
+            jarFile = Paths.get(toolArgs[0]);
+            destination = Paths.get(toolArgs[1]);
+            osgiJar = (toolArgs.length == 3 && !toolArgs[2].isEmpty()) ? toolArgs[2] :
+                    Paths.get(System.getProperty("carbon.home"), "wso2", "lib", "plugins",
+                            "org.eclipse.osgi_3.11.0.v20160603-1336.jar").toString();
+        }
 
         Path fileName = jarFile.getFileName();
         if (fileName == null) {
@@ -114,13 +190,13 @@ public class ICFProviderTool implements CarbonTool {
 
         Process process = null;
         if (Files.exists(jarFile) && Files.exists(destination) && Files.isWritable(destination) &&
-            !Files.exists(tmpDir)) {
+                !Files.exists(tmpDir)) {
             FileOutputStream fileOutputStream = null;
             try {
                 Files.createDirectory(tmpDir);
 
                 // Prepare source.
-                String source = String.format(CLASS_TEMPLATE, spiImpl, spiImpl, spiImpl);
+                String source = String.format(classTemplate, spiImpl, spiImpl, spiImpl);
 
                 // Save source in .java file.
                 Path internal = Files.createDirectory(tmpDir.resolve(INTERNAL_PKG_NAME));
@@ -146,11 +222,11 @@ public class ICFProviderTool implements CarbonTool {
                 // Add the .class file to jar
                 StringBuilder command = new StringBuilder();
                 command.append("jar uf ")
-                       .append(finalJarPath.toString())
-                       .append(" -C ")
-                       .append(tmpDir.toString())
-                       .append(" ")
-                       .append(internal.resolve(ACTIVATOR_CLASS_FILE).toString().replace(tmpDir.toString(), ""));
+                        .append(finalJarPath.toString())
+                        .append(" -C ")
+                        .append(tmpDir.toString())
+                        .append(" ")
+                        .append(internal.resolve(ACTIVATOR_CLASS_FILE).toString().replace(tmpDir.toString(), ""));
                 logger.log(Level.INFO, "Executing '" + command.toString() + "'");
                 process = Runtime.getRuntime().exec(command.toString());
                 process.waitFor(5, TimeUnit.SECONDS);
@@ -175,7 +251,7 @@ public class ICFProviderTool implements CarbonTool {
             }
         } else {
             String message = "The destination location '" + tmpDir.toString() +
-                             "' already exist/does not have write permissions or jar file doesn't exist";
+                    "' already exist/does not have write permissions or jar file doesn't exist";
             logger.log(Level.WARNING, message);
         }
     }
@@ -196,7 +272,7 @@ public class ICFProviderTool implements CarbonTool {
             Path manifestmfFile = destination.resolve(MANIFEST_FILE_NAME);
             try (JarFile jar = new JarFile(finalJarPath.toString()); PrintWriter printWriter = new PrintWriter(
                     new OutputStreamWriter(new FileOutputStream(manifestmfFile.toFile()),
-                                           "UTF-8")); InputStream inputStream = jar
+                            "UTF-8")); InputStream inputStream = jar
                     .getInputStream(jar.getEntry(JAR_MANIFEST_FOLDER + "/" + MANIFEST_FILE_NAME));) {
                 Files.copy(inputStream, destination.resolve(MANIFEST_FILE_NAME + ".tmp"));
                 List<String> existingManifest = Files.readAllLines(destination.resolve(MANIFEST_FILE_NAME + ".tmp"));


### PR DESCRIPTION
## Purpose
This PR adds the capability of converting jars that are required to enable CDC through Siddhi-IO-CDC for Oracle database by modifying the existing ICFProviderTool.

These changes were introduced due to the reasons
 1. Oracle JDBC jar has SPI services and converting it through ` jartobundle.sh` tool won't copy those services files and won't get registered as an OSGi service properly
 2. `xstreams.jar` which is required for reading log files from Oracle database requires one native library which won't be resolved when converted to an OSGi bundle through the `jartobundle.sh`

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
