### PR TITLE
Fixing performance issues in IS 5.11

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/UserStoreConfigConstants.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/UserStoreConfigConstants.java
@@ -26,6 +26,8 @@ public class UserStoreConfigConstants {
     public static final String TENANTS = "tenants";
     public static final String RESOLVE_USER_ID_FROM_USER_NAME_CACHE_NAME = "user_id_from_user_name_cache";
     public static final String RESOLVE_USER_NAME_FROM_USER_ID_CACHE_NAME = "user_name_from_user_id_cache";
+    public static final String RESOLVE_USER_UNIQUE_ID_FROM_USER_NAME_CACHE_NAME = "user_unique_id_from_user_name_cache";
+    public static final String RESOLVE_USER_NAME_FROM_UNIQUE_USER_ID_CACHE_NAME = "user_name_from_unique_user_id_cache";
     //Define datasource property for JDBC
     public static final String dataSource = "dataSource";
     public static final String dataSourceDescription = "Connection name to user store";

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
@@ -12109,6 +12109,14 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
         }
     }
 
+    /**
+     * Get the user name of the given user from a unique user id natively supported user store.
+     *
+     * @param userID userID of the user.
+     * @param userStore user store of the user.
+     * @return user name.
+     * @throws UserStoreException Thrown by the underlying UserStoreManager.
+     */
     private String getUserNameFromCurrentUserStore(String userID, UserStore userStore) throws UserStoreException {
 
         String userName = getFromUserNameCache(userID);

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
@@ -96,13 +96,16 @@ import javax.sql.DataSource;
 
 import static org.wso2.carbon.user.core.UserCoreConstants.SYSTEM_DOMAIN_NAME;
 import static org.wso2.carbon.user.core.UserStoreConfigConstants.RESOLVE_USER_ID_FROM_USER_NAME_CACHE_NAME;
+import static org.wso2.carbon.user.core.UserStoreConfigConstants.RESOLVE_USER_NAME_FROM_UNIQUE_USER_ID_CACHE_NAME;
 import static org.wso2.carbon.user.core.UserStoreConfigConstants.RESOLVE_USER_NAME_FROM_USER_ID_CACHE_NAME;
+import static org.wso2.carbon.user.core.UserStoreConfigConstants.RESOLVE_USER_UNIQUE_ID_FROM_USER_NAME_CACHE_NAME;
 import static org.wso2.carbon.user.core.constants.UserCoreErrorConstants.ErrorMessages.ERROR_CODE_DUPLICATE_WHILE_ADDING_A_HYBRID_ROLE;
 import static org.wso2.carbon.user.core.constants.UserCoreErrorConstants.ErrorMessages.ERROR_CODE_DUPLICATE_WHILE_ADDING_A_SYSTEM_ROLE;
 import static org.wso2.carbon.user.core.constants.UserCoreErrorConstants.ErrorMessages.ERROR_CODE_DUPLICATE_WHILE_ADDING_A_SYSTEM_USER;
 import static org.wso2.carbon.user.core.constants.UserCoreErrorConstants.ErrorMessages.ERROR_CODE_DUPLICATE_WHILE_ADDING_A_USER;
 import static org.wso2.carbon.user.core.constants.UserCoreErrorConstants.ErrorMessages.ERROR_CODE_DUPLICATE_WHILE_ADDING_ROLE;
 import static org.wso2.carbon.user.core.constants.UserCoreErrorConstants.ErrorMessages.ERROR_CODE_ROLE_ALREADY_EXISTS;
+import static org.wso2.carbon.utils.multitenancy.MultitenantConstants.SUPER_TENANT_ID;
 
 public abstract class AbstractUserStoreManager implements PaginatedUserStoreManager,
         UniqueIDUserStoreManager {
@@ -7026,7 +7029,7 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
         }
     }
 
-    private UserStore getUserStoreWithID(final String userID) throws UserStoreException {
+    protected UserStore getUserStoreWithID(final String userID) throws UserStoreException {
 
         try {
             return AccessController
@@ -11154,9 +11157,9 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
         }
 
         // Check whether roles exist in cache
-        User user = userUniqueIDManger.getUser(userID, this);
-        if (user != null) {
-            String[] roleListOfUserFromCache = getRoleListOfUserFromCache(this.tenantId, user.getUsername());
+        String userName = this.getUserNameFromUserID(userID);
+        if (StringUtils.isNotEmpty(userName)) {
+            String[] roleListOfUserFromCache = getRoleListOfUserFromCache(this.tenantId, userName);
             if (roleListOfUserFromCache != null) {
                 roleNames = Arrays.asList(roleListOfUserFromCache);
                 if (roleNames.size() > 0) {
@@ -11172,10 +11175,10 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
 
         // If unique id feature is not enabled, we have to call the legacy methods.
         if (!isUniqueUserIdEnabledInUserStore(userStore)) {
-            if (user == null) {
+            if (StringUtils.isEmpty(userName)) {
                 return Arrays.asList(realmConfig.getEveryOneRoleName());
             }
-            return Arrays.asList(doGetRoleListOfUser(user.getUsername(), "*"));
+            return Arrays.asList(doGetRoleListOfUser(userName, "*"));
         } else {
             return doGetRoleListOfUserWithID(userID, "*");
         }
@@ -12098,20 +12101,23 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
             return ((AbstractUserStoreManager) userStore.getUserStoreManager())
                     .getUserNameFromUserID(userStore.getDomainFreeUserId());
         }
+
+        if (isUniqueUserIdEnabledInUserStore(userStore)) {
+            return getUserNameFromCurrentUserStore(userID, userStore);
+        } else {
+            return userUniqueIDManger.getUser(userID, this).getDomainQualifiedUsername();
+        }
+    }
+
+    private String getUserNameFromCurrentUserStore(String userID, UserStore userStore) throws UserStoreException {
+
         String userName = getFromUserNameCache(userID);
         if (StringUtils.isEmpty(userName)) {
-            if (isUniqueUserIdEnabledInUserStore(userStore)) {
-                userName = doGetUserNameFromUserIDWithID(userID);
-                addToUserNameCache(userID, userName, userStore);
-                addToUserIDCache(userID, userName, userStore);
-                return UserCoreUtil.addDomainToName(userName, userStore.getDomainName());
-            }
-            userName = userUniqueIDManger.getUser(userID, this).getDomainQualifiedUsername();
+            userName = doGetUserNameFromUserIDWithID(userID);
             addToUserNameCache(userID, userName, userStore);
             addToUserIDCache(userID, userName, userStore);
-            return userName;
         }
-        return userName;
+        return UserCoreUtil.addDomainToName(userName, userStore.getDomainName());
     }
 
     private String getFromUserNameCache(String userID) {
@@ -12147,6 +12153,11 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
                 .clearCacheEntry(UserCoreUtil.addDomainToName(userName, userStore.getDomainName()),
                         RESOLVE_USER_ID_FROM_USER_NAME_CACHE_NAME, tenantId);
         UserIdResolverCache.getInstance().clearCacheEntry(userID, RESOLVE_USER_NAME_FROM_USER_ID_CACHE_NAME, tenantId);
+        UserIdResolverCache.getInstance()
+                .clearCacheEntry(UserCoreUtil.addDomainToName(userName, userStore.getDomainName()),
+                        RESOLVE_USER_UNIQUE_ID_FROM_USER_NAME_CACHE_NAME, SUPER_TENANT_ID);
+        UserIdResolverCache.getInstance()
+                .clearCacheEntry(userID, RESOLVE_USER_NAME_FROM_UNIQUE_USER_ID_CACHE_NAME, SUPER_TENANT_ID);
     }
 
     /**

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/UserUniqueIDManger.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/UserUniqueIDManger.java
@@ -31,6 +31,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
+import static org.wso2.carbon.user.core.UserStoreConfigConstants.RESOLVE_USER_NAME_FROM_UNIQUE_USER_ID_CACHE_NAME;
+import static org.wso2.carbon.user.core.UserStoreConfigConstants.RESOLVE_USER_UNIQUE_ID_FROM_USER_NAME_CACHE_NAME;
+import static org.wso2.carbon.utils.multitenancy.MultitenantConstants.SUPER_TENANT_ID;
+
 /**
  * This will manage the relationship between the user unique id in the system against the unique id in the user store.
  */
@@ -67,21 +71,48 @@ public class UserUniqueIDManger {
     public User getUser(String uniqueId, AbstractUserStoreManager userStoreManager)
             throws UserStoreException {
 
-        String[] usernames = userStoreManager.getUserList(UserCoreClaimConstants.USER_ID_CLAIM_URI, uniqueId, null);
+        String userName = getFromUserNameCache(uniqueId);
+        if (StringUtils.isEmpty(userName)) {
 
-        if (usernames.length > 1) {
-            throw new UserStoreException("More than one user presents with the same user unique id.");
-        }
+            String[] usernames = userStoreManager.getUserList(UserCoreClaimConstants.USER_ID_CLAIM_URI, uniqueId,
+                    null);
+            if (usernames.length > 1) {
+                throw new UserStoreException("More than one user presents with the same user unique id.");
+            }
 
-        if (usernames.length == 0) {
-            return null;
+            if (usernames.length == 0) {
+                return null;
+            }
+            userName = usernames[0];
+            addToUserNameCache(uniqueId, userName);
+            addToUserIDCache(uniqueId, userName);
         }
 
         User user = new User();
         user.setUserID(uniqueId);
-        user.setUsername(UserCoreUtil.removeDomainFromName(usernames[0]));
-        user.setUserStoreDomain(UserCoreUtil.extractDomainFromName(usernames[0]));
+        user.setUsername(UserCoreUtil.removeDomainFromName(userName));
+        user.setUserStoreDomain(UserCoreUtil.extractDomainFromName(userName));
         return user;
+    }
+
+    private void addToUserIDCache(String userID, String userName) {
+
+        UserIdResolverCache.getInstance()
+                .addToCache(userName, userID,
+                        RESOLVE_USER_UNIQUE_ID_FROM_USER_NAME_CACHE_NAME, SUPER_TENANT_ID);
+    }
+
+    private void addToUserNameCache(String userID, String userName) {
+
+        UserIdResolverCache.getInstance()
+                .addToCache(userID, userName,
+                        RESOLVE_USER_NAME_FROM_UNIQUE_USER_ID_CACHE_NAME, SUPER_TENANT_ID);
+    }
+
+    private String getFromUserNameCache(String userID) {
+
+        return UserIdResolverCache.getInstance().getValueFromCache(userID,
+                RESOLVE_USER_NAME_FROM_UNIQUE_USER_ID_CACHE_NAME, SUPER_TENANT_ID);
     }
 
     /**

--- a/core/org.wso2.carbon.user.core/src/test/java/org/wso2/carbon/user/core/authman/AdvancedPermissionTreeWithIDTest.java
+++ b/core/org.wso2.carbon.user.core/src/test/java/org/wso2/carbon/user/core/authman/AdvancedPermissionTreeWithIDTest.java
@@ -28,14 +28,22 @@ import org.wso2.carbon.user.core.UserRealm;
 import org.wso2.carbon.user.core.UserStoreException;
 import org.wso2.carbon.user.core.UserStoreManager;
 import org.wso2.carbon.user.core.common.DefaultRealm;
+import org.wso2.carbon.user.core.common.UserIdResolverCache;
 import org.wso2.carbon.user.core.config.TestRealmConfigBuilder;
 import org.wso2.carbon.user.core.jdbc.JDBCRealmTest;
 import org.wso2.carbon.user.core.util.DatabaseUtil;
 import org.wso2.carbon.utils.ServerConstants;
 import org.wso2.carbon.utils.dbcreator.DatabaseCreator;
+import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 
 import java.io.File;
 import java.io.InputStream;
+import java.lang.management.MemoryUsage;
+
+import static org.wso2.carbon.user.core.UserStoreConfigConstants.RESOLVE_USER_ID_FROM_USER_NAME_CACHE_NAME;
+import static org.wso2.carbon.user.core.UserStoreConfigConstants.RESOLVE_USER_NAME_FROM_UNIQUE_USER_ID_CACHE_NAME;
+import static org.wso2.carbon.user.core.UserStoreConfigConstants.RESOLVE_USER_NAME_FROM_USER_ID_CACHE_NAME;
+import static org.wso2.carbon.user.core.UserStoreConfigConstants.RESOLVE_USER_UNIQUE_ID_FROM_USER_NAME_CACHE_NAME;
 
 public class AdvancedPermissionTreeWithIDTest extends BaseTestCase {
     private UserRealm realm = null;
@@ -49,6 +57,7 @@ public class AdvancedPermissionTreeWithIDTest extends BaseTestCase {
 
     public void testStuff() throws Exception {
         DatabaseUtil.closeDatabasePoolConnection();
+        clearUserIdResolverCache();
         initRealmStuff();
         admin = realm.getUserStoreManager();
         authMan = realm.getAuthorizationManager();
@@ -133,5 +142,16 @@ public class AdvancedPermissionTreeWithIDTest extends BaseTestCase {
     public void doTestUserRoleCachingInCaseInsensitiveUsername() throws UserStoreException {
         admin.deleteRole("Internal/role1");
         assertFalse(authMan.isUserAuthorized("indunil", "/s/t/u/v/w/x/y", "read"));
+    }
+
+    private void clearUserIdResolverCache() {
+
+        UserIdResolverCache.getInstance()
+                .clear(RESOLVE_USER_UNIQUE_ID_FROM_USER_NAME_CACHE_NAME, MultitenantConstants.SUPER_TENANT_ID);
+        UserIdResolverCache.getInstance().clear(RESOLVE_USER_NAME_FROM_UNIQUE_USER_ID_CACHE_NAME, MultitenantConstants.SUPER_TENANT_ID);
+        UserIdResolverCache.getInstance()
+                .clear(RESOLVE_USER_ID_FROM_USER_NAME_CACHE_NAME, MultitenantConstants.SUPER_TENANT_ID);
+        UserIdResolverCache.getInstance()
+                .clear(RESOLVE_USER_NAME_FROM_USER_ID_CACHE_NAME, MultitenantConstants.SUPER_TENANT_ID);
     }
 }

--- a/core/org.wso2.carbon.user.core/src/test/java/org/wso2/carbon/user/core/jdbc/JDBCRealmWithUniqueIDTest.java
+++ b/core/org.wso2.carbon.user.core/src/test/java/org/wso2/carbon/user/core/jdbc/JDBCRealmWithUniqueIDTest.java
@@ -32,7 +32,10 @@ import org.wso2.carbon.user.core.authorization.JDBCAuthorizationManager;
 import org.wso2.carbon.user.core.common.DefaultRealm;
 import org.wso2.carbon.user.core.common.UserIdResolverCache;
 import static org.wso2.carbon.user.core.UserStoreConfigConstants.RESOLVE_USER_ID_FROM_USER_NAME_CACHE_NAME;
+import static org.wso2.carbon.user.core.UserStoreConfigConstants.RESOLVE_USER_NAME_FROM_UNIQUE_USER_ID_CACHE_NAME;
 import static org.wso2.carbon.user.core.UserStoreConfigConstants.RESOLVE_USER_NAME_FROM_USER_ID_CACHE_NAME;
+import static org.wso2.carbon.user.core.UserStoreConfigConstants.RESOLVE_USER_UNIQUE_ID_FROM_USER_NAME_CACHE_NAME;
+
 import org.wso2.carbon.user.core.config.RealmConfigXMLProcessor;
 import org.wso2.carbon.user.core.config.TestRealmConfigBuilder;
 import org.wso2.carbon.user.core.util.DatabaseUtil;
@@ -60,10 +63,7 @@ public class JDBCRealmWithUniqueIDTest extends BaseTestCase {
     public void testStuff() throws Exception {
 
         DatabaseUtil.closeDatabasePoolConnection();
-        UserIdResolverCache.getInstance()
-                .clear(RESOLVE_USER_ID_FROM_USER_NAME_CACHE_NAME, MultitenantConstants.SUPER_TENANT_ID);
-        UserIdResolverCache.getInstance()
-                .clear(RESOLVE_USER_NAME_FROM_USER_ID_CACHE_NAME, MultitenantConstants.SUPER_TENANT_ID);
+        clearUserIdResolverCache();
         initRealmStuff(TEST_URL);
         doUserStuff();
         doUserRoleStuff();
@@ -303,5 +303,17 @@ public class JDBCRealmWithUniqueIDTest extends BaseTestCase {
                 ClaimTestUtil.HOME_PROFILE_NAME);
         assertNull(obtained.get(ClaimTestUtil.CLAIM_URI2)); // overridden
 
+    }
+
+    private void clearUserIdResolverCache() {
+
+        UserIdResolverCache.getInstance()
+                .clear(RESOLVE_USER_UNIQUE_ID_FROM_USER_NAME_CACHE_NAME, MultitenantConstants.SUPER_TENANT_ID);
+        UserIdResolverCache.getInstance()
+                .clear(RESOLVE_USER_NAME_FROM_UNIQUE_USER_ID_CACHE_NAME, MultitenantConstants.SUPER_TENANT_ID);
+        UserIdResolverCache.getInstance()
+                .clear(RESOLVE_USER_ID_FROM_USER_NAME_CACHE_NAME, MultitenantConstants.SUPER_TENANT_ID);
+        UserIdResolverCache.getInstance()
+                .clear(RESOLVE_USER_NAME_FROM_USER_ID_CACHE_NAME, MultitenantConstants.SUPER_TENANT_ID);
     }
 }

--- a/core/org.wso2.carbon.user.core/src/test/java/org/wso2/carbon/user/core/jdbc/PermissionWithIDTest.java
+++ b/core/org.wso2.carbon.user.core/src/test/java/org/wso2/carbon/user/core/jdbc/PermissionWithIDTest.java
@@ -38,7 +38,9 @@ import java.io.File;
 import java.io.InputStream;
 
 import static org.wso2.carbon.user.core.UserStoreConfigConstants.RESOLVE_USER_ID_FROM_USER_NAME_CACHE_NAME;
+import static org.wso2.carbon.user.core.UserStoreConfigConstants.RESOLVE_USER_NAME_FROM_UNIQUE_USER_ID_CACHE_NAME;
 import static org.wso2.carbon.user.core.UserStoreConfigConstants.RESOLVE_USER_NAME_FROM_USER_ID_CACHE_NAME;
+import static org.wso2.carbon.user.core.UserStoreConfigConstants.RESOLVE_USER_UNIQUE_ID_FROM_USER_NAME_CACHE_NAME;
 
 public class PermissionWithIDTest extends BaseTestCase {
 
@@ -217,6 +219,10 @@ public class PermissionWithIDTest extends BaseTestCase {
 
     private void clearUserIdResolverCache() {
 
+        UserIdResolverCache.getInstance()
+                .clear(RESOLVE_USER_UNIQUE_ID_FROM_USER_NAME_CACHE_NAME, MultitenantConstants.SUPER_TENANT_ID);
+        UserIdResolverCache.getInstance()
+                .clear(RESOLVE_USER_NAME_FROM_UNIQUE_USER_ID_CACHE_NAME, MultitenantConstants.SUPER_TENANT_ID);
         UserIdResolverCache.getInstance()
                 .clear(RESOLVE_USER_ID_FROM_USER_NAME_CACHE_NAME, MultitenantConstants.SUPER_TENANT_ID);
         UserIdResolverCache.getInstance()

--- a/core/org.wso2.carbon.user.core/src/test/java/org/wso2/carbon/user/core/jdbc/ReadOnlyJDBCRealmTest.java
+++ b/core/org.wso2.carbon.user.core/src/test/java/org/wso2/carbon/user/core/jdbc/ReadOnlyJDBCRealmTest.java
@@ -47,7 +47,9 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.wso2.carbon.user.core.UserStoreConfigConstants.RESOLVE_USER_ID_FROM_USER_NAME_CACHE_NAME;
+import static org.wso2.carbon.user.core.UserStoreConfigConstants.RESOLVE_USER_NAME_FROM_UNIQUE_USER_ID_CACHE_NAME;
 import static org.wso2.carbon.user.core.UserStoreConfigConstants.RESOLVE_USER_NAME_FROM_USER_ID_CACHE_NAME;
+import static org.wso2.carbon.user.core.UserStoreConfigConstants.RESOLVE_USER_UNIQUE_ID_FROM_USER_NAME_CACHE_NAME;
 
 public class ReadOnlyJDBCRealmTest extends BaseTestCase {
 
@@ -237,5 +239,9 @@ public class ReadOnlyJDBCRealmTest extends BaseTestCase {
                 .clear(RESOLVE_USER_ID_FROM_USER_NAME_CACHE_NAME, MultitenantConstants.SUPER_TENANT_ID);
         UserIdResolverCache.getInstance()
                 .clear(RESOLVE_USER_NAME_FROM_USER_ID_CACHE_NAME, MultitenantConstants.SUPER_TENANT_ID);
+        UserIdResolverCache.getInstance()
+                .clear(RESOLVE_USER_UNIQUE_ID_FROM_USER_NAME_CACHE_NAME, MultitenantConstants.SUPER_TENANT_ID);
+        UserIdResolverCache.getInstance()
+                .clear(RESOLVE_USER_NAME_FROM_UNIQUE_USER_ID_CACHE_NAME, MultitenantConstants.SUPER_TENANT_ID);
     }
 }

--- a/core/org.wso2.carbon.user.core/src/test/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCRealmPrimaryUserStoreTest.java
+++ b/core/org.wso2.carbon.user.core/src/test/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCRealmPrimaryUserStoreTest.java
@@ -54,7 +54,9 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import static org.wso2.carbon.user.core.UserStoreConfigConstants.RESOLVE_USER_ID_FROM_USER_NAME_CACHE_NAME;
+import static org.wso2.carbon.user.core.UserStoreConfigConstants.RESOLVE_USER_NAME_FROM_UNIQUE_USER_ID_CACHE_NAME;
 import static org.wso2.carbon.user.core.UserStoreConfigConstants.RESOLVE_USER_NAME_FROM_USER_ID_CACHE_NAME;
+import static org.wso2.carbon.user.core.UserStoreConfigConstants.RESOLVE_USER_UNIQUE_ID_FROM_USER_NAME_CACHE_NAME;
 
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class UniqueIDJDBCRealmPrimaryUserStoreTest extends BaseTestCase {
@@ -656,5 +658,9 @@ public class UniqueIDJDBCRealmPrimaryUserStoreTest extends BaseTestCase {
                 .clear(RESOLVE_USER_ID_FROM_USER_NAME_CACHE_NAME, MultitenantConstants.SUPER_TENANT_ID);
         UserIdResolverCache.getInstance()
                 .clear(RESOLVE_USER_NAME_FROM_USER_ID_CACHE_NAME, MultitenantConstants.SUPER_TENANT_ID);
+        UserIdResolverCache.getInstance()
+                .clear(RESOLVE_USER_UNIQUE_ID_FROM_USER_NAME_CACHE_NAME, MultitenantConstants.SUPER_TENANT_ID);
+        UserIdResolverCache.getInstance()
+                .clear(RESOLVE_USER_NAME_FROM_UNIQUE_USER_ID_CACHE_NAME, MultitenantConstants.SUPER_TENANT_ID);
     }
 }

--- a/core/org.wso2.carbon.user.core/src/test/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCRealmSecondaryUserStoreTest.java
+++ b/core/org.wso2.carbon.user.core/src/test/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCRealmSecondaryUserStoreTest.java
@@ -40,7 +40,10 @@ import org.wso2.carbon.user.core.common.DefaultRealm;
 import org.wso2.carbon.user.core.common.LoginIdentifier;
 import org.wso2.carbon.user.core.common.User;
 import static org.wso2.carbon.user.core.UserStoreConfigConstants.RESOLVE_USER_ID_FROM_USER_NAME_CACHE_NAME;
+import static org.wso2.carbon.user.core.UserStoreConfigConstants.RESOLVE_USER_NAME_FROM_UNIQUE_USER_ID_CACHE_NAME;
 import static org.wso2.carbon.user.core.UserStoreConfigConstants.RESOLVE_USER_NAME_FROM_USER_ID_CACHE_NAME;
+import static org.wso2.carbon.user.core.UserStoreConfigConstants.RESOLVE_USER_UNIQUE_ID_FROM_USER_NAME_CACHE_NAME;
+
 import org.wso2.carbon.user.core.common.UserIdResolverCache;
 import org.wso2.carbon.user.core.config.TestRealmConfigBuilder;
 import org.wso2.carbon.user.core.model.ExpressionAttribute;
@@ -85,10 +88,7 @@ public class UniqueIDJDBCRealmSecondaryUserStoreTest extends BaseTestCase {
 
         super.setUp();
         DatabaseUtil.closeDatabasePoolConnection();
-        UserIdResolverCache.getInstance()
-                .clear(RESOLVE_USER_ID_FROM_USER_NAME_CACHE_NAME, MultitenantConstants.SUPER_TENANT_ID);
-        UserIdResolverCache.getInstance()
-                .clear(RESOLVE_USER_NAME_FROM_USER_ID_CACHE_NAME, MultitenantConstants.SUPER_TENANT_ID);
+        clearUserIdResolverCache();
         initRealmStuff(TEST_URL);
         DatabaseUtil.closeDatabasePoolConnection();
     }
@@ -805,6 +805,18 @@ public class UniqueIDJDBCRealmSecondaryUserStoreTest extends BaseTestCase {
             }
         }
         return map;
+    }
+
+    private void clearUserIdResolverCache() {
+
+        UserIdResolverCache.getInstance()
+                .clear(RESOLVE_USER_UNIQUE_ID_FROM_USER_NAME_CACHE_NAME, MultitenantConstants.SUPER_TENANT_ID);
+        UserIdResolverCache.getInstance()
+                .clear(RESOLVE_USER_NAME_FROM_UNIQUE_USER_ID_CACHE_NAME, MultitenantConstants.SUPER_TENANT_ID);
+        UserIdResolverCache.getInstance()
+                .clear(RESOLVE_USER_ID_FROM_USER_NAME_CACHE_NAME, MultitenantConstants.SUPER_TENANT_ID);
+        UserIdResolverCache.getInstance()
+                .clear(RESOLVE_USER_NAME_FROM_USER_ID_CACHE_NAME, MultitenantConstants.SUPER_TENANT_ID);
     }
 
 }


### PR DESCRIPTION
## Purpose
> Introduce a caching layer at UserUniqueIDManager to cache the user name
> Add invalidation for above cache
> Since the UserUniqueIDManager class is only should be accessible from the abstract user store manager when the underlying user store does not support unique user id. In scenarios that underline user store natively support unique user id there should be a implementation to getUserNameFromUserID that implementation should be used to get user name from user id

