### PR TITLE
Update web.xml.j2 template file to add custom filters and filter-mappings

### DIFF
--- a/distribution/kernel/carbon-home/repository/resources/conf/templates/repository/conf/tomcat/web.xml.j2
+++ b/distribution/kernel/carbon-home/repository/resources/conf/templates/repository/conf/tomcat/web.xml.j2
@@ -93,6 +93,20 @@
     <!--                                                                      -->
     <!--
                                                                       -->
+    {% for filter in tomcat.filter %}
+    <filter>
+        <filter-name>{{filter.name}}</filter-name>
+        <filter-class>{{filter.class}}</filter-class>
+    </filter>
+    {% endfor %}
+
+    {% for filter_mapping in tomcat.filter_mapping %}
+    <filter-mapping>
+        <filter-name>{{filter_mapping.name}}</filter-name>
+        <url-pattern>{{filter_mapping.url_pattern}}</url-pattern>
+    </filter-mapping>
+    {% endfor %}
+
     <servlet>
         <servlet-name>default</servlet-name>
         <servlet-class>org.apache.catalina.servlets.DefaultServlet</servlet-class>

--- a/distribution/kernel/carbon-home/repository/resources/conf/templates/repository/conf/tomcat/web.xml.j2
+++ b/distribution/kernel/carbon-home/repository/resources/conf/templates/repository/conf/tomcat/web.xml.j2
@@ -97,6 +97,12 @@
     <filter>
         <filter-name>{{filter.name}}</filter-name>
         <filter-class>{{filter.class}}</filter-class>
+        {% for key,value in filter.init_params.items() %}
+        <init-param>
+            <param-name>{{key}}</param-name>
+            <param-value>{{value}}</param-value>
+        </init-param>
+        {% endfor %}
     </filter>
     {% endfor %}
 
@@ -104,6 +110,9 @@
     <filter-mapping>
         <filter-name>{{filter_mapping.name}}</filter-name>
         <url-pattern>{{filter_mapping.url_pattern}}</url-pattern>
+        {% for dispatcher in filter_mapping.dispatchers %}
+        <dispatcher>{{dispatcher}}</dispatcher>
+        {% endfor %}
     </filter-mapping>
     {% endfor %}
 


### PR DESCRIPTION
Update web.xml.j2 template file to add custom filters and filter-mappings.

## Purpose
> This fix is to enable the products to configure custom filters and filter-mappings in tomcat/web.xml using deployment.toml file. 

With this fix filters can be configured using deployment.toml as follows:

```
[[tomcat.filter]]
name = "<Filter-Name>"
class = "<Filter-Class>"
[tomcat.filter.init_params]
<param-name1> = <param-value1>
<param-name2> = <param-value2>

[[tomcat.filter_mapping]]
name = "<Filter-Name>"
url_pattern = "<URL-Pattern>"
dispatchers=["<dispatcher1>", "<dispatcher2>"]
```

**Example** : If the following config needs to be added to <IS_HOME>/repository/conf/tomcat/web.xml, the deployment.toml configuration should be as shown below.

Config that needs to be added to <IS_HOME>/repository/conf/tomcat/web.xml

  ```
  </filter>
        <filter-name>CORS</filter-name>
        <filter-class>com.thetransactioncompany.cors.CORSFilter</filter-class>
        <init-param>
            <param-name>cors.allowOrigin</param-name>
            <param-value>https://localhost:9000, https://localhost:9001</param-value>
        </init-param>
        <init-param>
            <param-name>cors.exposedHeaders</param-name>
            <param-value>Location</param-value>
        </init-param>
        <init-param>
            <param-name>cors.supportedMethods</param-name>
            <param-value>GET, HEAD, POST, DELETE, OPTIONS, PATCH, PUT</param-value>
        </init-param>
    </filter>

    <filter-mapping>
        <filter-name>CORS</filter-name>
        <url-pattern>/*</url-pattern>
        <dispatcher>FORWARD</dispatcher>
        <dispatcher>REQUEST</dispatcher>
    </filter-mapping>
```
Config to be added to <IS_HOME>/repository/conf/deployment.toml:
```
[[tomcat.filter]]
name = "CORS"
class = "com.thetransactioncompany.cors.CORSFilter"
[tomcat.filter.init_params]
"cors.allowOrigin"="https://localhost:9000, https://localhost:9001"
"cors.supportedMethods"="GET, HEAD, POST, DELETE, OPTIONS, PATCH, PUT"
"cors.exposedHeaders"="Location"

[[tomcat.filter_mapping]]
name = "CORS"
url_pattern = "/*"
dispatchers=["FORWARD", "REQUEST"]
```

Note : Note that since `<param-name>cors.exposedHeaders</param-name> ` contains fullstops(.) in the param-name, the key `"cors.exposedHeaders"` in `[tomcat.filter.init_params]` should be within double quotations("") as shown in the example. Not adding the quotations will result in a mis-configured filter.
