### PR TITLE
Allow HTTP accesslog to be configured with Log4J

### DIFF
--- a/core/org.wso2.carbon.tomcat.ext/src/main/java/org/wso2/carbon/tomcat/ext/valves/ConfigurableLoggerAccessLogValve.java
+++ b/core/org.wso2.carbon.tomcat.ext/src/main/java/org/wso2/carbon/tomcat/ext/valves/ConfigurableLoggerAccessLogValve.java
@@ -1,0 +1,89 @@
+package org.wso2.carbon.tomcat.ext.valves;
+
+import org.apache.catalina.connector.Request;
+import org.apache.catalina.connector.Response;
+import org.apache.catalina.valves.AbstractAccessLogValve;
+import org.apache.catalina.valves.AccessLogValve;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.log4j.MDC;
+
+import java.io.CharArrayWriter;
+import java.util.Map;
+
+/**
+ * Configurable Access Log valve, which logs to the logger system used by carbon platform.
+ * Use this instead of default access log valve provided by Tomcat.
+ * This provides ability to use different log appender, such as stdout, Socket Appender, etc.
+ * <p>
+ * This extends from default Tomcat Access log valve to behave the same way inside the carbon to retain
+ * backward compatibility. However, we can extend from the base AbstractAccessLogValve once we fully moved to
+ * Log4J logger.
+ */
+public class ConfigurableLoggerAccessLogValve extends AbstractAccessLogValve {
+
+    private static final org.apache.juli.logging.Log log = org.apache.juli.logging.LogFactory.getLog(
+            AccessLogValve.class);
+    private static final Log ACCESS_LOG = LogFactory.getLog("HTTP_ACCESS");
+
+    /**
+     * Overridden to associate the Correlation ID data from the original thread to the access log writer thread.
+     * The log writing (this method) is called with a different thread pool, not by the original request handler thread.
+     * Hence we need to copy the MDC to this thread.
+     *
+     * @param request
+     * @param response
+     * @param time
+     */
+    @Override
+    public void log(Request request, Response response, long time) {
+
+        Map<String, String> toAssociateMdc =
+                (Map) request.getAttribute(RequestCorrelationIdValve.CORRELATION_ID_MDC_REQUEST_ATTRIBUTE_NAME);
+        copyMdcFromRequest(toAssociateMdc);
+        try {
+            super.log(request, response, time);
+        } finally {
+            removeMdcCopiedFromRequest(toAssociateMdc);
+        }
+    }
+
+    @Override
+    public void log(CharArrayWriter message) {
+
+        if (ACCESS_LOG.isInfoEnabled()) {
+            ACCESS_LOG.info(message.toString());
+        }
+    }
+
+    /**
+     * Removes the MDC added from the Request from the log writer thread.
+     *
+     * @param toAssociateMdc
+     */
+    private void removeMdcCopiedFromRequest(Map<String, String> toAssociateMdc) {
+
+        if (toAssociateMdc != null) {
+            for (Map.Entry<String, String> entry : toAssociateMdc.entrySet()) {
+                MDC.remove(entry.getKey());
+            }
+        }
+    }
+
+    /**
+     * The access log happened with asynchronous mechanism with a different thread than the request handler thread.
+     * We need to copy the original correlation ID data Map from the Request fo MDC so that it will be
+     * available for the Log4J system to do its formatting.
+     *
+     * @param toAssociateMdc
+     */
+    private void copyMdcFromRequest(Map<String, String> toAssociateMdc) {
+
+        if (toAssociateMdc != null) {
+            for (Map.Entry<String, String> entry : toAssociateMdc.entrySet()) {
+                MDC.put(entry.getKey(), entry.getValue());
+            }
+        }
+    }
+
+}

--- a/core/org.wso2.carbon.tomcat.ext/src/main/java/org/wso2/carbon/tomcat/ext/valves/ConfigurableLoggerAccessLogValve.java
+++ b/core/org.wso2.carbon.tomcat.ext/src/main/java/org/wso2/carbon/tomcat/ext/valves/ConfigurableLoggerAccessLogValve.java
@@ -1,3 +1,21 @@
+/*
+ *  Copyright (c)  2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
 package org.wso2.carbon.tomcat.ext.valves;
 
 import org.apache.catalina.connector.Request;

--- a/core/org.wso2.carbon.tomcat.ext/src/main/java/org/wso2/carbon/tomcat/ext/valves/RequestCorrelationIdValve.java
+++ b/core/org.wso2.carbon.tomcat.ext/src/main/java/org/wso2/carbon/tomcat/ext/valves/RequestCorrelationIdValve.java
@@ -57,6 +57,8 @@ public class RequestCorrelationIdValve extends ValveBase {
 
     private static final Log correlationLog = LogFactory.getLog("correlation");
     private static final String CORRELATION_ID_MDC = "Correlation-ID";
+    /* package private */ static final String CORRELATION_ID_MDC_REQUEST_ATTRIBUTE_NAME =
+            "org.wso2.request.correlation.MDC";
     private Map<String, String> headerToIdMapping;
     private Map<String, String> queryToIdMapping;
     private static List<String> toRemoveFromThread = new ArrayList<>();
@@ -104,11 +106,16 @@ public class RequestCorrelationIdValve extends ValveBase {
             }
 
             if (associateToThreadMap.size() == 0) {
-                associateToThread(UUID.randomUUID().toString());
-            } else {
-                associateToThread(associateToThreadMap);
+                // Put the default generated correlation ID.
+                associateToThreadMap.put(correlationIdMdc, UUID.randomUUID().toString());
             }
 
+            associateToThread(associateToThreadMap);
+
+
+            // Associates the generated Correlation ID Mapping to the request so that,
+            // it will be available for any other asynchronous flows or threads spawned for this request
+            request.setAttribute(CORRELATION_ID_MDC_REQUEST_ATTRIBUTE_NAME, associateToThreadMap);
             if (isEnableCorrelationLogs) {
                 long currentTime = System.currentTimeMillis();
                 long timeTaken = currentTime - requestStartTime;

--- a/core/org.wso2.carbon.tomcat.ext/src/main/java/org/wso2/carbon/tomcat/ext/valves/RequestCorrelationIdValve.java
+++ b/core/org.wso2.carbon.tomcat.ext/src/main/java/org/wso2/carbon/tomcat/ext/valves/RequestCorrelationIdValve.java
@@ -188,15 +188,6 @@ public class RequestCorrelationIdValve extends ValveBase {
     }
 
     /**
-     * Associate a random correlation id value to thread
-     *
-     * @param generatedValue Randomly generated UUID
-     */
-    private void associateToThread(String generatedValue) {
-        MDC.put(correlationIdMdc, generatedValue);
-    }
-
-    /**
      * Remove all headers values associated with the thread.
      */
     private void disAssociateFromThread() {

--- a/distribution/kernel/carbon-home/repository/resources/conf/templates/repository/conf/tomcat/catalina-server.xml.j2
+++ b/distribution/kernel/carbon-home/repository/resources/conf/templates/repository/conf/tomcat/catalina-server.xml.j2
@@ -66,7 +66,13 @@
                 <Valve className="org.wso2.carbon.tomcat.ext.valves.RequestCorrelationIdValve"
                        headerToCorrelationIdMapping="{'activityid':'Correlation-ID'}" queryToCorrelationIdMapping="{'RelayState':'Correlation-ID'}"/>
                 <Valve className="org.wso2.carbon.tomcat.ext.valves.CarbonContextCreatorValve"/>
+                {% if http_access_log.useLogger is sameas true %}
+                <Valve className="org.wso2.carbon.tomcat.ext.valves.ConfigurableLoggerAccessLogValve"
+                    pattern="{{http_access_log.pattern}}"/>
+                {% else %}
                 <Valve className="org.apache.catalina.valves.AccessLogValve" directory="${carbon.home}/repository/logs"
+                    prefix="http_access_" suffix=".log" pattern="{{http_access_log.pattern}}"/>
+                {% endif %}
                        prefix="http_access_" suffix=".log" pattern="%h %l %u %t %r %s %b %{Referer}i %{User-Agent}i %T"/>
                 <Valve className="org.wso2.carbon.tomcat.ext.valves.CarbonStuckThreadDetectionValve" threshold="600"/>
                 <Valve className="org.wso2.carbon.tomcat.ext.valves.CompositeValve"/>


### PR DESCRIPTION

## Purpose
Address https://github.com/wso2/carbon-kernel/issues/2660


## User stories
This will allow HTTP access log to be written to sys-out or using any remote publisher supported by Log4J system.
Helps to use the HTTP Access Log in container native way. and eliminate the use of shared volume to write log file.

## Release note
Available in next kernel release

## Documentation
Replace " <Valve className="org.apache.catalina.valves.AccessLogValve" "section in "catalina-server.xml.j2" with following. This will allow the previous logger to be the default, while allowing someone to use the new logger via the config.
```
                {% if http_access_log.useLogger is sameas true %}
                <Valve className="org.wso2.carbon.tomcat.ext.valves.ConfigurableLoggerAccessLogValve"
                    pattern="{{http_access_log.pattern}}"/>
                {% else %}
                <Valve className="org.apache.catalina.valves.AccessLogValve" directory="${carbon.home}/repository/logs"
                    prefix="http_access_" suffix=".log" pattern="{{http_access_log.pattern}}"/>
                {% endif %}
```


Add following to "deployment.toml"

```
[http_access_log]
useLogger = true
```
