### PR TITLE
Change the value of STS Callback Handler 

### DIFF
--- a/distribution/kernel/carbon-home/repository/resources/conf/default.json
+++ b/distribution/kernel/carbon-home/repository/resources/conf/default.json
@@ -183,6 +183,6 @@
   "versioning_configuration.enable_versioning_tags": false,
   "versioning_configuration.enable_versioning_ratings": false,
   "versioning_configuration.enable_version_resources_on_change" : false,
-  "sts.callback_handler" : "org.wso2.carbon.identity.provider.AttributeCallbackHandler"
+  "sts.callback_handler" : "org.wso2.carbon.identity.sts.common.identity.provider.AttributeCallbackHandler"
 
 }


### PR DESCRIPTION
## Purpose
> Currently the product uses both OpenSAML2 and OpenSAML3. OpenSAML2 is mainly used for the STS functionality. As planned WS-Trust functionality is to be provided as a connector and WS-Federation will be re implemented. Since there is a migration of implementation from carbon-identity-framework and identity-inbound-auth-openid to inbound-auth-sts the package of the STS callback handler has been changed hence causing this change.

## Goals
> With this PR the callback handler value is changed to the new package where the callback handler exists.

## Release note
> Provide WS-Trust functionality as a connector

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Related PRs
> https://github.com/wso2/carbon-identity-framework/pull/2921
> https://github.com/wso2/wso2-wss4j/pull/82
> https://github.com/wso2-extensions/identity-inbound-auth-openid/pull/68
> https://github.com/wso2/carbon-multitenancy/pull/193
> https://github.com/wso2-extensions/identity-inbound-auth-sts/pull/90
> https://github.com/wso2/identity-api-server/pull/164

## Test environment
> JDK version: JDK 8
> Operating System: Linux
> Database: H2(Default)
> Browsers Tested: Chrome and Firefox 

Resolves: https://github.com/wso2/product-is/issues/8350