### PR TITLE
Add key-mappings for DateAndTimePattern user-store property

### DIFF
--- a/distribution/kernel/carbon-home/repository/resources/conf/key-mappings.json
+++ b/distribution/kernel/carbon-home/repository/resources/conf/key-mappings.json
@@ -84,6 +84,7 @@
   "user_store.kdc_enabled": "user_store.properties.kdcEnabled",
   "user_store.membership_attribute_range": "user_store.properties.MembershipAttributeRange",
   "user_store.ssl_certificate_validation_enabled": "user_store.properties.SSLCertificateValidationEnabled",
+  "user_store.date_and_time_pattern": "user_store.properties.DateAndTimePattern",
 
   "transport.https.properties.certificate_verification": "transport.https.sslHostConfig.properties.certificateVerification",
   "transport.https.properties.protocols": "transport.https.sslHostConfig.properties.protocols",


### PR DESCRIPTION
## Purpose
Add key-mappings for DateAndTimePattern user-store property
- With this fix, DateAndTimePattern can be defined as in below example
```
[user_store]
date_and_time_pattern = "yyyyMMddHHmmssZ"
```