### PR TITLE
Prevent listing users in all the user stores when retrieving user domain

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
@@ -7143,11 +7143,20 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
                         }
                     } else {
                         // This is happening when the user store is not supporting uniqueID.
-                        if (abstractUserStoreManager.getUserList(UserCoreClaimConstants.USER_ID_CLAIM_URI, userId,
-                                null).length > 0) {
-                            domainName = entry.getKey();
-                            userUniqueIDDomainResolver.setDomainForUserId(userId, domainName, tenantId);
-                            break;
+                        try {
+                            if (abstractUserStoreManager.getUserListFromProperties(claimManager.getAttributeName(entry
+                                    .getKey(), UserCoreClaimConstants.USER_ID_CLAIM_URI), userId, null).length > 0) {
+                                domainName = entry.getKey();
+                                userUniqueIDDomainResolver.setDomainForUserId(userId, domainName, tenantId);
+                                break;
+                            }
+                        } catch (org.wso2.carbon.user.api.UserStoreException e) {
+                                handleGetUserListFailure(ErrorMessages.ERROR_CODE_ERROR_WHILE_GETTING_USER_LIST.getCode(),
+                                        String.format(ErrorMessages.ERROR_CODE_ERROR_WHILE_GETTING_USER_LIST.getMessage(),
+                                                e.getMessage()), UserCoreClaimConstants.USER_ID_CLAIM_URI, userId,
+                                        null);
+                                throw new UserStoreException("Unable retrieve users from getUserListFromProperties " +
+                                        "method from the user store: " + entry.getKey() + ".", e);
                         }
                     }
                 }


### PR DESCRIPTION
## Purpose
Fix: https://github.com/wso2/product-is/issues/9157
>  Invalid domain name set against userid in UM_UUID_DOMAIN_MAPPER can be observed in a multiple non-unique user ID userstore are configured in an IS-5.10.0 setup. As a result login to user-portal throws, errors as SCIM operation fails at loading user attributes and updating the password.

## Approach
> Prevent listing users in all the user stores when retrieving user domain and instead search inside the current userstore
