### PR TITLE
Disable The Customizable IndexPageURL 

### DIFF
--- a/core/org.wso2.carbon.ui/src/main/java/org/wso2/carbon/ui/CarbonSecuredHttpContext.java
+++ b/core/org.wso2.carbon.ui/src/main/java/org/wso2/carbon/ui/CarbonSecuredHttpContext.java
@@ -186,9 +186,6 @@ public class CarbonSecuredHttpContext extends SecuredComponentEntryHttpContext {
         indexPageURL = CarbonUILoginUtil.getIndexPageUrlFromCookie(requestedURI, indexPageURL,
                 request);
 
-        // If a custom index page is used send the login request with the indexpage specified
-        indexPageURL = CarbonUILoginUtil.getCustomIndexPage(request, indexPageURL);
-
         // Reading home page set on product.xml
         // If the params in the servletcontext is null get them from the UTIL
         indexPageURL = updateIndexPageWithHomePage(indexPageURL);

--- a/core/org.wso2.carbon.ui/src/main/java/org/wso2/carbon/ui/CarbonUILoginUtil.java
+++ b/core/org.wso2.carbon.ui/src/main/java/org/wso2/carbon/ui/CarbonUILoginUtil.java
@@ -169,6 +169,7 @@ public final class CarbonUILoginUtil {
      * @param indexPageURL
      * @return
      */
+    @Deprecated
     protected static String getCustomIndexPage(HttpServletRequest request, String indexPageURL) {
         // If a custom index page is used send the login request with the index page specified
         if (request.getParameter(CarbonConstants.INDEX_PAGE_URL) != null) {


### PR DESCRIPTION
## Purpose
> Having a query parameter for a customized index page overrides the requested page URL from the browser cookie, which will not allow the user to be redirected to the previously accessed page. This PR fixes this issue.