### PR TITLE
Update Release Guidelines For 4.6.x

### DIFF
--- a/release-guidelines.md
+++ b/release-guidelines.md
@@ -1,4 +1,4 @@
-# Carbon 4.5.x Release Process
+# Carbon 4.6.x Release Process
 
 ## Pre Release Tasks
 * Check whether upstream projects needs a release before releasing kernel. Kernel depends on wso2-axis2, wso2-axiom, and wso2-xmlschema (You need to check the PRs and the commits of these repos).
@@ -7,7 +7,7 @@
 * Do a FindSecurityBugs and ZAP scans and review the report. Send the report to security@wso2.com to get it reviewed/approved by the platform security team.
 
 ## Release Tasks
-1. Create a release branch from the 4.5.x branch.
+1. Create a release branch from the 4.6.x branch.
 2. Update the distribution/product/modules/distribution/release-notes.html for the latest release. We need to include the new features, new github filters for issues fixed for the current release and known issues.
     * Change “All fixed issues have been recorded at” section 
     * Change “All known issues have been recorded at” section 
@@ -15,12 +15,12 @@
 3. Verify  carbon.product, filter.properties, README.txt, bin/README.txt, release-notes.html, INSTALL.txt, about.html - check dates, hard-coded versions etc. (ex. 4420, 4.4.20, 2017)
   Following are the changes needed for the files.
     * Update core/org.wso2.carbon.ui/src/main/resources/web/docs/about.html
-        * Ex: `<h1>Version 4.5.19</h1>` -> `<h1>Version 4.5.20</h1>`
+        * Ex: `<h1>Version 4.6.19</h1>` -> `<h1>Version 4.6.20</h1>`
     * Update distribution/kernel/carbon.product
-        * Change product version Ex: 4.5.19.SNAPSHOT -> 4.5.20
-        * Change runtime version Ex: 4.5.19.SNAPSHOT -> 4.5.20
+        * Change product version Ex: 4.6.19.SNAPSHOT -> 4.6.20
+        * Change runtime version Ex: 4.6.19.SNAPSHOT -> 4.6.20
     * Update distribution/kernel/src/assembly/filter.properties
-        * Change carbon.version Ex: 4.5.19 -> 4.5.20
+        * Change carbon.version Ex: 4.6.19 -> 4.6.20
     * Update distribution/product/modules/distribution/INSTALL.txt
         * Change the version
     * Update distribution/product/modules/distribution/LICENSE.txt
@@ -37,11 +37,11 @@ Note: The tag should be RC1, but that should not be included for the product ver
 6. Once release is done, call for the release vote (send an email to dev@wso2.com) and wait for 72h.
 7. If there are no negative votes with in 72 hours, close the vote (reply to the same email)
 Note: If there are negative votes, add the changes and do the next RC version.(Go to step 8)
-8. If the vote passes, add the release tag from the RC tag that was passed, to the git repo (Ex: v4.5.20)
+8. If the vote passes, add the release tag from the RC tag that was passed, to the git repo (Ex: v4.6.20)
 9. In GitHub, draft a new release with the tag, give a proper title and release.
     
 ## Post Release Tasks
 * Change the version in the carbon.product to have the snapshot of the next version.
-* Merge the release branch to the relevant development branch(4.5.x).
+* Merge the release branch to the relevant development branch(4.6.x).
 * Send the release mail.
 


### PR DESCRIPTION
## Purpose
> Release guidelines need to be refactored for the corresponding minor version.