### PR TITLE
Provide options to enable/disable shutdown and restart server from management console

### DIFF
--- a/core/org.wso2.carbon.server.admin.ui/src/main/resources/org/wso2/carbon/server/admin/ui/i18n/Resources.properties
+++ b/core/org.wso2.carbon.server.admin.ui/src/main/resources/org/wso2/carbon/server/admin/ui/i18n/Resources.properties
@@ -49,3 +49,5 @@ days=day(s)
 hours=hr(s)
 minutes=min(s)
 seconds=sec(s)
+shutdown.disabled=Option to Shutdown Server from Management Console is disabled.
+restart.disabled=Option to Restart Server from Management Console is disabled.

--- a/core/org.wso2.carbon.server.admin.ui/src/main/resources/web/server-admin/index.jsp
+++ b/core/org.wso2.carbon.server.admin.ui/src/main/resources/web/server-admin/index.jsp
@@ -17,6 +17,7 @@
  -->
 <%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
 <%@ taglib uri="http://wso2.org/projects/carbon/taglibs/carbontags.jar" prefix="carbon" %>
+<%@ page import="org.wso2.carbon.base.ServerConfiguration" %>
 <jsp:include page="../dialog/display_messages.jsp"/>
 
 <script type="text/javascript" src="js/serveradmin.js"></script>
@@ -34,12 +35,27 @@
     <h2><fmt:message key="shutdown.restart.server"/></h2>
     <div id="workArea">
         <div id="output" style="display:none;"></div>
-
+    
+        <%
+            ServerConfiguration serverConfig = ServerConfiguration.getInstance();
+            String disableShutdown = serverConfig.getFirstProperty("disableShutdownRestartFromUI.disableShutdown");
+            String disableRestart = serverConfig.getFirstProperty("disableShutdownRestartFromUI.disableRestart");
+        %>
+        
         <table class="styledLeft" id="shutDown" width="100%">
             <thead>
             <tr><th colspan="2"><fmt:message key="shutdown"/></th></tr>
             </thead>
             <tbody>
+            <%
+                if ("true".equals(disableShutdown)) {
+            %>
+            <tr>
+                <td width="100%"><strong><fmt:message key="shutdown.disabled"/></strong></td>
+            </tr>
+            <%
+                } else {
+            %>
             <tr>
                 <td width="50%"><strong><fmt:message key="graceful.shutdown"/></strong></td>
                 <td width="50%"><strong><fmt:message key="forced.shutdown"/></strong></td>
@@ -66,16 +82,28 @@
                     </a>
                 </td>
             </tr>
+            <%
+                }
+            %>
             </tbody>
         </table>
-
+        
         <p>&nbsp;</p>
-
+    
         <table class="styledLeft" id="restart" width="100%">
             <thead>
             <tr><th colspan="2"><fmt:message key="restart"/></th></tr>
             </thead>
             <tbody>
+            <%
+                if ("true".equals(disableRestart)) {
+            %>
+            <tr>
+                <td width="100%"><strong><fmt:message key="restart.disabled"/></strong></td>
+            </tr>
+            <%
+                } else {
+            %>
             <tr>
                 <td width="50%"><strong><fmt:message key="graceful.restart"/></strong></td>
                 <td width="50%"><strong><fmt:message key="forced.restart"/></strong></td>
@@ -102,9 +130,11 @@
                     </a>
                 </td>
             </tr>
+            <%
+                }
+            %>
             </tbody>
         </table>
-        
         <p>&nbsp;</p>
     </div>
 </div>


### PR DESCRIPTION
## Purpose
Fix https://github.com/wso2/product-ei/issues/5147

## Approach
This will read carbon.xml file and enable/disable shutdown and restart server from the management console.
carbon.xml file located at <EI_HOME>/conf must be configured as follows.
  ``  <disableShutdownRestartFromUI>
        <disableShutdown>true</disableShutdown>
        <disableRestart>true</disableRestart>
    </disableShutdownRestartFromUI> ``