### PR TITLE
Read enableCorrelationLogs system property at the initialization time

### DIFF
--- a/core/org.wso2.carbon.ndatasource.rdbms/src/main/java/org/wso2/carbon/ndatasource/rdbms/CorrelationLogInterceptor.java
+++ b/core/org.wso2.carbon.ndatasource.rdbms/src/main/java/org/wso2/carbon/ndatasource/rdbms/CorrelationLogInterceptor.java
@@ -50,6 +50,7 @@ public class CorrelationLogInterceptor extends AbstractQueryReport {
     private static final String[] DEFAULT_BLACKLISTED_THREADS = {"MessageDeliveryTaskThreadPool", "HumanTaskServer" ,
             "BPELServer", "CarbonDeploymentSchedulerThread"};
     private List<String> blacklistedThreadList = new ArrayList<>();
+    private boolean isEnableCorrelationLogs;
 
     public CorrelationLogInterceptor() {
         String blacklistedThreadNames = System.getProperty(BLACKLISTED_THREADS_SYSTEM_PROPERTY);
@@ -61,6 +62,8 @@ public class CorrelationLogInterceptor extends AbstractQueryReport {
         if (!StringUtils.isEmpty(blacklistedThreadNames)) {
             blacklistedThreadList.addAll(Arrays.asList(StringUtils.split(blacklistedThreadNames, ',')));
         }
+
+        isEnableCorrelationLogs = Boolean.parseBoolean(System.getProperty(CORRELATION_LOG_SYSTEM_PROPERTY));
     }
 
     @Override
@@ -81,7 +84,7 @@ public class CorrelationLogInterceptor extends AbstractQueryReport {
     @Override
     public Object createStatement(Object proxy, Method method, Object[] args, Object statement, long time) {
         try {
-            if (Boolean.parseBoolean(System.getProperty(CORRELATION_LOG_SYSTEM_PROPERTY))) {
+            if (isEnableCorrelationLogs) {
                 return invokeProxy(method, args, statement, time);
             } else {
                 return statement;

--- a/core/org.wso2.carbon.tomcat.ext/src/main/java/org/wso2/carbon/tomcat/ext/valves/RequestCorrelationIdValve.java
+++ b/core/org.wso2.carbon.tomcat.ext/src/main/java/org/wso2/carbon/tomcat/ext/valves/RequestCorrelationIdValve.java
@@ -70,6 +70,7 @@ public class RequestCorrelationIdValve extends ValveBase {
     private static final String CORRELATION_LOG_SYSTEM_PROPERTY = "enableCorrelationLogs";
     private static final String PADDING_CHAR = "=";
     private static final String SPLITTING_CHAR = "&";
+    private boolean isEnableCorrelationLogs;
 
     @Override
     protected void initInternal() throws LifecycleException {
@@ -88,6 +89,8 @@ public class RequestCorrelationIdValve extends ValveBase {
         if (StringUtils.isNotEmpty(configuredCorrelationIdMdc)) {
             correlationIdMdc = configuredCorrelationIdMdc;
         }
+
+        isEnableCorrelationLogs = Boolean.parseBoolean(System.getProperty(CORRELATION_LOG_SYSTEM_PROPERTY));
     }
 
     @Override
@@ -106,7 +109,7 @@ public class RequestCorrelationIdValve extends ValveBase {
                 associateToThread(associateToThreadMap);
             }
 
-            if (Boolean.parseBoolean(System.getProperty(CORRELATION_LOG_SYSTEM_PROPERTY))) {
+            if (isEnableCorrelationLogs) {
                 long currentTime = System.currentTimeMillis();
                 long timeTaken = currentTime - requestStartTime;
                 logRequestDetails(currentTime, timeTaken, CORRELATION_LOG_REQUEST_START, request);
@@ -116,7 +119,7 @@ public class RequestCorrelationIdValve extends ValveBase {
                 getNext().invoke(request, response);
             }
         } finally {
-            if (Boolean.parseBoolean(System.getProperty(CORRELATION_LOG_SYSTEM_PROPERTY))) {
+            if (isEnableCorrelationLogs) {
                 long currentTime = System.currentTimeMillis();
                 long timeTaken = currentTime - requestStartTime;
                 logRequestDetails(currentTime, timeTaken, CORRELATION_LOG_REQUEST_END, request);


### PR DESCRIPTION
With the results of a test run, we can see the `System.getProperty` is called for each request and each database call. This contributes to the highest block on the Java Monitor, as can be seen in the below image.
![image](https://user-images.githubusercontent.com/1332991/70979660-fe04b400-20d7-11ea-9a93-a822b89061cc.png)

This call is not required always and can be read at the class initialization time and can be used when required.
