### PR TITLE
Modify sql command to fix a syntax error

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/JDBCUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/JDBCUserStoreManager.java
@@ -4325,10 +4325,12 @@ public class JDBCUserStoreManager extends AbstractUserStoreManager {
 
         if (MYSQL.equals(dbType)) {
             sqlBuilder.updateSql(" GROUP BY U.UM_USER_NAME ");
-            if (groupFilterCount > 0) {
+            if (groupFilterCount > 0 && claimFilterCount > 0) {
+                sqlBuilder.updateSql(" HAVING (COUNT(DISTINCT R.UM_ROLE_NAME) = " + groupFilterCount +
+                        " AND COUNT(DISTINCT UA.UM_ATTR_VALUE) = " + claimFilterCount + ")");
+            } else if (groupFilterCount > 0) {
                 sqlBuilder.updateSql(" HAVING COUNT(DISTINCT R.UM_ROLE_NAME) = " + groupFilterCount);
-            }
-            if (claimFilterCount > 0) {
+            } else if (claimFilterCount > 0) {
                 sqlBuilder.updateSql(" HAVING COUNT(DISTINCT UA.UM_ATTR_VALUE) = " + claimFilterCount);
             }
         }

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCUserStoreManager.java
@@ -3478,10 +3478,12 @@ public class UniqueIDJDBCUserStoreManager extends JDBCUserStoreManager {
 
         if (MYSQL.equals(dbType)) {
             sqlBuilder.updateSql(" GROUP BY U.UM_USER_NAME, U.UM_USER_ID ");
-            if (groupFilterCount > 0) {
+            if (groupFilterCount > 0 && claimFilterCount > 0) {
+                sqlBuilder.updateSql(" HAVING (COUNT(DISTINCT R.UM_ROLE_NAME) = " + groupFilterCount +
+                        " AND COUNT(DISTINCT UA.UM_ATTR_VALUE) = " + claimFilterCount + ")");
+            } else if (groupFilterCount > 0) {
                 sqlBuilder.updateSql(" HAVING COUNT(DISTINCT R.UM_ROLE_NAME) = " + groupFilterCount);
-            }
-            if (claimFilterCount > 0) {
+            } else if (claimFilterCount > 0) {
                 sqlBuilder.updateSql(" HAVING COUNT(DISTINCT UA.UM_ATTR_VALUE) = " + claimFilterCount);
             }
         }


### PR DESCRIPTION
This resolves https://github.com/wso2/product-is/issues/8170 which is caused by a syntax error in the sql command when trying to filter using both claim and group filters with 'and'.