### PR TITLE
Fix EI-5131: AttachmentMap is not included in the superTenantOutMessageContext

### DIFF
--- a/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/multitenancy/transports/TenantTransportSender.java
+++ b/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/multitenancy/transports/TenantTransportSender.java
@@ -148,6 +148,7 @@ public class TenantTransportSender extends AbstractHandler implements TransportS
                 Constants.Configuration.CONTENT_TYPE, contentTypeProperty);
 
         superTenantOutMessageContext.setDoingMTOM(msgContext.isDoingMTOM());
+        superTenantOutMessageContext.setAttachmentMap(msgContext.getAttachmentMap());
 
         superTenantOutMessageContext.setProperty(org.apache.axis2.Constants.Configuration.CHARACTER_SET_ENCODING,
                 msgContext.getProperty(org.apache.axis2.Constants.Configuration.CHARACTER_SET_ENCODING));


### PR DESCRIPTION


This is to fix wso2/product-ei#5131

