### PR TITLE
Fix NPE in ICF, JNI and SPI Provider tool

### DIFF
--- a/features/org.wso2.carbon.server.feature/resources/bin/icf-provider.bat
+++ b/features/org.wso2.carbon.server.feature/resources/bin/icf-provider.bat
@@ -71,7 +71,7 @@ set CURRENT_DIR=%cd%
 cd %CARBON_HOME%\bin
 echo JAVA_HOME environment variable is set to %JAVA_HOME%
 echo CARBON_HOME environment variable is set to %CARBON_HOME%
-java -cp ".\*;..\bin\tools\*" -Dcarbon.home="%CARBON_HOME" -Dwso2.carbon.tool="icf-provider" org.wso2.carbon.tools.CarbonToolExecutor %1 %2 %3 %4
+java -cp ".\*;..\bin\tools\*" -Dcarbon.home="%CARBON_HOME%" -Dwso2.carbon.tool="icf-provider" org.wso2.carbon.tools.CarbonToolExecutor %1 %2 %3 %4
 
 :end
 goto endlocal

--- a/features/org.wso2.carbon.server.feature/resources/bin/jni-provider.bat
+++ b/features/org.wso2.carbon.server.feature/resources/bin/jni-provider.bat
@@ -71,7 +71,7 @@ set CURRENT_DIR=%cd%
 cd %CARBON_HOME%\bin
 echo JAVA_HOME environment variable is set to %JAVA_HOME%
 echo CARBON_HOME environment variable is set to %CARBON_HOME%
-java -cp ".\*;..\bin\tools\*" -Dcarbon.home="%CARBON_HOME" -Dwso2.carbon.tool="jni-provider" org.wso2.carbon.tools.CarbonToolExecutor %1 %2 %3 %4
+java -cp ".\*;..\bin\tools\*" -Dcarbon.home="%CARBON_HOME%" -Dwso2.carbon.tool="jni-provider" org.wso2.carbon.tools.CarbonToolExecutor %1 %2 %3 %4
 
 :end
 goto endlocal

--- a/features/org.wso2.carbon.server.feature/resources/bin/spi-provider.bat
+++ b/features/org.wso2.carbon.server.feature/resources/bin/spi-provider.bat
@@ -71,7 +71,7 @@ set CURRENT_DIR=%cd%
 cd %CARBON_HOME%\bin
 echo JAVA_HOME environment variable is set to %JAVA_HOME%
 echo CARBON_HOME environment variable is set to %CARBON_HOME%
-java -cp ".\*;..\bin\tools\*" -Dcarbon.home="%CARBON_HOME" -Dwso2.carbon.tool="spi-provider" org.wso2.carbon.tools.CarbonToolExecutor %1 %2 %3 %4 %5
+java -cp ".\*;..\bin\tools\*" -Dcarbon.home="%CARBON_HOME%" -Dwso2.carbon.tool="spi-provider" org.wso2.carbon.tools.CarbonToolExecutor %1 %2 %3 %4 %5
 
 :end
 goto endlocal

--- a/tools/tools-core/src/main/java/org/wso2/carbon/tools/spi/ICFProviderTool.java
+++ b/tools/tools-core/src/main/java/org/wso2/carbon/tools/spi/ICFProviderTool.java
@@ -127,6 +127,10 @@ public class ICFProviderTool implements CarbonTool {
                 Files.write(internal.resolve(ACTIVATOR_JAVA_FILE), source.getBytes(StandardCharsets.UTF_8));
 
                 // Compile source file.
+                if (System.getProperty("os.name").toLowerCase((Locale.ENGLISH)).contains("windows")) {
+                    System.setProperty("java.home", System.getenv("JAVA_HOME"));
+                }
+
                 JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
 
                 List<String> compilerArgs = new ArrayList<>();

--- a/tools/tools-core/src/main/java/org/wso2/carbon/tools/spi/NativeLibraryProvider.java
+++ b/tools/tools-core/src/main/java/org/wso2/carbon/tools/spi/NativeLibraryProvider.java
@@ -125,6 +125,9 @@ public class NativeLibraryProvider implements CarbonTool {
                 Files.write(internal.resolve(ACTIVATOR_JAVA_FILE), source.getBytes(StandardCharsets.UTF_8));
 
                 // Compile source file.
+                if (System.getProperty("os.name").toLowerCase(Locale.ENGLISH).contains("windows")) {
+                    System.setProperty("java.home", System.getenv("JAVA_HOME"));
+                }
                 JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
 
                 List<String> compilerArgs = new ArrayList<>();

--- a/tools/tools-core/src/main/java/org/wso2/carbon/tools/spi/SPIProviderTool.java
+++ b/tools/tools-core/src/main/java/org/wso2/carbon/tools/spi/SPIProviderTool.java
@@ -125,6 +125,9 @@ public class SPIProviderTool implements CarbonTool {
                 Files.write(internal.resolve(ACTIVATOR_JAVA_FILE), source.getBytes(StandardCharsets.UTF_8));
 
                 // Compile source file.
+                if (System.getProperty("os.name").toLowerCase(Locale.ENGLISH).contains("windows")) {
+                    System.setProperty("java.home", System.getenv("JAVA_HOME"));
+                }
                 JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
 
                 List<String> compilerArgs = new ArrayList<>();


### PR DESCRIPTION
## Purpose
> Fix https://github.com/wso2/carbon-kernel/issues/2601
> Fix issue when providing carbon_home variable in bat scripts

## Approach
> set the jdk for java.home variable when the os is windows

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes