### PR TITLE
Handle Duplicate Role Addition With Concurrent Calls

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
@@ -90,6 +90,7 @@ import static org.wso2.carbon.user.core.constants.UserCoreErrorConstants.ErrorMe
 import static org.wso2.carbon.user.core.constants.UserCoreErrorConstants.ErrorMessages.ERROR_CODE_DUPLICATE_WHILE_ADDING_A_SYSTEM_USER;
 import static org.wso2.carbon.user.core.constants.UserCoreErrorConstants.ErrorMessages.ERROR_CODE_DUPLICATE_WHILE_ADDING_A_USER;
 import static org.wso2.carbon.user.core.constants.UserCoreErrorConstants.ErrorMessages.ERROR_CODE_DUPLICATE_WHILE_ADDING_ROLE;
+import static org.wso2.carbon.user.core.constants.UserCoreErrorConstants.ErrorMessages.ERROR_CODE_DUPLICATE_WHILE_WRITING_TO_DATABASE;
 
 public abstract class AbstractUserStoreManager implements UserStoreManager, PaginatedUserStoreManager {
 
@@ -5151,23 +5152,8 @@ public abstract class AbstractUserStoreManager implements UserStoreManager, Pagi
             throws UserStoreException {
 
         // #################### Domain Name Free Zone Starts Here ################################
-
-        if (roleName.contains(UserCoreConstants.DOMAIN_SEPARATOR)
-                && roleName.toLowerCase().startsWith(APPLICATION_DOMAIN.toLowerCase())) {
-            if (hybridRoleManager.isExistingRole(roleName)) {
-                handleRoleAlreadyExistException(roleName, userList, permissions);
-            }
-
-            hybridRoleManager.addHybridRole(roleName, userList);
-
-        } else {
-            if (hybridRoleManager.isExistingRole(UserCoreUtil.removeDomainFromName(roleName))) {
-                handleRoleAlreadyExistException(roleName, userList, permissions);
-            }
-
-            hybridRoleManager.addHybridRole(UserCoreUtil.removeDomainFromName(roleName), userList);
-        }
-
+        String domainModeratedRoleName = removeDomainIfNotApplicationRole(roleName);
+        createHybridRole(domainModeratedRoleName, userList, permissions);
 
         if (permissions != null) {
             for (org.wso2.carbon.user.api.Permission permission : permissions) {
@@ -5906,11 +5892,7 @@ public abstract class AbstractUserStoreManager implements UserStoreManager, Pagi
             handleAddRoleFailure(errorCode, errorMessage, roleName, userList, permissions);
             throw new UserStoreException(errorCode + " - " + errorMessage);
         }
-
-        if (systemUserRoleManager.isExistingRole(roleName)) {
-            handleRoleAlreadyExistException(roleName, userList, permissions);
-        }
-        systemUserRoleManager.addSystemRole(roleName, userList);
+        createSystemRole(roleName, userList, permissions);
     }
 
 
@@ -7329,5 +7311,59 @@ public abstract class AbstractUserStoreManager implements UserStoreManager, Pagi
     private boolean isInternalRole(String domain) {
 
         return domain.equals("Internal") || domain.equals("Application");
+    }
+
+    private String removeDomainIfNotApplicationRole(String roleName) {
+
+        String formattedRoleName;
+        if (roleName.contains(UserCoreConstants.DOMAIN_SEPARATOR)
+                && roleName.toLowerCase().startsWith(APPLICATION_DOMAIN.toLowerCase())) {
+            formattedRoleName = roleName;
+        } else {
+            formattedRoleName = UserCoreUtil.removeDomainFromName(roleName);
+        }
+        return formattedRoleName;
+    }
+
+    private void createHybridRole(String roleName, String[] userList, org.wso2.carbon.user.api.Permission[] permissions)
+            throws UserStoreException {
+
+        // It is possible that the adding role could already exists at the table. But if concurrent requests were made,
+        // it is possible that the adding role does not exists at this moment, but it still could exists at the
+        // moment when DB query is called.
+        try {
+            hybridRoleManager.addHybridRole(roleName, userList);
+        } catch (UserStoreException e) {
+            // Could be already existing error or unique constraint violation, either of them could point to already
+            // existing role issue.
+            if (hybridRoleManager.isExistingRole(roleName)) {
+                handleRoleAlreadyExistException(roleName, userList, permissions);
+            }
+
+            // Otherwise, the error is propagated.
+            throw e;
+        }
+    }
+
+    private void createSystemRole(String roleName, String[] userList, Permission[] permissions) throws UserStoreException {
+
+        if (systemUserRoleManager.isExistingRole(roleName)) {
+            handleRoleAlreadyExistException(roleName, userList, permissions);
+        }
+
+        // It is possible that the adding role could already exists at the table. But if concurrent requests were made,
+        // it is possible that the adding role does not exists at this moment, but it still could exists at the
+        // moment when DB query is called.
+        try {
+            systemUserRoleManager.addSystemRole(roleName, userList);
+        } catch (UserStoreException e) {
+            if (ERROR_CODE_DUPLICATE_WHILE_ADDING_A_SYSTEM_ROLE.getCode().contains(e.getErrorCode())) {
+                // Could be a possible unique constraint violation due to already existing role.
+                if (systemUserRoleManager.isExistingRole(roleName)) {
+                    handleRoleAlreadyExistException(roleName, userList, permissions);
+                }
+            }
+            throw e;
+        }
     }
 }

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
@@ -91,6 +91,7 @@ import static org.wso2.carbon.user.core.constants.UserCoreErrorConstants.ErrorMe
 import static org.wso2.carbon.user.core.constants.UserCoreErrorConstants.ErrorMessages.ERROR_CODE_DUPLICATE_WHILE_ADDING_A_USER;
 import static org.wso2.carbon.user.core.constants.UserCoreErrorConstants.ErrorMessages.ERROR_CODE_DUPLICATE_WHILE_ADDING_ROLE;
 import static org.wso2.carbon.user.core.constants.UserCoreErrorConstants.ErrorMessages.ERROR_CODE_DUPLICATE_WHILE_WRITING_TO_DATABASE;
+import static org.wso2.carbon.user.core.constants.UserCoreErrorConstants.ErrorMessages.ERROR_CODE_ROLE_ALREADY_EXISTS;
 
 public abstract class AbstractUserStoreManager implements UserStoreManager, PaginatedUserStoreManager {
 
@@ -7334,12 +7335,11 @@ public abstract class AbstractUserStoreManager implements UserStoreManager, Pagi
         try {
             hybridRoleManager.addHybridRole(roleName, userList);
         } catch (UserStoreException e) {
-            // Could be already existing error or unique constraint violation, either of them could point to already
-            // existing role issue.
-            if (hybridRoleManager.isExistingRole(roleName)) {
+            // In case of a unique constraint violation.
+            if (ERROR_CODE_ROLE_ALREADY_EXISTS.getCode().equals(e.getErrorCode())
+                    && hybridRoleManager.isExistingRole(roleName)) {
                 handleRoleAlreadyExistException(roleName, userList, permissions);
             }
-
             // Otherwise, the error is propagated.
             throw e;
         }

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
@@ -90,7 +90,6 @@ import static org.wso2.carbon.user.core.constants.UserCoreErrorConstants.ErrorMe
 import static org.wso2.carbon.user.core.constants.UserCoreErrorConstants.ErrorMessages.ERROR_CODE_DUPLICATE_WHILE_ADDING_A_SYSTEM_USER;
 import static org.wso2.carbon.user.core.constants.UserCoreErrorConstants.ErrorMessages.ERROR_CODE_DUPLICATE_WHILE_ADDING_A_USER;
 import static org.wso2.carbon.user.core.constants.UserCoreErrorConstants.ErrorMessages.ERROR_CODE_DUPLICATE_WHILE_ADDING_ROLE;
-import static org.wso2.carbon.user.core.constants.UserCoreErrorConstants.ErrorMessages.ERROR_CODE_DUPLICATE_WHILE_WRITING_TO_DATABASE;
 import static org.wso2.carbon.user.core.constants.UserCoreErrorConstants.ErrorMessages.ERROR_CODE_ROLE_ALREADY_EXISTS;
 
 public abstract class AbstractUserStoreManager implements UserStoreManager, PaginatedUserStoreManager {
@@ -5154,6 +5153,9 @@ public abstract class AbstractUserStoreManager implements UserStoreManager, Pagi
 
         // #################### Domain Name Free Zone Starts Here ################################
         String domainModeratedRoleName = removeDomainIfNotApplicationRole(roleName);
+        if (hybridRoleManager.isExistingRole(domainModeratedRoleName)) {
+            handleRoleAlreadyExistException(domainModeratedRoleName, userList, permissions);
+        }
         createHybridRole(domainModeratedRoleName, userList, permissions);
 
         if (permissions != null) {
@@ -5185,7 +5187,7 @@ public abstract class AbstractUserStoreManager implements UserStoreManager, Pagi
         String errorCode = ErrorMessages.ERROR_CODE_ROLE_ALREADY_EXISTS.getCode();
         String errorMessage = String.format(ErrorMessages.ERROR_CODE_ROLE_ALREADY_EXISTS.getMessage(), roleName);
         handleAddRoleFailure(errorCode, errorMessage, roleName, userList, permissions);
-        throw new UserStoreException(errorCode + " - " + errorMessage);
+        throw new UserStoreException(errorCode + " - " + errorMessage, errorCode, null);
     }
 
     /**

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
@@ -7338,8 +7338,7 @@ public abstract class AbstractUserStoreManager implements UserStoreManager, Pagi
             hybridRoleManager.addHybridRole(roleName, userList);
         } catch (UserStoreException e) {
             // In case of a unique constraint violation.
-            if (ERROR_CODE_ROLE_ALREADY_EXISTS.getCode().equals(e.getErrorCode())
-                    && hybridRoleManager.isExistingRole(roleName)) {
+            if (ERROR_CODE_ROLE_ALREADY_EXISTS.getCode().equals(e.getErrorCode())) {
                 handleRoleAlreadyExistException(roleName, userList, permissions);
             }
             // Otherwise, the error is propagated.
@@ -7360,10 +7359,8 @@ public abstract class AbstractUserStoreManager implements UserStoreManager, Pagi
             systemUserRoleManager.addSystemRole(roleName, userList);
         } catch (UserStoreException e) {
             if (ERROR_CODE_DUPLICATE_WHILE_ADDING_A_SYSTEM_ROLE.getCode().contains(e.getErrorCode())) {
-                // Could be a possible unique constraint violation due to already existing role.
-                if (systemUserRoleManager.isExistingRole(roleName)) {
-                    handleRoleAlreadyExistException(roleName, userList, permissions);
-                }
+                // A unique constraint violation due to already existing role.
+                handleRoleAlreadyExistException(roleName, userList, permissions);
             }
             throw e;
         }

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/hybrid/HybridRoleManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/hybrid/HybridRoleManager.java
@@ -46,8 +46,6 @@ import java.util.List;
 import java.util.Map;
 import javax.sql.DataSource;
 
-import static org.wso2.carbon.user.core.constants.UserCoreErrorConstants.ErrorMessages.ERROR_CODE_DUPLICATE_WHILE_ADDING_A_HYBRID_ROLE;
-import static org.wso2.carbon.user.core.constants.UserCoreErrorConstants.ErrorMessages.ERROR_CODE_DUPLICATE_WHILE_ADDING_A_SYSTEM_ROLE;
 import static org.wso2.carbon.user.core.constants.UserCoreErrorConstants.ErrorMessages.ERROR_CODE_DUPLICATE_WHILE_WRITING_TO_DATABASE;
 
 public class HybridRoleManager {
@@ -134,7 +132,8 @@ public class HybridRoleManager {
             if (e instanceof UserStoreException && ERROR_CODE_DUPLICATE_WHILE_WRITING_TO_DATABASE.getCode().equals(((UserStoreException) e)
                     .getErrorCode())) {
                 // Duplicate entry
-                throw new UserStoreException(e.getMessage(), ERROR_CODE_DUPLICATE_WHILE_ADDING_A_HYBRID_ROLE.getCode(), e);
+                String errMsg = getRoleAlreadyExistsErrorMessage(roleName);
+                throw new UserStoreException(errMsg, e);
             } else {
                 // Other SQL Exception
                 throw new UserStoreException(e.getMessage(), e);

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/hybrid/HybridRoleManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/hybrid/HybridRoleManager.java
@@ -27,6 +27,7 @@ import org.wso2.carbon.user.core.UserStoreException;
 import org.wso2.carbon.user.core.authorization.AuthorizationCache;
 import org.wso2.carbon.user.core.common.UserRolesCache;
 import org.wso2.carbon.user.core.constants.UserCoreDBConstants;
+import org.wso2.carbon.user.core.constants.UserCoreErrorConstants;
 import org.wso2.carbon.user.core.jdbc.JDBCUserStoreManager;
 import org.wso2.carbon.user.core.jdbc.caseinsensitive.JDBCCaseInsensitiveConstants;
 import org.wso2.carbon.user.core.util.DatabaseUtil;
@@ -106,8 +107,8 @@ public class HybridRoleManager {
                         roleName, tenantId);
                 dbConnection.commit();
             } else {
-                throw new UserStoreException("Role name: " + roleName
-                        + " in the system. Please pick another role name.");
+                String errMsg = getRoleAlreadyExistsErrorMessage(roleName);
+                throw new UserStoreException(errMsg);
             }
             if (userList != null) {
                 String sql = HybridJDBCConstants.ADD_USER_TO_ROLE_SQL;
@@ -940,5 +941,13 @@ public class HybridRoleManager {
             sqlStmt = getRoleListOfUserSQLConfig;
         }
         return sqlStmt;
+    }
+
+    private String getRoleAlreadyExistsErrorMessage(String roleName) {
+
+        String errorCode = UserCoreErrorConstants.ErrorMessages.ERROR_CODE_ROLE_ALREADY_EXISTS.getCode();
+        String errorMessage = String.format(UserCoreErrorConstants.ErrorMessages.ERROR_CODE_ROLE_ALREADY_EXISTS
+                .getMessage(), roleName);
+        return errorCode + " - " + errorMessage;
     }
 }


### PR DESCRIPTION
## Purpose
> Fixes https://github.com/wso2/product-is/issues/5363
-  When a role is added, sometimes the scenario can throw a constraint violation exception from the DB level if the role already exists. This cannot be mitigated by checking whether the role is already there, prior creation because if concurrent requests were made, the unique constraint error could only be visible once a DB entry is attempted. This PR handles such scenario.

- Also, if a role already exists during role creation flow, then the kernel is supposed to throw an error saying the role already exists. The specific `Role Already Exists` error message is used for that purpose. This PR also fixes some places where that convention is not followed.