### PR TITLE
Disable sending session data as the part of the request

### DIFF
--- a/core/org.wso2.carbon.ui/src/main/resources/web/admin/jsp/WSRequestXSSproxy_ajaxprocessor.jsp
+++ b/core/org.wso2.carbon.ui/src/main/resources/web/admin/jsp/WSRequestXSSproxy_ajaxprocessor.jsp
@@ -228,7 +228,7 @@
     ConfigurationContext configContext = (ConfigurationContext) config.getServletContext()
             .getAttribute(CarbonConstants.CLIENT_CONFIGURATION_CONTEXT);
     String cookie = (String) session.getAttribute(ServerConstants.ADMIN_SERVICE_COOKIE);
-    opts.setManageSession(true);
+    opts.setManageSession(false);
     opts.setProperty(org.apache.axis2.transport.http.HTTPConstants.COOKIE_STRING, request.getHeader("Cookie"));
     ServiceClient sc = new ServiceClient(configContext, null);
     sc.setOptions(opts);


### PR DESCRIPTION
## Purpose
When making an HTTP GET request from the "Try it" tool to the JSP called "WSRequestXSSproxy_ajaxprocessor.jsp", the JSESSIONID and other cookies are sent with the request, leveraging attackers to perform "Stealing Session Cookie" via SSRF (Server-Side Request Forgery) vulnerability.

Making the following option to false will stop sending the session data as part of the request since there is no specific use case to send the session data via this request.

`opts.setManageSession(false);`