### PR TITLE
Resolved Tenant API creation fails intermittently.

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/authorization/PermissionTree.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/authorization/PermissionTree.java
@@ -1053,7 +1053,6 @@ public class PermissionTree {
             statement.setString(3, resourceId);
             rs = statement.executeQuery();
             write.lock();
-            getNode(root, PermissionTreeUtil.toComponenets(resourceId)).getLastNode().getRoleAllowPermissions().clear();
             try {
                 while (rs.next()) {
                     short allow = rs.getShort(3);


### PR DESCRIPTION
## Purpose
> Fix wso2/product-apim/issues/7816 & https://github.com/wso2/product-apim/issues/8247
The tenant user could not able to create an API as the permission for the user has been removed by this particular line.
To create an API, user role 'Internal/creator' must have permission. But we here are cleaning the role-based permission from the node for all user roles. 

The tenant user could not able to create an API as the permission for the user has been removed.
Scenario: To create an API user must have 'Internal/creator' permission. When the first tenant user with 'Internal/creator' permission tries to create an API, the user's existing permissions are removed from the registry and throwing an exception saying that user does not have permission to create API.

In this PR I have removed the line which clears the permissions from the registry.
This line was introduced recently by this PR wso2/carbon-kernel#2346 to resolve API Visibility issue in the Developer portal in a distributed setup(wso2/product-apim#6609). The actual fix for this is else part only. We don't need to clear resource permission. The issue is still reproducible if we remove the else part and did not reproduce if we remove that particular line.