### PR TITLE
Fix class cast exception

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
@@ -6180,7 +6180,7 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
      * @throws UserStoreException Exception that will be thrown by relevant listeners.
      */
     private void handleAddRoleFailureWithID(String errorCode, String errorMessage, String roleName, String[] userIDList,
-            Permission[] permissions) throws UserStoreException {
+            org.wso2.carbon.user.api.Permission[] permissions) throws UserStoreException {
 
         for (UserManagementErrorEventListener listener : UMListenerServiceComponent
                 .getUserManagementErrorEventListeners()) {
@@ -6309,7 +6309,7 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
             } else {
                 doAddInternalRoleWithID(roleName,
                         getUserIDsFromUserNames(Arrays.asList(userList)).toArray(new String[0]),
-                        (Permission[]) permissions);
+                        (org.wso2.carbon.user.api.Permission[]) permissions);
             }
 
             // Calling only the audit logger, to maintain the back-ward compatibility
@@ -7024,7 +7024,7 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
      * @param permissions Relevant permissions added for new role.
      * @throws UserStoreException User Store Exception.
      */
-    private void handleRoleAlreadyExistExceptionWithID(String roleName, String[] userIDList, Permission[] permissions)
+    private void handleRoleAlreadyExistExceptionWithID(String roleName, String[] userIDList, org.wso2.carbon.user.api.Permission[] permissions)
             throws UserStoreException {
 
         String errorCode = ErrorMessages.ERROR_CODE_ROLE_ALREADY_EXISTS.getCode();
@@ -13515,7 +13515,7 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
      * @param permissions permissions.
      * @throws UserStoreException An unexpected exception has occurred.
      */
-    protected void doAddInternalRoleWithID(String roleName, String[] userIDList, Permission[] permissions)
+    protected void doAddInternalRoleWithID(String roleName, String[] userIDList, org.wso2.carbon.user.api.Permission[] permissions)
             throws UserStoreException {
 
         // #################### Domain Name Free Zone Starts Here ################################


### PR DESCRIPTION
## Purpose
This PR fixes the following stack trace when using the UniqueIDJDBCUserStoreManager

```
[2020-01-14 16:21:15,314] ERROR - APIManagerComponent Exception when creating default roles for tenant -1234
java.lang.ClassCastException: [Lorg.wso2.carbon.user.api.Permission; cannot be cast to [Lorg.wso2.carbon.user.core.Permission;
	at org.wso2.carbon.user.core.common.AbstractUserStoreManager.addRole(AbstractUserStoreManager.java:6311) ~[org.wso2.carbon.user.core_4.6.0.alpha3.jar:?]
	at org.wso2.carbon.user.core.common.AbstractUserStoreManager.addRole(AbstractUserStoreManager.java:8445) ~[org.wso2.carbon.user.core_4.6.0.alpha3.jar:?]
	at org.wso2.carbon.apimgt.impl.utils.APIUtil.createRole_aroundBody248(APIUtil.java:4618) ~[org.wso2.carbon.apimgt.impl_6.6.6.SNAPSHOT.jar:?]
	at org.wso2.carbon.apimgt.impl.utils.APIUtil.createRole(APIUtil.java:4596) ~[org.wso2.carbon.apimgt.impl_6.6.6.SNAPSHOT.jar:?]
	at org.wso2.carbon.apimgt.impl.utils.APIUtil.createPublisherRole_aroundBody242(APIUtil.java:4556) ~[org.wso2.carbon.apimgt.impl_6.6.6.SNAPSHOT.jar:?]
	at org.wso2.carbon.apimgt.impl.utils.APIUtil.createPublisherRole(APIUtil.java:4552) ~[org.wso2.carbon.apimgt.impl_6.6.6.SNAPSHOT.jar:?]
	at org.wso2.carbon.apimgt.impl.utils.APIUtil.createDefaultRoles_aroundBody224(APIUtil.java:4263) ~[org.wso2.carbon.apimgt.impl_6.6.6.SNAPSHOT.jar:?]
	at org.wso2.carbon.apimgt.impl.utils.APIUtil.createDefaultRoles(APIUtil.java:4251) ~[org.wso2.carbon.apimgt.impl_6.6.6.SNAPSHOT.jar:?]
	at org.wso2.carbon.apimgt.impl.internal.APIManagerComponent.activate_aroundBody0(APIManagerComponent.java:192) [org.wso2.carbon.apimgt.impl_6.6.6.SNAPSHOT.jar:?]
	at org.wso2.carbon.apimgt.impl.internal.APIManagerComponent.activate(APIManagerComponent.java:133) [org.wso2.carbon.apimgt.impl_6.6.6.SNAPSHOT.jar:?]
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:1.8.0_191]
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:1.8.0_191]
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:1.8.0_191]
	at java.lang.reflect.Method.invoke(Method.java:498) ~[?:1.8.0_191]
	at org.eclipse.equinox.internal.ds.model.ServiceComponent.activate(ServiceComponent.java:260) [org.eclipse.equinox.ds_1.4.400.v20160226-2036.jar:?]
	at org.eclipse.equinox.internal.ds.model.ServiceComponentProp.activate(ServiceComponentProp.java:146) [org.eclipse.equinox.ds_1.4.400.v20160226-2036.jar:?]
	at org.eclipse.equinox.internal.ds.model.ServiceComponentProp.build(ServiceComponentProp.java:345) [org.eclipse.equinox.ds_1.4.400.v20160226-2036.jar:?]
	at org.eclipse.equinox.internal.ds.InstanceProcess.buildComponent(InstanceProcess.java:620) [org.eclipse.equinox.ds_1.4.400.v20160226-2036.jar:?]
	at org.eclipse.equinox.internal.ds.InstanceProcess.buildComponents(InstanceProcess.java:197) [org.eclipse.equinox.ds_1.4.400.v20160226-2036.jar:?]
	at org.eclipse.equinox.internal.ds.Resolver.getEligible(Resolver.java:343) [org.eclipse.equinox.ds_1.4.400.v20160226-2036.jar:?]
	at org.eclipse.equinox.internal.ds.SCRManager.serviceChanged(SCRManager.java:222) [org.eclipse.equinox.ds_1.4.400.v20160226-2036.jar:?]
	at org.eclipse.osgi.internal.serviceregistry.FilteredServiceListener.serviceChanged(FilteredServiceListener.java:113) [org.eclipse.osgi_3.14.0.v20190517-1309.jar:?]
	at org.eclipse.osgi.internal.framework.BundleContextImpl.dispatchEvent(BundleContextImpl.java:985) [org.eclipse.osgi_3.14.0.v20190517-1309.jar:?]
	at org.eclipse.osgi.framework.eventmgr.EventManager.dispatchEvent(EventManager.java:234) [org.eclipse.osgi_3.14.0.v20190517-1309.jar:?]
	at org.eclipse.osgi.framework.eventmgr.ListenerQueue.dispatchEventSynchronous(ListenerQueue.java:151) [org.eclipse.osgi_3.14.0.v20190517-1309.jar:?]
	at org.eclipse.osgi.internal.serviceregistry.ServiceRegistry.publishServiceEventPrivileged(ServiceRegistry.java:866) [org.eclipse.osgi_3.14.0.v20190517-1309.jar:?]
	at org.eclipse.osgi.internal.serviceregistry.ServiceRegistry.publishServiceEvent(ServiceRegistry.java:804) [org.eclipse.osgi_3.14.0.v20190517-1309.jar:?]
	at org.eclipse.osgi.internal.serviceregistry.ServiceRegistrationImpl.register(ServiceRegistrationImpl.java:130) [org.eclipse.osgi_3.14.0.v20190517-1309.jar:?]
	at org.eclipse.osgi.internal.serviceregistry.ServiceRegistry.registerService(ServiceRegistry.java:228) [org.eclipse.osgi_3.14.0.v20190517-1309.jar:?]
	at org.eclipse.osgi.internal.framework.BundleContextImpl.registerService(BundleContextImpl.java:525) [org.eclipse.osgi_3.14.0.v20190517-1309.jar:?]
	at org.eclipse.osgi.internal.framework.BundleContextImpl.registerService(BundleContextImpl.java:544) [org.eclipse.osgi_3.14.0.v20190517-1309.jar:?]
	at org.wso2.carbon.core.init.CarbonServerManager.initializeCarbon(CarbonServerManager.java:529) [org.wso2.carbon.core_4.6.0.alpha3.jar:?]
	at org.wso2.carbon.core.init.CarbonServerManager.removePendingItem(CarbonServerManager.java:305) [org.wso2.carbon.core_4.6.0.alpha3.jar:?]
	at org.wso2.carbon.core.init.PreAxis2ConfigItemListener.bundleChanged(PreAxis2ConfigItemListener.java:118) [org.wso2.carbon.core_4.6.0.alpha3.jar:?]
	at org.eclipse.osgi.internal.framework.BundleContextImpl.dispatchEvent(BundleContextImpl.java:973) [org.eclipse.osgi_3.14.0.v20190517-1309.jar:?]
	at org.eclipse.osgi.framework.eventmgr.EventManager.dispatchEvent(EventManager.java:234) [org.eclipse.osgi_3.14.0.v20190517-1309.jar:?]
	at org.eclipse.osgi.framework.eventmgr.EventManager$EventThread.run(EventManager.java:345) [org.eclipse.osgi_3.14.0.v20190517-1309.jar:?]
```