### PR TITLE
Add new constructor to user store exception.

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/UserStoreException.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/UserStoreException.java
@@ -38,6 +38,10 @@ public class UserStoreException extends org.wso2.carbon.user.api.UserStoreExcept
         super(message, cause);
         this.errorCode = errorCode;
     }
+    public UserStoreException(String message, String errorCode){
+        super(message);
+        this.errorCode=errorCode;
+    }
 
     public UserStoreException(String message, boolean convertMessage) {
         super(message);

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/UserStoreException.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/UserStoreException.java
@@ -38,9 +38,10 @@ public class UserStoreException extends org.wso2.carbon.user.api.UserStoreExcept
         super(message, cause);
         this.errorCode = errorCode;
     }
-    public UserStoreException(String message, String errorCode){
+
+    public UserStoreException(String message, String errorCode) {
         super(message);
-        this.errorCode=errorCode;
+        this.errorCode = errorCode;
     }
 
     public UserStoreException(String message, boolean convertMessage) {

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
@@ -10791,7 +10791,7 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
                     realmConfig.getUserStoreProperty(UserCoreConstants.RealmConfig.PROPERTY_DOMAIN_NAME));
             String errorCode = ErrorMessages.ERROR_CODE_NON_EXISTING_USER.getCode();
             handleGetUserFailureWithID(errorCode, errorMessage, userID, requestedClaims, profileName);
-            throw new UserStoreException(errorCode + " - " + errorMessage,errorCode);
+            throw new UserStoreException(errorCode + " - " + errorMessage, errorCode);
         }
         // check for null claim list
         if (requestedClaims == null) {

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
@@ -10791,7 +10791,7 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
                     realmConfig.getUserStoreProperty(UserCoreConstants.RealmConfig.PROPERTY_DOMAIN_NAME));
             String errorCode = ErrorMessages.ERROR_CODE_NON_EXISTING_USER.getCode();
             handleGetUserFailureWithID(errorCode, errorMessage, userID, requestedClaims, profileName);
-            throw new UserStoreException(errorCode + " - " + errorMessage);
+            throw new UserStoreException(errorCode + " - " + errorMessage,errorCode);
         }
         // check for null claim list
         if (requestedClaims == null) {


### PR DESCRIPTION
## Purpose
For the issue https://github.com/wso2/product-is/issues/7628, need to have constructor for UserStoreException class with error message and error code without Throwable attribute. Because [getuserwithID](https://github.com/wso2/carbon-kernel/blob/v4.6.0-beta2/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java#L10794)  method throws exception without error code.

