### PR TITLE
Update multi-valued user claims independently from non-multi-valued claims

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/UniqueIDUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/UniqueIDUserStoreManager.java
@@ -247,11 +247,14 @@ public interface UniqueIDUserStoreManager extends UserStoreManager {
      * @param profileName                      The profile name, can be null. If null the default profile is considered.
      * @throws UserStoreException Thrown if an error occurred in userstore operation.
      */
-    void setUserClaimValuesWithID(String userID, Map<String, List<String>> oldClaimMap,
+    default void setUserClaimValuesWithID(String userID, Map<String, List<String>> oldClaimMap,
                                   Map<String, List<String>> multiValuedClaimsToAdd,
                                   Map<String, List<String>> multiValuedClaimsToDelete,
                                   Map<String, List<String>> claimsExcludingMultiValuedClaims,
-                                  String profileName) throws UserStoreException;
+                                  String profileName) throws UserStoreException {
+
+        throw new UserStoreException("Operation is not supported.");
+    }
 
     /**
      * Retrieves a list of users for given user claim value.

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/UniqueIDUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/UniqueIDUserStoreManager.java
@@ -237,6 +237,23 @@ public interface UniqueIDUserStoreManager extends UserStoreManager {
             throws UserStoreException;
 
     /**
+     * Set user claim values.
+     *
+     * @param userID                           UserID of the user.
+     * @param oldClaimMap                      A map of existing claim URIs of the user against values.
+     * @param multiValuedClaimsToAdd           A map of multi-valued claim URIs against values to add.
+     * @param multiValuedClaimsToDelete        A map of multi-valued claim URIs against values to delete.
+     * @param claimsExcludingMultiValuedClaims A map of non-multi-valued claim URIs against values to replace.
+     * @param profileName                      The profile name, can be null. If null the default profile is considered.
+     * @throws UserStoreException Thrown if an error occurred in userstore operation.
+     */
+    void setUserClaimValuesWithID(String userID, Map<String, List<String>> oldClaimMap,
+                                  Map<String, List<String>> multiValuedClaimsToAdd,
+                                  Map<String, List<String>> multiValuedClaimsToDelete,
+                                  Map<String, List<String>> claimsExcludingMultiValuedClaims,
+                                  String profileName) throws UserStoreException;
+
+    /**
      * Retrieves a list of users for given user claim value.
      *
      * @param claim       claim uri.

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
@@ -615,10 +615,6 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
                                              Map<String, List<String>> claimAttributesToReplace, String profileName)
             throws UserStoreException, NotImplementedException {
 
-        if (log.isDebugEnabled()) {
-            log.debug("doSetUserAttributes operation is not implemented in: " + this.getClass());
-        }
-
         throw new NotImplementedException("doSetUserAttributes operation is not implemented in: " + this.getClass());
     }
 
@@ -658,9 +654,6 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
                                              Map<String, List<String>> claimAttributesToReplace, String profileName)
             throws UserStoreException, NotImplementedException {
 
-        if (log.isDebugEnabled()) {
-            log.debug("doSetUserAttributesWithID operation is not implemented in: " + this.getClass());
-        }
         throw new NotImplementedException("doSetUserAttributesWithID operation is not implemented in: "
                 + this.getClass());
     }
@@ -15442,7 +15435,6 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
                             e.getMessage()), userID, claims, profileName);
             throw e;
         }
-
     }
 
     private void invokeDoPostSetUserClaimsWithIDListeners(String userID, Map<String, String> claims, String profileName)

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
@@ -735,7 +735,7 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
                                         String profileName)
             throws UserStoreException, NotImplementedException {
 
-        if (profileName == null) {
+        if (StringUtils.isBlank(profileName)) {
             profileName = UserCoreConstants.DEFAULT_PROFILE;
         }
 
@@ -792,7 +792,6 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
             throws UserStoreException {
 
         Map<String, List<String>> userStoreAttributeValueMap = new HashMap<>();
-
         try {
             for (Map.Entry<String, List<String>> claimEntry : claims.entrySet()) {
                 String claimURI = claimEntry.getKey();
@@ -801,11 +800,9 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
             }
         } catch (org.wso2.carbon.user.api.UserStoreException e) {
             String errorMessage = "Error occurred while getting claim attribute for user : " + userIdentifier;
-
             if (log.isDebugEnabled()) {
                 log.debug(errorMessage, e);
             }
-
             throw new UserStoreException(errorMessage, e);
         }
         return userStoreAttributeValueMap;
@@ -12905,8 +12902,7 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
         invokeDoPreSetUserClaimsWithIDListeners(userID, claims, profileName);
         // #################### </Pre Listeners> #####################################################
 
-        // If user store is readonly this method should not get invoked with non empty claim set.
-
+        // If userstore is readonly this method should not get invoked with non empty claim set.
         if (isReadOnly() && !claims.isEmpty()) {
             handleSetUserClaimValuesFailureWithID(ErrorMessages.ERROR_CODE_READONLY_USER_STORE.getCode(),
                     ErrorMessages.ERROR_CODE_READONLY_USER_STORE.getMessage(), userID, claims, profileName);

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
@@ -602,6 +602,29 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
     /**
      * Set the user attributes of a user.
      *
+     * @param userName                 UserName of the user.
+     * @param claimAttributesToAdd     A processed map of userstore attribute values to add.
+     * @param claimAttributesToDelete  A processed map of userstore attribute values to delte.
+     * @param claimAttributesToReplace A processed map of userstore attribute values to replace.
+     * @param profileName              The profile name, can be null. If null the default profile is considered.
+     * @throws UserStoreException      Thrown if the userstore operation fails.
+     * @throws NotImplementedException Thrown if the operation is not implemented in the underlying userstore.
+     */
+    protected void doSetUserAttributes(String userName, Map<String, List<String>> claimAttributesToAdd,
+                                             Map<String, List<String>> claimAttributesToDelete,
+                                             Map<String, List<String>> claimAttributesToReplace, String profileName)
+            throws UserStoreException, NotImplementedException {
+
+        if (log.isDebugEnabled()) {
+            log.debug("doSetUserAttributes operation is not implemented in: " + this.getClass());
+        }
+
+        throw new NotImplementedException("doSetUserAttributes operation is not implemented in: " + this.getClass());
+    }
+
+    /**
+     * Set the user attributes of a user.
+     *
      * @param processedClaimAttributes A processed map of user store attribute values.
      * @param userID                   UserID of the user.
      * @param profileName              The profile name, can be null. If null the default profile is considered.
@@ -615,6 +638,29 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
             log.debug("doSetUserAttributesWithID operation is not implemented in: " + this.getClass());
         }
 
+        throw new NotImplementedException("doSetUserAttributesWithID operation is not implemented in: "
+                + this.getClass());
+    }
+
+    /**
+     * Set the user attributes of a user.
+     *
+     * @param userID                   UserID of the user.
+     * @param claimAttributesToAdd     A processed map of userstore attribute values to add.
+     * @param claimAttributesToDelete  A processed map of userstore attribute values to delete.
+     * @param claimAttributesToReplace A processed map of userstore attribute values to replace.
+     * @param profileName              The profile name, can be null. If null the default profile is considered.
+     * @throws UserStoreException      Thrown if the userstore operation fails.
+     * @throws NotImplementedException Thrown if the operation is not implemented in the underlying userstore.
+     */
+    protected void doSetUserAttributesWithID(String userID, Map<String, List<String>> claimAttributesToAdd,
+                                             Map<String, List<String>> claimAttributesToDelete,
+                                             Map<String, List<String>> claimAttributesToReplace, String profileName)
+            throws UserStoreException, NotImplementedException {
+
+        if (log.isDebugEnabled()) {
+            log.debug("doSetUserAttributesWithID operation is not implemented in: " + this.getClass());
+        }
         throw new NotImplementedException("doSetUserAttributesWithID operation is not implemented in: "
                 + this.getClass());
     }
@@ -672,6 +718,45 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
     }
 
     /**
+     * Set many user claim values by treating multi-valued claims independently from simple claims.
+     *
+     * @param userName                         User's username.
+     * @param multiValuedClaimsToAdd           Map of multi-valued claim URIs against values to be added.
+     * @param multiValuedClaimsToDelete        Map of multi-valued claim URIs against values to be deleted.
+     * @param claimsExcludingMultiValuedClaims Map of claim URIs excluding multi-valued claims against values
+     *                                         to be modified.
+     * @param profileName                      The profile name, can be null. If null the default profile is considered.
+     * @throws UserStoreException      An unexpected exception has occurred.
+     * @throws NotImplementedException Functionality is not implemented exception.
+     */
+    protected void doSetUserClaimValues(String userName, Map<String, List<String>> multiValuedClaimsToAdd,
+                                        Map<String, List<String>> multiValuedClaimsToDelete,
+                                        Map<String, List<String>> claimsExcludingMultiValuedClaims,
+                                        String profileName)
+            throws UserStoreException, NotImplementedException {
+
+        if (profileName == null) {
+            profileName = UserCoreConstants.DEFAULT_PROFILE;
+        }
+
+        // Resolving claims to user store attributes.
+        Map<String, List<String>> claimAttributeValueMapToAdd =
+                resolveUserStoreAttributeValueMaps(userName, multiValuedClaimsToAdd);
+        Map<String, List<String>> claimAttributeValueMapToDelete =
+                resolveUserStoreAttributeValueMaps(userName, multiValuedClaimsToDelete);
+        Map<String, List<String>> claimAttributeValueMapToModify =
+                resolveUserStoreAttributeValueMaps(userName, claimsExcludingMultiValuedClaims);
+
+        processAttributesBeforeUpdate(userName, claimAttributeValueMapToAdd, profileName);
+        processAttributesBeforeUpdate(userName, claimAttributeValueMapToDelete, profileName);
+        processAttributesBeforeUpdate(userName, claimAttributeValueMapToModify, profileName);
+
+        // Persist the attribute values map.
+        doSetUserAttributes(userName, claimAttributeValueMapToAdd, claimAttributeValueMapToDelete,
+                claimAttributeValueMapToModify, profileName);
+    }
+
+    /**
      * Resolves claim URIs as user store properties.
      *
      * @param userIdentifier Username of the user.
@@ -686,6 +771,30 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
 
         try {
             for (Map.Entry<String, String> claimEntry : claims.entrySet()) {
+                String claimURI = claimEntry.getKey();
+                String attributeName = getClaimAtrribute(claimURI, userIdentifier, null);
+                userStoreAttributeValueMap.put(attributeName, claimEntry.getValue());
+            }
+        } catch (org.wso2.carbon.user.api.UserStoreException e) {
+            String errorMessage = "Error occurred while getting claim attribute for user : " + userIdentifier;
+
+            if (log.isDebugEnabled()) {
+                log.debug(errorMessage, e);
+            }
+
+            throw new UserStoreException(errorMessage, e);
+        }
+        return userStoreAttributeValueMap;
+    }
+
+    private Map<String, List<String>> resolveUserStoreAttributeValueMaps(String userIdentifier,
+                                                                         Map<String, List<String>> claims)
+            throws UserStoreException {
+
+        Map<String, List<String>> userStoreAttributeValueMap = new HashMap<>();
+
+        try {
+            for (Map.Entry<String, List<String>> claimEntry : claims.entrySet()) {
                 String claimURI = claimEntry.getKey();
                 String attributeName = getClaimAtrribute(claimURI, userIdentifier, null);
                 userStoreAttributeValueMap.put(attributeName, claimEntry.getValue());
@@ -724,6 +833,41 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
 
         // Persist the attribute values map.
         doSetUserAttributesWithID(userID, claimAttributeValueMapForPersist, profileName);
+    }
+
+    /**
+     * Set many user claim values.
+     *
+     * @param userID                           The user ID.
+     * @param multiValuedClaimsToAdd           Map of multi-valued claim URIs against values to add.
+     * @param multiValuedClaimsToDelete        Map of multi-valued claim URIs against values to delete.
+     * @param claimsExcludingMultiValuedClaims Map of non-multi-valued claim URIs against values to replace.
+     * @param profileName                      The profile name, can be null. If null the default profile is considered.
+     * @throws UserStoreException      Thrown if an unexpected exception has occurred in userstore operation.
+     * @throws NotImplementedException Thrown if the operation is not implemented in the underlying userstore.
+     */
+    protected void doSetUserClaimValuesWithID(String userID, Map<String, List<String>> multiValuedClaimsToAdd,
+                                              Map<String, List<String>> multiValuedClaimsToDelete,
+                                              Map<String, List<String>> claimsExcludingMultiValuedClaims,
+                                              String profileName) throws UserStoreException, NotImplementedException {
+
+        if (profileName == null) {
+            profileName = UserCoreConstants.DEFAULT_PROFILE;
+        }
+        // Resolving claims to user store attributes.
+        Map<String, List<String>> claimAttributeValueMapToAdd =
+                resolveUserStoreAttributeValueMaps(userID, multiValuedClaimsToAdd);
+        Map<String, List<String>> claimAttributeValueMapToDelete =
+                resolveUserStoreAttributeValueMaps(userID, multiValuedClaimsToDelete);
+        Map<String, List<String>> claimAttributeValueMapToModify =
+                resolveUserStoreAttributeValueMaps(userID, claimsExcludingMultiValuedClaims);
+
+        processAttributesBeforeUpdateWithID(userID, claimAttributeValueMapToAdd, profileName);
+        processAttributesBeforeUpdateWithID(userID, claimAttributeValueMapToDelete, profileName);
+        processAttributesBeforeUpdateWithID(userID, claimAttributeValueMapToModify, profileName);
+        // Persist the attribute values map.
+        doSetUserAttributesWithID(userID, claimAttributeValueMapToAdd, claimAttributeValueMapToDelete,
+                claimAttributeValueMapToModify, profileName);
     }
 
     /**
@@ -7715,7 +7859,7 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
      * @param userAttributes Un-processed map (user store attribute name -> attribute value) of user store.
      * @param profileName    Profile name of the user.
      */
-    protected void processAttributesBeforeUpdate(String userName, Map<String, String> userAttributes,
+    protected void processAttributesBeforeUpdate(String userName, Map<String, ? extends Object> userAttributes,
                                                  String profileName) {
         // Not implemented for AbstractUserStoreManager, may have implementations at subclasses.
     }
@@ -7739,7 +7883,7 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
      * @param userAttributes Un-processed map (user store attribute name -> attribute value) of user store.
      * @param profileName    Profile name of the user.
      */
-    protected void processAttributesBeforeUpdateWithID(String userID, Map<String, String> userAttributes,
+    protected void processAttributesBeforeUpdateWithID(String userID, Map<String, ? extends Object> userAttributes,
                                                        String profileName) {
         // Not implemented for AbstractUserStoreManager, may have implementations at subclasses.
     }
@@ -12720,6 +12864,111 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
 
     }
 
+    /**
+     * Set user claim values.
+     *
+     * @param userID                           UserID of the user.
+     * @param oldClaimMap                      A map of existing claim URIs of the user against values.
+     * @param multiValuedClaimsToAdd           A map of multi-valued claim URIs against values to add.
+     * @param multiValuedClaimsToDelete        A map of multi-valued claim URIs against values to delete.
+     * @param claimsExcludingMultiValuedClaims A map of non-multi-valued claim URIs against values to replace.
+     * @param profileName                      The profile name, can be null. If null the default profile is considered.
+     * @throws UserStoreException Thrown if an error occured in userstore operation.
+     */
+    public final void setUserClaimValuesWithID(String userID, Map<String, List<String>> oldClaimMap,
+                                               Map<String, List<String>> multiValuedClaimsToAdd,
+                                               Map<String, List<String>> multiValuedClaimsToDelete,
+                                               Map<String, List<String>> claimsExcludingMultiValuedClaims,
+                                               String profileName) throws UserStoreException {
+
+        UserStore userStore = getUserStoreWithID(userID);
+        if (userStore.isRecurssive()) {
+            ((AbstractUserStoreManager) userStore.getUserStoreManager())
+                    .setUserClaimValuesWithID(userStore.getDomainFreeUserId(), oldClaimMap, multiValuedClaimsToAdd,
+                            multiValuedClaimsToDelete, claimsExcludingMultiValuedClaims, profileName);
+            return;
+        }
+        Map<String, String> claims =
+                getModifiedClaims(oldClaimMap, multiValuedClaimsToAdd, multiValuedClaimsToDelete,
+                        claimsExcludingMultiValuedClaims);
+
+        // #################### Domain Name Free Zone Starts Here ################################
+
+        boolean isUniqueIdEnabled = isUniqueUserIdEnabledInUserStore(userStore);
+        boolean isUserExists;
+        if (isUniqueIdEnabled) {
+            isUserExists = doCheckExistingUserWithID(userID);
+        } else {
+            String userNameFromUserID = doGetUserNameFromUserID(userID);
+            isUserExists = userNameFromUserID != null;
+        }
+
+        if (!isUserExists) {
+            String errorMessage = String.format(ErrorMessages.ERROR_CODE_NON_EXISTING_USER.getMessage(), userID,
+                    realmConfig.getUserStoreProperty(UserCoreConstants.RealmConfig.PROPERTY_DOMAIN_NAME));
+            String errorCode = ErrorMessages.ERROR_CODE_NON_EXISTING_USER.getCode();
+            handleSetUserClaimValuesFailureWithID(errorCode, errorMessage, userID, claims, profileName);
+            throw new UserStoreException(errorCode + " - " + errorMessage);
+        }
+
+        // #################### <Pre Listeners> #####################################################
+        invokeDoPreSetUserClaimsWithIDListeners(userID, claims, profileName);
+        // #################### </Pre Listeners> #####################################################
+
+        // If user store is readonly this method should not get invoked with non empty claim set.
+
+        if (isReadOnly() && !claims.isEmpty()) {
+            handleSetUserClaimValuesFailureWithID(ErrorMessages.ERROR_CODE_READONLY_USER_STORE.getCode(),
+                    ErrorMessages.ERROR_CODE_READONLY_USER_STORE.getMessage(), userID, claims, profileName);
+            throw new UserStoreException(ErrorMessages.ERROR_CODE_READONLY_USER_STORE.toString());
+        }
+
+        // Any additional simple claim modified due to pre listeners are taken into claimsExcludingMultiValuedClaims map.
+        String separator = ",";
+        if (StringUtils.isNotEmpty(realmConfig.getUserStoreProperty(MULTI_ATTRIBUTE_SEPARATOR))) {
+            separator = realmConfig.getUserStoreProperty(MULTI_ATTRIBUTE_SEPARATOR);
+        }
+        if (claimsExcludingMultiValuedClaims != null) {
+            for (Map.Entry<String, String> claim : claims.entrySet()) {
+                claimsExcludingMultiValuedClaims.put(claim.getKey(), Arrays.asList(claim.getValue().split(separator)));
+            }
+        }
+        (claimsExcludingMultiValuedClaims.keySet()).removeAll(multiValuedClaimsToAdd.keySet());
+        (claimsExcludingMultiValuedClaims.keySet()).removeAll(multiValuedClaimsToDelete.keySet());
+
+        // Set claim values if user store is not read only.
+        try {
+            if (!isReadOnly()) {
+                // If unique id feature is not enabled, we have to call the legacy methods.
+                if (!isUniqueUserIdEnabledInUserStore(userStore)) {
+                    User user = userUniqueIDManger.getUser(userID, this);
+                    doSetUserClaimValues(user.getUsername(), multiValuedClaimsToAdd, multiValuedClaimsToDelete,
+                            claimsExcludingMultiValuedClaims, profileName);
+                } else {
+                    doSetUserClaimValuesWithID(userID, multiValuedClaimsToAdd, multiValuedClaimsToDelete,
+                            claimsExcludingMultiValuedClaims, profileName);
+                }
+            }
+        } catch (NotImplementedException e) {
+            if (!isUniqueUserIdEnabledInUserStore(userStore)) {
+                User user = userUniqueIDManger.getUser(userID, this);
+                doSetUserClaimValues(user.getUsername(), claims, profileName);
+            } else {
+                doSetUserClaimValuesWithID(userID, claims, profileName);
+            }
+        } catch (UserStoreException e) {
+            handleSetUserClaimValuesFailureWithID(
+                    ErrorMessages.ERROR_CODE_ERROR_WHILE_SETTING_USER_CLAIM_VALUES.getCode(),
+                    String.format(ErrorMessages.ERROR_CODE_ERROR_WHILE_SETTING_USER_CLAIM_VALUES.getMessage(),
+                            e.getMessage()), userID, claims, profileName);
+            throw e;
+        }
+
+        // #################### <Post Listeners> #####################################################
+        invokeDoPostSetUserClaimsWithIDListeners(userID, claims, profileName);
+        // #################### </Post Listeners> #####################################################
+    }
+
     @Override
     public final void updateCredentialByAdminWithID(String userID, Object newCredential) throws UserStoreException {
 
@@ -15122,5 +15371,115 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
             domainNameProperty = UserCoreConstants.PRIMARY_DEFAULT_DOMAIN_NAME;
         }
         return domainNameProperty;
+    }
+
+    /**
+     * Process and return the modifed claim values against claim URI. Add or remove specific claim values
+     * against old claim values of multi-valued claims. Replace old claim values from modified values for
+     * non multi-valued claims.
+     *
+     * @param oldClaimMap                      Map of claim URIs against old claim values of user.
+     * @param multiValuedClaimsToAdd           Map of multi-valued claim URIs against values need to be added to
+     *                                         old claim value.
+     * @param multiValuedClaimsToDelete        Map of multi-valued claim URIs against values need to be removed from
+     *                                         old claim value.
+     * @param claimsExcludingMultiValuedClaims Map of non multi-valued claim URIs against modified values to be stred.
+     * @return Map of claim URIs against the modified claim values.
+     */
+    private Map<String, String> getModifiedClaims(Map<String, List<String>> oldClaimMap,
+                                                  Map<String, List<String>> multiValuedClaimsToAdd,
+                                                  Map<String, List<String>> multiValuedClaimsToDelete,
+                                                  Map<String, List<String>> claimsExcludingMultiValuedClaims) {
+
+        Map<String, String> claims = new HashMap<>();
+        String separator = ",";
+        if (StringUtils.isNotEmpty(realmConfig.getUserStoreProperty(MULTI_ATTRIBUTE_SEPARATOR))) {
+            separator = realmConfig.getUserStoreProperty(MULTI_ATTRIBUTE_SEPARATOR);
+        }
+        if (claimsExcludingMultiValuedClaims != null) {
+            for (String claimURI : claimsExcludingMultiValuedClaims.keySet()) {
+                claims.put(claimURI,
+                        StringUtils.join(claimsExcludingMultiValuedClaims.get(claimURI).iterator(), separator));
+            }
+        }
+
+        // Get modified claim values for multi-valued claims.
+        if (multiValuedClaimsToAdd != null) {
+            for (String claimURI : multiValuedClaimsToAdd.keySet()) {
+                List<String> modifiedValue = new ArrayList<>();
+                if (oldClaimMap.containsKey(claimURI)) {
+                    modifiedValue.addAll(oldClaimMap.get(claimURI));
+                    modifiedValue.addAll(multiValuedClaimsToAdd.get(claimURI));
+                } else {
+                    modifiedValue.addAll(multiValuedClaimsToAdd.get(claimURI));
+                }
+                claims.put(claimURI, StringUtils.join(modifiedValue.iterator(), separator));
+            }
+        }
+        if (multiValuedClaimsToDelete != null) {
+            for (String claimURI : multiValuedClaimsToDelete.keySet()) {
+                List<String> values = null;
+                if (claims.containsKey(claimURI)) {
+                    values = Arrays.asList(claims.get(claimURI).split(separator));
+                } else if (oldClaimMap.containsKey(claimURI)) {
+                    values = oldClaimMap.get(claimURI);
+                }
+                if (!CollectionUtils.isEmpty(values)) {
+                    List<String> modifiedValue =
+                            (List<String>) CollectionUtils.subtract(values, multiValuedClaimsToDelete.get(claimURI));
+                    claims.put(claimURI, StringUtils.join(modifiedValue.iterator(), separator));
+                }
+            }
+        }
+        return claims;
+    }
+
+    private void invokeDoPreSetUserClaimsWithIDListeners(String userID, Map<String, String> claims, String profileName)
+            throws UserStoreException {
+
+        try {
+            for (UserOperationEventListener listener : UMListenerServiceComponent.getUserOperationEventListeners()) {
+                if (!((AbstractUserOperationEventListener) listener)
+                        .doPreSetUserClaimValuesWithID(userID, claims, profileName, this)) {
+                    handleSetUserClaimValuesFailureWithID(
+                            ErrorMessages.ERROR_CODE_ERROR_DURING_PRE_SET_USER_CLAIM_VALUES.getCode(),
+                            String.format(ErrorMessages.ERROR_CODE_ERROR_DURING_PRE_SET_USER_CLAIM_VALUES.getMessage(),
+                                    UserCoreErrorConstants.PRE_LISTENER_TASKS_FAILED_MESSAGE), userID, claims,
+                            profileName);
+                    return;
+                }
+            }
+        } catch (UserStoreException e) {
+            handleSetUserClaimValuesFailureWithID(
+                    ErrorMessages.ERROR_CODE_ERROR_DURING_PRE_SET_USER_CLAIM_VALUES.getCode(),
+                    String.format(ErrorMessages.ERROR_CODE_ERROR_DURING_PRE_SET_USER_CLAIM_VALUES.getMessage(),
+                            e.getMessage()), userID, claims, profileName);
+            throw e;
+        }
+
+    }
+
+    private void invokeDoPostSetUserClaimsWithIDListeners(String userID, Map<String, String> claims, String profileName)
+            throws UserStoreException {
+
+        try {
+            for (UserOperationEventListener listener : UMListenerServiceComponent.getUserOperationEventListeners()) {
+                if (!((AbstractUserOperationEventListener) listener)
+                        .doPostSetUserClaimValuesWithID(userID, claims, profileName, this)) {
+                    handleSetUserClaimValuesFailureWithID(
+                            ErrorMessages.ERROR_CODE_ERROR_DURING_POST_SET_USER_CLAIM_VALUES.getCode(),
+                            String.format(ErrorMessages.ERROR_CODE_ERROR_DURING_POST_SET_USER_CLAIM_VALUES.getMessage(),
+                                    UserCoreErrorConstants.POST_LISTENER_TASKS_FAILED_MESSAGE), userID, claims,
+                            profileName);
+                    return;
+                }
+            }
+        } catch (UserStoreException e) {
+            handleSetUserClaimValuesFailureWithID(
+                    ErrorMessages.ERROR_CODE_ERROR_DURING_POST_SET_USER_CLAIM_VALUES.getCode(),
+                    String.format(ErrorMessages.ERROR_CODE_ERROR_DURING_POST_SET_USER_CLAIM_VALUES.getMessage(),
+                            e.getMessage()), userID, claims, profileName);
+            throw e;
+        }
     }
 }

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
@@ -12864,17 +12864,7 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
 
     }
 
-    /**
-     * Set user claim values.
-     *
-     * @param userID                           UserID of the user.
-     * @param oldClaimMap                      A map of existing claim URIs of the user against values.
-     * @param multiValuedClaimsToAdd           A map of multi-valued claim URIs against values to add.
-     * @param multiValuedClaimsToDelete        A map of multi-valued claim URIs against values to delete.
-     * @param claimsExcludingMultiValuedClaims A map of non-multi-valued claim URIs against values to replace.
-     * @param profileName                      The profile name, can be null. If null the default profile is considered.
-     * @throws UserStoreException Thrown if an error occured in userstore operation.
-     */
+    @Override
     public final void setUserClaimValuesWithID(String userID, Map<String, List<String>> oldClaimMap,
                                                Map<String, List<String>> multiValuedClaimsToAdd,
                                                Map<String, List<String>> multiValuedClaimsToDelete,

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/IterativeUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/IterativeUserStoreManager.java
@@ -20,6 +20,7 @@ package org.wso2.carbon.user.core.common;
 
 import org.wso2.carbon.user.api.Properties;
 import org.wso2.carbon.user.api.RealmConfiguration;
+import org.wso2.carbon.user.core.NotImplementedException;
 import org.wso2.carbon.user.core.UserStoreException;
 import org.wso2.carbon.user.core.tenant.Tenant;
 
@@ -136,6 +137,16 @@ public class IterativeUserStoreManager extends AbstractUserStoreManager {
     public void doSetUserClaimValues(String userName, Map<String, String> claims, String profileName) throws UserStoreException {
 
         this.abstractUserStoreManager.doSetUserClaimValues(userName, claims, profileName);
+    }
+
+    @Override
+    protected void doSetUserClaimValues(String userName, Map<String, List<String>> multiValuedClaimsToAdd,
+                                        Map<String, List<String>> multiValuedClaimsToDelete,
+                                        Map<String, List<String>> claimsExcludingMultiValuedClaims, String profileName)
+            throws UserStoreException, NotImplementedException {
+
+        this.abstractUserStoreManager.doSetUserClaimValues(userName, multiValuedClaimsToAdd, multiValuedClaimsToDelete,
+                claimsExcludingMultiValuedClaims, profileName);
     }
 
     @Override

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/JDBCUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/JDBCUserStoreManager.java
@@ -27,6 +27,7 @@ import org.wso2.carbon.context.CarbonContext;
 import org.wso2.carbon.user.api.Properties;
 import org.wso2.carbon.user.api.Property;
 import org.wso2.carbon.user.api.RealmConfiguration;
+import org.wso2.carbon.user.core.NotImplementedException;
 import org.wso2.carbon.user.core.UserCoreConstants;
 import org.wso2.carbon.user.core.UserRealm;
 import org.wso2.carbon.user.core.UserStoreException;
@@ -2233,6 +2234,15 @@ public class JDBCUserStoreManager extends AbstractUserStoreManager {
     }
 
     @Override
+    public void doSetUserClaimValues(String userName, Map<String, List<String>> multiValuedClaimsToAdd,
+                                           Map<String, List<String>> multiValuedClaimsToDelete,
+                                           Map<String, List<String>> claimsExcludingMultiValuedClaims,
+                                           String profileName) throws UserStoreException, NotImplementedException {
+
+        throw new NotImplementedException("This functionality is not yet implemented for JDBC userstores.");
+    }
+
+    @Override
     protected void doSetUserAttributes(String userName, Map<String, String> processedClaimAttributes,
                                        String profileName) throws UserStoreException {
 
@@ -2259,6 +2269,14 @@ public class JDBCUserStoreManager extends AbstractUserStoreManager {
         } finally {
             DatabaseUtil.closeAllConnections(dbConnection);
         }
+    }
+
+    protected void doSetUserAttributes(String userName, Map<String, List<String>> claimAttributesToAdd,
+                                       Map<String, List<String>> claimAttributesToDelete,
+                                       Map<String, List<String>> claimAttributesToReplace, String profileName)
+            throws NotImplementedException, UserStoreException {
+
+        throw new NotImplementedException("This functionality is not yet implemented for JDBC userstores.");
     }
 
     /**

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCUserStoreManager.java
@@ -26,6 +26,7 @@ import org.wso2.carbon.CarbonConstants;
 import org.wso2.carbon.context.CarbonContext;
 import org.wso2.carbon.user.api.Property;
 import org.wso2.carbon.user.api.RealmConfiguration;
+import org.wso2.carbon.user.core.NotImplementedException;
 import org.wso2.carbon.user.core.UserCoreConstants;
 import org.wso2.carbon.user.core.UserRealm;
 import org.wso2.carbon.user.core.UserStoreException;
@@ -1809,11 +1810,29 @@ public class UniqueIDJDBCUserStoreManager extends JDBCUserStoreManager {
     }
 
     @Override
+    public void doSetUserClaimValues(String userName, Map<String, List<String>> multiValuedClaimsToAdd,
+                                     Map<String, List<String>> multiValuedClaimsToDelete,
+                                     Map<String, List<String>> claimsExcludingMultiValuedClaims,
+                                     String profileName) throws UserStoreException {
+
+        throw new UserStoreException("Operation is not supported.");
+    }
+
+    @Override
     public void doSetUserClaimValuesWithID(String userID, Map<String, String> claims, String profileName)
             throws UserStoreException {
 
         claims.putIfAbsent(UserCoreConstants.PROFILE_CONFIGURATION, UserCoreConstants.DEFAULT_PROFILE_CONFIGURATION);
         super.doSetUserClaimValuesWithID(userID, claims, profileName);
+    }
+
+    @Override
+    public void doSetUserClaimValuesWithID(String userID, Map<String, List<String>> multiValuedClaimsToAdd,
+                                           Map<String, List<String>> multiValuedClaimsToDelete,
+                                           Map<String, List<String>> claimsExcludingMultiValuedClaims,
+                                           String profileName) throws NotImplementedException {
+
+        throw new NotImplementedException("This functionality is not yet implemented for JDBC userstores.");
     }
 
     @Override
@@ -1847,6 +1866,15 @@ public class UniqueIDJDBCUserStoreManager extends JDBCUserStoreManager {
     }
 
     @Override
+    protected void doSetUserAttributesWithID(String userID, Map<String, List<String>> claimAttributesToAdd,
+                              Map<String, List<String>> claimAttributesToDelete,
+                              Map<String, List<String>> claimAttributesToReplace, String profileName)
+            throws NotImplementedException {
+
+        throw new NotImplementedException("This functionality is not yet implemented for JDBC userstores.");
+    }
+
+    @Override
     protected void doSetUserAttribute(String userName, String attributeName, String value, String profileName)
             throws UserStoreException {
 
@@ -1856,6 +1884,15 @@ public class UniqueIDJDBCUserStoreManager extends JDBCUserStoreManager {
     @Override
     protected void doSetUserAttributes(String userName, Map<String, String> processedClaimAttributes,
                                        String profileName) throws UserStoreException {
+
+        throw new UserStoreException("Operation is not supported.");
+    }
+
+    @Override
+    protected void doSetUserAttributes(String userID, Map<String, List<String>> claimAttributesToAdd,
+                                       Map<String, List<String>> claimAttributesToDelete,
+                                       Map<String, List<String>> claimAttributesToReplace, String profileName)
+            throws UserStoreException {
 
         throw new UserStoreException("Operation is not supported.");
     }

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCUserStoreManager.java
@@ -1832,7 +1832,7 @@ public class UniqueIDJDBCUserStoreManager extends JDBCUserStoreManager {
                                            Map<String, List<String>> claimsExcludingMultiValuedClaims,
                                            String profileName) throws NotImplementedException {
 
-        throw new NotImplementedException("This functionality is not yet implemented for JDBC userstores.");
+        throw new NotImplementedException("This functionality is not yet implemented for UniqueID JDBC userstores.");
     }
 
     @Override

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/ReadOnlyLDAPUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/ReadOnlyLDAPUserStoreManager.java
@@ -3903,6 +3903,16 @@ public class ReadOnlyLDAPUserStoreManager extends AbstractUserStoreManager {
                 "User store is operating in read only mode. Cannot write into the user store.");
     }
 
+    @Override
+    protected void doSetUserAttributes(String userName, Map<String, List<String>> claimAttributesToAdd,
+                                       Map<String, List<String>> claimAttributesToDelete,
+                                       Map<String, List<String>> claimAttributesToReplace, String profileName)
+            throws UserStoreException {
+
+        throw new UserStoreException(
+                "User store is operating in read only mode. Cannot write into the user store.");
+    }
+
     /**
      *
      */

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/ReadWriteLDAPUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/ReadWriteLDAPUserStoreManager.java
@@ -954,14 +954,11 @@ public class ReadWriteLDAPUserStoreManager extends ReadOnlyLDAPUserStoreManager 
                 returnedUserEntry = returnedResultList.next().getName();
                 handleLdapUserNameAttributeChanges(claimAttributesToReplace, subDirContext, returnedUserEntry);
             }
-
         } catch (NamingException e) {
             String errorMessage = "Results could not be retrieved from the directory context for user : " + userName;
-
             if (log.isDebugEnabled()) {
                 log.debug(errorMessage, e);
             }
-
             throw new UserStoreException(errorMessage, e);
         } finally {
             JNDIUtil.closeNamingEnumeration(returnedResultList);

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/ReadWriteLDAPUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/ReadWriteLDAPUserStoreManager.java
@@ -26,6 +26,7 @@ import org.wso2.carbon.context.CarbonContext;
 import org.wso2.carbon.user.api.Properties;
 import org.wso2.carbon.user.api.Property;
 import org.wso2.carbon.user.api.RealmConfiguration;
+import org.wso2.carbon.user.core.NotImplementedException;
 import org.wso2.carbon.user.core.UserCoreConstants;
 import org.wso2.carbon.user.core.UserRealm;
 import org.wso2.carbon.user.core.UserStoreConfigConstants;
@@ -921,6 +922,80 @@ public class ReadWriteLDAPUserStoreManager extends ReadOnlyLDAPUserStoreManager 
         }
     }
 
+    protected void doSetUserAttributes(String userName, Map<String, List<String>> claimAttributesToAdd,
+                                       Map<String, List<String>> claimAttributesToDelete,
+                                       Map<String, List<String>> claimAttributesToReplace, String profileName)
+            throws UserStoreException, NotImplementedException {
+
+        // Get the LDAP Directory context.
+        DirContext dirContext = this.connectionSource.getContext();
+        DirContext subDirContext = null;
+        // Search the relevant user entry by user name.
+        String userSearchBase = realmConfig.getUserStoreProperty(LDAPConstants.USER_SEARCH_BASE);
+        String userSearchFilter = realmConfig
+                .getUserStoreProperty(LDAPConstants.USER_NAME_SEARCH_FILTER);
+        // If user name contains domain name, remove domain name.
+        userName = UserCoreUtil.removeDomainFromName(userName);
+        userSearchFilter = userSearchFilter.replace("?", escapeSpecialCharactersForFilter(userName));
+
+        SearchControls searchControls = new SearchControls();
+        searchControls.setSearchScope(SearchControls.SUBTREE_SCOPE);
+        searchControls.setReturningAttributes(null);
+
+        NamingEnumeration<SearchResult> returnedResultList = null;
+        String returnedUserEntry = StringUtils.EMPTY;
+
+        try {
+            subDirContext = (DirContext) dirContext.lookup(escapeDNForSearch(userSearchBase));
+            returnedResultList = dirContext.search(escapeDNForSearch(userSearchBase), userSearchFilter, searchControls);
+
+            // Assume only one user is returned from the search.
+            if (returnedResultList.hasMore()) {
+                returnedUserEntry = returnedResultList.next().getName();
+                handleLdapUserNameAttributeChanges(claimAttributesToReplace, subDirContext, returnedUserEntry);
+            }
+
+        } catch (NamingException e) {
+            String errorMessage = "Results could not be retrieved from the directory context for user : " + userName;
+
+            if (log.isDebugEnabled()) {
+                log.debug(errorMessage, e);
+            }
+
+            throw new UserStoreException(errorMessage, e);
+        } finally {
+            JNDIUtil.closeNamingEnumeration(returnedResultList);
+        }
+
+        try {
+            Attributes attributesToBeAdded = getUpdatedAttributes(userName, claimAttributesToAdd);
+            Attributes attributesToBeDeleted = getUpdatedAttributes(userName, claimAttributesToDelete);
+            Attributes attributesToBeReplaced = getUpdatedAttributes(userName, claimAttributesToReplace);
+            try {
+                subDirContext.modifyAttributes(returnedUserEntry, DirContext.ADD_ATTRIBUTE, attributesToBeAdded);
+            } catch (Exception e) {
+                if (!StringUtils.equals("error code 20 - ATTRIBUTE_OR_VALUE_EXISTS",
+                        (e.getMessage()).split(":")[1].trim())) {
+                    handleException(e, userName);
+                }
+            }
+            try {
+                subDirContext.modifyAttributes(returnedUserEntry, DirContext.REMOVE_ATTRIBUTE, attributesToBeDeleted);
+            } catch (Exception e) {
+                if (!StringUtils
+                        .equals("error code 16 - NO_SUCH_ATTRIBUTE", (e.getMessage()).split(":")[1].trim())) {
+                    handleException(e, userName);
+                }
+            }
+            subDirContext.modifyAttributes(returnedUserEntry, DirContext.REPLACE_ATTRIBUTE, attributesToBeReplaced);
+        } catch (NamingException e) {
+            handleException(e, userName);
+        } finally {
+            JNDIUtil.closeContext(subDirContext);
+            JNDIUtil.closeContext(dirContext);
+        }
+    }
+
     /**
      * Handle the modification of any changes to the userName attribute.
      *
@@ -929,12 +1004,24 @@ public class ReadWriteLDAPUserStoreManager extends ReadOnlyLDAPUserStoreManager 
      * @param returnedUserEntry   Returned result from the user search operation.
      * @throws NamingException Thrown if an error is occurred during the userName modification.
      */
-    protected void handleLdapUserNameAttributeChanges(Map<String, String> userAttributeValues,
+    protected void handleLdapUserNameAttributeChanges(Map<String, ? extends Object> userAttributeValues,
                                                       DirContext subDirContext, String returnedUserEntry)
             throws NamingException {
 
-        userAttributeValues.computeIfPresent(LDAPConstants.UID,
-                (attributeName, attributeValue) -> UserCoreUtil.removeDomainFromName(attributeValue));
+        if (userAttributeValues.containsKey(LDAPConstants.UID)) {
+            String attributeValue = StringUtils.EMPTY;
+            if (userAttributeValues.get(LDAPConstants.UID) instanceof String) {
+                Map<String, String> newMap = (Map<String, String>) userAttributeValues;
+                attributeValue = (String) userAttributeValues.get(LDAPConstants.UID);
+                newMap.put(LDAPConstants.UID, UserCoreUtil.removeDomainFromName(attributeValue));
+            } else if (userAttributeValues.get(LDAPConstants.UID) instanceof List) {
+                Map<String, List<String>> newMap = (Map<String, List<String>>) userAttributeValues;
+                List<String> domainNameFreeUserName = new ArrayList<>();
+                attributeValue = (String) ((List) userAttributeValues.get(LDAPConstants.UID)).get(0);
+                domainNameFreeUserName.add(UserCoreUtil.removeDomainFromName(attributeValue));
+                newMap.put(LDAPConstants.UID, domainNameFreeUserName);
+            }
+        }
     }
 
     @Override
@@ -2355,5 +2442,31 @@ public class ReadWriteLDAPUserStoreManager extends ReadOnlyLDAPUserStoreManager 
         Property property = new Property(name, value, displayName + "#" + description, null);
         RW_LDAP_UM_ADVANCED_PROPERTIES.add(property);
 
+    }
+
+    private Attributes getUpdatedAttributes(String userName, Map<String, List<String>> processedClaimAttributes) {
+
+        if (processedClaimAttributes.containsKey(realmConfig.getUserStoreProperty(
+                LDAPConstants.USER_NAME_ATTRIBUTE))) {
+            removeFromUserCache(userName);
+        }
+
+        Attributes updatedAttributes = new BasicAttributes(true);
+
+        processedClaimAttributes.entrySet().forEach(claimEntry -> {
+            Attribute currentUpdatedAttribute = new BasicAttribute(claimEntry.getKey());
+            // If updated attribute value is null, remove its values.
+            if (EMPTY_ATTRIBUTE_STRING.equals(claimEntry.getValue().get(0))) {
+                currentUpdatedAttribute.clear();
+            } else {
+                for (String claimValue : claimEntry.getValue()) {
+                    if (claimValue != null && claimValue.trim().length() > 0) {
+                        currentUpdatedAttribute.add(claimValue);
+                    }
+                }
+            }
+            updatedAttributes.put(currentUpdatedAttribute);
+        });
+        return updatedAttributes;
     }
 }

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/UniqueIDActiveDirectoryUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/UniqueIDActiveDirectoryUserStoreManager.java
@@ -577,13 +577,28 @@ public class UniqueIDActiveDirectoryUserStoreManager extends UniqueIDReadWriteLD
     }
 
     @Override
-    protected void handleLdapUserIdAttributeChanges(Map<String, String> userAttributeValues,
+    public void doSetUserClaimValues(String userName, Map<String, List<String>> multiValuedClaimsToAdd,
+                                     Map<String, List<String>> multiValuedClaimsToDelete,
+                                     Map<String, List<String>> claimsExcludingMultiValuedClaims,
+                                     String profileName) throws UserStoreException {
+
+        throw new UserStoreException("Operation is not supported.");
+    }
+
+    @Override
+    protected void handleLdapUserIdAttributeChanges(Map<String, ? extends Object> userAttributeValues,
                                                     DirContext subDirContext, String returnedUserEntry)
             throws NamingException {
 
         if (userAttributeValues.containsKey(LDAPConstants.CN)) {
-            subDirContext.rename(returnedUserEntry, LDAPConstants.CN_CAPITALIZED + "=" +
-                    escapeSpecialCharactersForDN(userAttributeValues.get(LDAPConstants.CN)));
+            String commonName = StringUtils.EMPTY;
+            if (userAttributeValues.get(LDAPConstants.CN) instanceof String) {
+                commonName = (String) userAttributeValues.get(LDAPConstants.CN);
+            } else if (userAttributeValues.get(LDAPConstants.CN) instanceof List) {
+                commonName = (String) ((List) userAttributeValues.get(LDAPConstants.CN)).get(0);
+            }
+            subDirContext.rename(returnedUserEntry,
+                    LDAPConstants.CN_CAPITALIZED + "=" + escapeSpecialCharactersForDN(commonName));
             userAttributeValues.remove(LDAPConstants.CN);
         }
     }
@@ -927,7 +942,7 @@ public class UniqueIDActiveDirectoryUserStoreManager extends UniqueIDReadWriteLD
     }
 
     @Override
-    protected void processAttributesBeforeUpdateWithID(String userID, Map<String, String> userStorePropertyValues,
+    protected void processAttributesBeforeUpdateWithID(String userID, Map<String, ? extends Object> userStorePropertyValues,
                                                        String profileName) {
 
         String immutableAttributesProperty = Optional.ofNullable(realmConfig

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/UniqueIDReadOnlyLDAPUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/UniqueIDReadOnlyLDAPUserStoreManager.java
@@ -28,6 +28,7 @@ import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.user.api.Properties;
 import org.wso2.carbon.user.api.Property;
 import org.wso2.carbon.user.api.RealmConfiguration;
+import org.wso2.carbon.user.core.NotImplementedException;
 import org.wso2.carbon.user.core.UserCoreConstants;
 import org.wso2.carbon.user.core.UserRealm;
 import org.wso2.carbon.user.core.UserStoreConfigConstants;
@@ -1516,6 +1517,15 @@ public class UniqueIDReadOnlyLDAPUserStoreManager extends ReadOnlyLDAPUserStoreM
     }
 
     @Override
+    protected void doSetUserAttributesWithID(String userID, Map<String, List<String>> claimAttributesToAdd,
+                                             Map<String, List<String>> claimAttributesToDelete,
+                                             Map<String, List<String>> claimAttributesToReplace, String profileName)
+            throws UserStoreException {
+
+        throw new UserStoreException("User store is operating in read only mode. Cannot write into the user store.");
+    }
+
+    @Override
     public void doDeleteUserClaimValue(String userName, String claimURI, String profileName) throws UserStoreException {
 
         throw new UserStoreException("Operation is not supported.");
@@ -1592,6 +1602,15 @@ public class UniqueIDReadOnlyLDAPUserStoreManager extends ReadOnlyLDAPUserStoreM
 
         throw new UserStoreException("Operation is not supported.");
 
+    }
+
+    @Override
+    public void doSetUserClaimValues(String userName, Map<String, List<String>> multiValuedClaimsToAdd,
+                                     Map<String, List<String>> multiValuedClaimsToDelete,
+                                     Map<String, List<String>> claimsExcludingMultiValuedClaims,
+                                     String profileName) throws UserStoreException {
+
+        throw new UserStoreException("Operation is not supported.");
     }
 
     @Override

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/UniqueIDReadWriteLDAPUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/UniqueIDReadWriteLDAPUserStoreManager.java
@@ -27,6 +27,7 @@ import org.wso2.carbon.context.CarbonContext;
 import org.wso2.carbon.user.api.Properties;
 import org.wso2.carbon.user.api.Property;
 import org.wso2.carbon.user.api.RealmConfiguration;
+import org.wso2.carbon.user.core.NotImplementedException;
 import org.wso2.carbon.user.core.UserCoreConstants;
 import org.wso2.carbon.user.core.UserRealm;
 import org.wso2.carbon.user.core.UserStoreConfigConstants;
@@ -850,6 +851,15 @@ public class UniqueIDReadWriteLDAPUserStoreManager extends UniqueIDReadOnlyLDAPU
     }
 
     @Override
+    public void doSetUserClaimValues(String userName, Map<String, List<String>> multiValuedClaimsToAdd,
+                                     Map<String, List<String>> multiValuedClaimsToDelete,
+                                     Map<String, List<String>> claimsExcludingMultiValuedClaims,
+                                     String profileName) throws UserStoreException {
+
+        throw new UserStoreException("Operation is not supported.");
+    }
+
+    @Override
     protected void doSetUserAttribute(String userName, String attributeName, String value, String profileName)
             throws UserStoreException {
 
@@ -944,6 +954,15 @@ public class UniqueIDReadWriteLDAPUserStoreManager extends UniqueIDReadOnlyLDAPU
     @Override
     protected void doSetUserAttributes(String userName, Map<String, String> processedClaimAttributes,
                                        String profileName) throws UserStoreException {
+
+        throw new UserStoreException("Operation is not supported.");
+    }
+
+    @Override
+    protected void doSetUserAttributes(String userID, Map<String, List<String>> claimAttributesToAdd,
+                                       Map<String, List<String>> claimAttributesToDelete,
+                                       Map<String, List<String>> claimAttributesToReplace, String profileName)
+            throws UserStoreException {
 
         throw new UserStoreException("Operation is not supported.");
     }
@@ -1051,6 +1070,88 @@ public class UniqueIDReadWriteLDAPUserStoreManager extends UniqueIDReadOnlyLDAPU
         }
     }
 
+    @Override
+    protected void doSetUserAttributesWithID(String userID, Map<String, List<String>> claimAttributesToAdd,
+                                             Map<String, List<String>> claimAttributesToDelete,
+                                             Map<String, List<String>> claimAttributesToReplace, String profileName)
+            throws NotImplementedException, UserStoreException {
+
+        // Get the LDAP Directory context.
+        DirContext dirContext = this.connectionSource.getContext();
+        DirContext subDirContext = null;
+        // Search the relevant user entry by user name.
+        String userSearchBase = realmConfig.getUserStoreProperty(LDAPConstants.USER_SEARCH_BASE);
+        String userSearchFilter = realmConfig.getUserStoreProperty(LDAPConstants.USER_ID_SEARCH_FILTER);
+        String userIDAttribute = realmConfig.getUserStoreProperty(LDAPConstants.USER_ID_ATTRIBUTE);
+
+        userSearchFilter = userSearchFilter.replace(LDAPConstants.UID, userIDAttribute);
+
+        if (OBJECT_GUID.equalsIgnoreCase(userIDAttribute) && isBinaryUserAttribute(userIDAttribute)) {
+            userID = transformUUIDToObjectGUID(userID);
+            userSearchFilter = userSearchFilter.replace("?", userID);
+        } else {
+            userSearchFilter = userSearchFilter.replace("?", escapeSpecialCharactersForFilter(userID));
+        }
+
+        SearchControls searchControls = new SearchControls();
+        searchControls.setSearchScope(SearchControls.SUBTREE_SCOPE);
+        searchControls.setReturningAttributes(null);
+
+        NamingEnumeration<SearchResult> returnedResultList = null;
+        String returnedUserEntry = "";
+
+        try {
+            subDirContext = (DirContext) dirContext.lookup(escapeDNForSearch(userSearchBase));
+            returnedResultList = dirContext.search(escapeDNForSearch(userSearchBase), userSearchFilter, searchControls);
+
+            // Assume only one user is returned from the search.
+            if (returnedResultList.hasMore()) {
+                returnedUserEntry = returnedResultList.next().getName();
+                handleLdapUserIdAttributeChanges(claimAttributesToReplace, subDirContext, returnedUserEntry);
+            }
+
+        } catch (NamingException e) {
+            String errorMessage = "Results could not be retrieved from the directory context for user : " + userID;
+
+            if (log.isDebugEnabled()) {
+                log.debug(errorMessage, e);
+            }
+
+            throw new UserStoreException(errorMessage, e);
+        } finally {
+            JNDIUtil.closeNamingEnumeration(returnedResultList);
+        }
+
+        try {
+            Attributes attributesToBeAdded = getUpdatedAttributes(userID, claimAttributesToAdd);
+            Attributes attributesToBeDeleted = getUpdatedAttributes(userID, claimAttributesToDelete);
+            Attributes attributesToBeReplaced = getUpdatedAttributes(userID, claimAttributesToReplace);
+
+            try {
+                subDirContext.modifyAttributes(returnedUserEntry, DirContext.ADD_ATTRIBUTE, attributesToBeAdded);
+            } catch (Exception e) {
+                if (!StringUtils.equals("error code 20 - ATTRIBUTE_OR_VALUE_EXISTS",
+                        (e.getMessage()).split(":")[1].trim())) {
+                    handleException(e, userID);
+                }
+            }
+            try {
+                subDirContext.modifyAttributes(returnedUserEntry, DirContext.REMOVE_ATTRIBUTE, attributesToBeDeleted);
+            } catch (Exception e) {
+                if (!StringUtils
+                        .equals("error code 16 - NO_SUCH_ATTRIBUTE", (e.getMessage()).split(":")[1].trim())) {
+                    handleException(e, userID);
+                }
+            }
+            subDirContext.modifyAttributes(returnedUserEntry, DirContext.REPLACE_ATTRIBUTE, attributesToBeReplaced);
+        } catch (NamingException e) {
+            handleException(e, userID);
+        } finally {
+            JNDIUtil.closeContext(subDirContext);
+            JNDIUtil.closeContext(dirContext);
+        }
+    }
+
     /**
      * Handle the modification of any changes to the userName attribute.
      *
@@ -1059,12 +1160,24 @@ public class UniqueIDReadWriteLDAPUserStoreManager extends UniqueIDReadOnlyLDAPU
      * @param returnedUserEntry   Returned result from the user search operation.
      * @throws NamingException Thrown if an error is occurred during the userName modification.
      */
-    protected void handleLdapUserIdAttributeChanges(Map<String, String> userAttributeValues,
+    protected void handleLdapUserIdAttributeChanges(Map<String, ? extends Object> userAttributeValues,
                                                     DirContext subDirContext, String returnedUserEntry)
             throws NamingException {
 
-        userAttributeValues.computeIfPresent(LDAPConstants.UID,
-                (attributeName, attributeValue) -> UserCoreUtil.removeDomainFromName(attributeValue));
+        if (userAttributeValues.containsKey(LDAPConstants.UID)) {
+            String attributeValue = StringUtils.EMPTY;
+            if (userAttributeValues.get(LDAPConstants.UID) instanceof String) {
+                Map<String, String> newMap = (Map<String, String>) userAttributeValues;
+                attributeValue = (String) userAttributeValues.get(LDAPConstants.UID);
+                newMap.put(LDAPConstants.UID, UserCoreUtil.removeDomainFromName(attributeValue));
+            } else if (userAttributeValues.get(LDAPConstants.UID) instanceof List) {
+                Map<String, List<String>> newMap = (Map<String, List<String>>) userAttributeValues;
+                List<String> domainNameFreeUserName = new ArrayList<>();
+                attributeValue = (String) ((List) userAttributeValues.get(LDAPConstants.UID)).get(0);
+                domainNameFreeUserName.add(UserCoreUtil.removeDomainFromName(attributeValue));
+                newMap.put(LDAPConstants.UID, domainNameFreeUserName);
+            }
+        }
     }
 
     @Override
@@ -2330,16 +2443,30 @@ public class UniqueIDReadWriteLDAPUserStoreManager extends UniqueIDReadOnlyLDAPU
         UNIQUE_ID_RW_LDAP_UM_ADVANCED_PROPERTIES.add(property);
     }
 
-    @Override
-    protected boolean isUserIdGeneratedByUserStore(String userID, Map<String, String> userAttributes) {
+    private Attributes getUpdatedAttributes(String userID, Map<String, List<String>> processedClaimAttributes) {
 
-        String immutableAttributesProperty = Optional.ofNullable(realmConfig
-                .getUserStoreProperty(UserStoreConfigConstants.immutableAttributes)).orElse("");
-
-        String[] immutableAttributes = StringUtils.split(immutableAttributesProperty, ",");
-        String userIdProperty = realmConfig.getUserStoreProperty(LDAPConstants.USER_ID_ATTRIBUTE);
-
-        return ArrayUtils.contains(immutableAttributes, userIdProperty);
+        if (processedClaimAttributes.containsKey(realmConfig.getUserStoreProperty(LDAPConstants.USER_NAME_ATTRIBUTE))) {
+            removeFromUserCache(userID);
+        }
+        Attributes updatedAttributes = new BasicAttributes(true);
+        processedClaimAttributes.entrySet().forEach(claimEntry -> {
+            Attribute currentUpdatedAttribute = new BasicAttribute(claimEntry.getKey());
+            // Skipping profile configuration attribute.
+            if (UserCoreConstants.PROFILE_CONFIGURATION.equals(claimEntry.getKey())) {
+                return;
+            }
+            // If updated attribute value is null, remove its values.
+            if (EMPTY_ATTRIBUTE_STRING.equals(claimEntry.getValue().get(0))) {
+                currentUpdatedAttribute.clear();
+            } else {
+                for (String claimValue : claimEntry.getValue()) {
+                    if (claimValue != null && claimValue.trim().length() > 0) {
+                        currentUpdatedAttribute.add(claimValue);
+                    }
+                }
+            }
+            updatedAttributes.put(currentUpdatedAttribute);
+        });
+        return updatedAttributes;
     }
-
 }


### PR DESCRIPTION
## Purpose
Fix for wso2/product-is#8135
Support multi-valued claim updates independently from single-valued claims.
 
## Related PRs
Public fix for https://github.com/wso2-support/carbon4-kernel/pull/984 and https://github.com/wso2-support/carbon4-kernel/pull/988