### PR TITLE
Fixing issue in not picking configured system properties in deployment.toml file during server runtime

### DIFF
--- a/core/org.wso2.carbon.bootstrap/src/main/java/org/wso2/carbon/bootstrap/Bootstrap.java
+++ b/core/org.wso2.carbon.bootstrap/src/main/java/org/wso2/carbon/bootstrap/Bootstrap.java
@@ -44,8 +44,6 @@ public class Bootstrap {
     private static final String CARBON_HOME = "carbon.home";
     private static final String INTERNAL_CARBON_LIB_DIR_PATH = "carbon.internal.lib.dir.path";
     protected static final String ROOT = System.getProperty(CARBON_HOME, ".");
-    private static final String CARBON_PROPERTIES = "carbon.properties";
-    private static final String CONF_DIRECTORY_PATH = "carbon.config.dir.path";
 
     public static void main(String args[]) {
         new Bootstrap().loadClass(args);
@@ -53,7 +51,6 @@ public class Bootstrap {
 
     protected final void loadClass(String args[]) {
         try {
-            addSystemProperties();
             addClassPathEntries();
             ClassLoader cl = new URLClassLoader(classpath.toArray(new URL[classpath.size()]));
 
@@ -73,37 +70,6 @@ public class Bootstrap {
             System.exit(1);
         }
 
-    }
-
-    private void addSystemProperties(){
-        Properties properties = new Properties();
-        String filePath = System.getProperty(CONF_DIRECTORY_PATH) + File.separator + CARBON_PROPERTIES;
-        File file = new File(filePath);
-
-        if (file.exists()) {
-            InputStream in = null;
-            try {
-                in = new FileInputStream(file);
-                properties.load(in);
-            } catch (IOException e) {
-                e.printStackTrace();
-                System.exit(1);
-            } finally {
-                if (in != null) {
-                    try {
-                        in.close();
-                    } catch (IOException ignored) {
-                        // Exception is ignored as there is no need to break the execution here
-                    }
-                }
-            }
-        }
-
-        Set<Object> keys = properties.keySet();
-        for (Object key: keys)  {
-            System.setProperty((String)key, (String)properties.get(key));
-        }
-        System.setProperty("javax.xml.bind.JAXBContextFactory", "com.sun.xml.bind.v2.ContextFactory");
     }
 
     protected void addClassPathEntries() throws MalformedURLException {

--- a/core/org.wso2.carbon.server/src/main/java/org/wso2/carbon/server/Main.java
+++ b/core/org.wso2.carbon.server/src/main/java/org/wso2/carbon/server/Main.java
@@ -36,6 +36,8 @@ import java.util.logging.Level;
 
 public class Main {
     private static final java.util.logging.Logger logger = java.util.logging.Logger.getLogger(Main.class.getName());
+    private static final String CARBON_PROPERTIES = "carbon.properties";
+    private static final String CONF_DIRECTORY_PATH = "carbon.config.dir.path";
 
     /**
      * Launch the Carbon server.
@@ -101,6 +103,7 @@ public class Main {
             System.setProperty(LauncherConstants.PROFILE, LauncherConstants.DEFAULT_CARBON_PROFILE);
         }
         handleConfiguration();
+        addSystemProperties();
         invokeExtensions();
         launchCarbon();
     }
@@ -233,5 +236,39 @@ public class Main {
             logger.log(Level.SEVERE, "Error while performing configuration changes", e);
             System.exit(1);
         }
+    }
+
+    /**
+     * Reading carbon.properties file and setting system properties.
+     */
+    private static void addSystemProperties(){
+        java.util.Properties properties = new java.util.Properties();
+        String filePath = System.getProperty(CONF_DIRECTORY_PATH) + File.separator + CARBON_PROPERTIES;
+        File file = new File(filePath);
+
+        if (file.exists()) {
+            java.io.InputStream in = null;
+            try {
+                in = new java.io.FileInputStream(file);
+                properties.load(in);
+            } catch (IOException e) {
+                e.printStackTrace();
+                System.exit(1);
+            } finally {
+                if (in != null) {
+                    try {
+                        in.close();
+                    } catch (IOException ignored) {
+                        // Exception is ignored as there is no need to break the execution here
+                    }
+                }
+            }
+        }
+
+        java.util.Set<Object> keys = properties.keySet();
+        for (Object key: keys)  {
+            System.setProperty((String)key, (String)properties.get(key));
+        }
+        System.setProperty("javax.xml.bind.JAXBContextFactory", "com.sun.xml.bind.v2.ContextFactory");
     }
 }


### PR DESCRIPTION
This PR will fix the issue [#8663](https://github.com/wso2/product-apim/issues/8663)

**Issue**
Configurations added in the deployment.toml file are not picking during the run time, in the first server start up, since the system properties are set from the carbon.properties before parsing the configurations.

**Steps to reproduce:**

1.Add system configurations to deployment.toml file
[system.parameter]
'org.wso2.CipherTransformation'="RSA"

2.Start the server. The default value will be picked up from the carbon.properties file

3.Restart the server. Then the configured value in the deployment.toml will be picked.