### PR TITLE
 Fix axis2.xml.j2 template file to support custom globally engaged modules

### DIFF
--- a/distribution/kernel/carbon-home/repository/resources/conf/templates/repository/conf/axis2/axis2.xml.j2
+++ b/distribution/kernel/carbon-home/repository/resources/conf/templates/repository/conf/axis2/axis2.xml.j2
@@ -25,6 +25,10 @@
     <module ref="addressing"/>
     {% endif %}
 
+    {% for module in server.globally_engaged_modules %}
+    <module ref="{{module}}"/>
+    {% endfor %}
+
     <!-- ================================================= -->
     <!-- Parameters -->
     <!-- ================================================= -->


### PR DESCRIPTION
## Purpose
> Axis2.xml.j2 template doesn't support adding custom modules under globally engaged modules.
This fix will update the template to add custom globally engaged modules.
(This fix is required by open banking solution)

 Usage of the new config in the deployment.toml :

```
[server]
globally_engaged_modules = ["<custom module name>"]
```
## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Related PRs
> https://github.com/wso2-support/product-apim/pull/535
   https://github.com/wso2/product-apim/pull/8042

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.