### PR TITLE
Handle exceptions during scheduled cache cleanup

### DIFF
--- a/core/javax.cache/src/main/java/org/wso2/carbon/caching/impl/CacheCleanupTask.java
+++ b/core/javax.cache/src/main/java/org/wso2/carbon/caching/impl/CacheCleanupTask.java
@@ -58,15 +58,19 @@ public class CacheCleanupTask implements Runnable {
             cc.setTenantId(MultitenantConstants.SUPER_TENANT_ID);
             cc.setTenantDomain(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
             for (CacheImpl cache : caches) {
-                cache.runCacheExpiry();
-                if (log.isDebugEnabled()) {
-                    log.debug("Cache expiry completed for cache " + cache.getName());
+                try {
+                    cache.runCacheExpiry();
+                    if (log.isDebugEnabled()) {
+                        log.debug("Cache expiry completed for the cache: " + cache.getName());
+                    }
+                } catch (IllegalStateException e) {
+                    if (log.isDebugEnabled()) {
+                        log.debug("Error occurred while running CacheCleanupTask for the cache: " + cache.getName(), e);
+                    }
+                } catch (Throwable e) {
+                    log.error("Error occurred while running CacheCleanupTask for the cache: " + cache.getName(), e);
                 }
             }
-        } catch (IllegalStateException e) {
-            log.debug("Error occurred while running CacheCleanupTask", e);
-        } catch (Throwable e) {
-            log.error("Error occurred while running CacheCleanupTask", e);
         } finally {
             PrivilegedCarbonContext.endTenantFlow();
         }


### PR DESCRIPTION
Fix wso2/product-is#7400

#### Approach
Catch `IllegalStateException` and `Throwable` inside the loop itself and log an error with the name of the specific cache that got failed. Therefore the CacheCleanupTask will continue with the remaining caches in the list.