### PR TITLE
Add Date And Time Pattern for userstore configurations

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/UserStoreConfigConstants.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/UserStoreConfigConstants.java
@@ -55,6 +55,10 @@ public class UserStoreConfigConstants {
     public static final String timestampAttributes = "TimestampAttributes";
     public static final String timestampAttributesDescription = "Comma-separated list of user store attributes " +
             "having the data type of Timestamp and may require a conversion when reading from/writing to user store";
+    public static final String dateAndTimePattern = "DateAndTimePattern";
+    public static final String dateAndTimePatternDescription = "Pattern of Date and Time values are stored, if not " +
+            "specified default timestamp representation is used.";
+    public static final String dateAndTimePatternDisplayName = "Date And Time Pattern";
     public static final String timestampAttributesDisplayName = "Timestamp Attributes";
 
     //Mandatory to LDAP user stores

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/ActiveDirectoryUserStoreConstants.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/ActiveDirectoryUserStoreConstants.java
@@ -202,6 +202,8 @@ public class ActiveDirectoryUserStoreConstants {
                 UserStoreConfigConstants.userIdSearchFilterAttributeName, "(&(objectClass=person)(uid=?))",
                 UserStoreConfigConstants.userIdSearchFilterDescription, false,
                 new Property[] { USER.getProperty(), STRING.getProperty(), TRUE.getProperty() });
+        setProperty(UserStoreConfigConstants.dateAndTimePattern, "", UserStoreConfigConstants
+                .dateAndTimePatternDisplayName, UserStoreConfigConstants.dateAndTimePatternDescription, new Property[]{CONNECTION.getProperty(), STRING.getProperty(), FALSE.getProperty()});
     }
 
     private static void setMandatoryProperty(String name, String displayName, String value, String description,

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/ReadOnlyLDAPUserStoreConstants.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/ReadOnlyLDAPUserStoreConstants.java
@@ -126,6 +126,8 @@ public class ReadOnlyLDAPUserStoreConstants {
         setProperty(UserStoreConfigConstants.lDAPInitialContextFactory, "LDAP Initial Context Factory",
                 "com.sun.jndi.ldap.LdapCtxFactory", UserStoreConfigConstants.lDAPInitialContextFactoryDescription,
                 new Property[] { CONNECTION.getProperty(), STRING.getProperty(), FALSE.getProperty() });
+        setProperty(UserStoreConfigConstants.dateAndTimePattern, "", UserStoreConfigConstants
+                .dateAndTimePatternDisplayName, UserStoreConfigConstants.dateAndTimePatternDescription, new Property[]{CONNECTION.getProperty(), STRING.getProperty(), FALSE.getProperty()});
     }
 
     private static void setMandatoryProperty(String name, String displayName, String value, String description,

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/ReadWriteLDAPUserStoreConstants.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/ReadWriteLDAPUserStoreConstants.java
@@ -161,6 +161,8 @@ public class ReadWriteLDAPUserStoreConstants {
         setProperty(UserStoreConfigConstants.lDAPInitialContextFactory, "LDAP Initial Context Factory",
                 "com.sun.jndi.ldap.LdapCtxFactory", UserStoreConfigConstants.lDAPInitialContextFactoryDescription,
                 new Property[] { CONNECTION.getProperty(), STRING.getProperty(), FALSE.getProperty() });
+        setProperty(UserStoreConfigConstants.dateAndTimePattern, "", UserStoreConfigConstants
+                .dateAndTimePatternDisplayName, UserStoreConfigConstants.dateAndTimePatternDescription, new Property[]{CONNECTION.getProperty(), STRING.getProperty(), FALSE.getProperty()});
     }
 
     private static void setMandatoryProperty(String name, String displayName, String value, String description,


### PR DESCRIPTION
## Purpose
Add Date And Time Pattern for userstore configurations for LDAP and AD userstore config