### PR TITLE
Add config for server disable/enable shutdown/restart option

### DIFF
--- a/core/org.wso2.carbon.server.admin.ui/src/main/resources/org/wso2/carbon/server/admin/ui/i18n/Resources.properties
+++ b/core/org.wso2.carbon.server.admin.ui/src/main/resources/org/wso2/carbon/server/admin/ui/i18n/Resources.properties
@@ -49,3 +49,6 @@ days=day(s)
 hours=hr(s)
 minutes=min(s)
 seconds=sec(s)
+shutdown.disabled=Option to Shutdown Server from Management Console is disabled.
+restart.disabled=Option to Restart Server from Management Console is disabled.
+

--- a/core/org.wso2.carbon.server.admin.ui/src/main/resources/web/server-admin/index.jsp
+++ b/core/org.wso2.carbon.server.admin.ui/src/main/resources/web/server-admin/index.jsp
@@ -17,6 +17,7 @@
  -->
 <%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
 <%@ taglib uri="http://wso2.org/projects/carbon/taglibs/carbontags.jar" prefix="carbon" %>
+<%@ page import="org.wso2.carbon.base.ServerConfiguration" %>
 <jsp:include page="../dialog/display_messages.jsp"/>
 
 <script type="text/javascript" src="js/serveradmin.js"></script>
@@ -35,11 +36,26 @@
     <div id="workArea">
         <div id="output" style="display:none;"></div>
 
+        <%
+            ServerConfiguration serverConfig = ServerConfiguration.getInstance();
+            String disableShutdown = serverConfig.getFirstProperty("disableShutdownRestartFromUI.disableShutdown");
+            String disableRestart = serverConfig.getFirstProperty("disableShutdownRestartFromUI.disableRestart");
+        %>
+
         <table class="styledLeft" id="shutDown" width="100%">
             <thead>
             <tr><th colspan="2"><fmt:message key="shutdown"/></th></tr>
             </thead>
             <tbody>
+            <%
+                if ("true".equals(disableShutdown)) {
+            %>
+            <tr>
+                <td width="100%"><strong><fmt:message key="shutdown.disabled"/></strong></td>
+            </tr>
+            <%
+            } else {
+            %>
             <tr>
                 <td width="50%"><strong><fmt:message key="graceful.shutdown"/></strong></td>
                 <td width="50%"><strong><fmt:message key="forced.shutdown"/></strong></td>
@@ -66,6 +82,9 @@
                     </a>
                 </td>
             </tr>
+            <%
+                }
+            %>
             </tbody>
         </table>
 
@@ -76,6 +95,15 @@
             <tr><th colspan="2"><fmt:message key="restart"/></th></tr>
             </thead>
             <tbody>
+            <%
+                if ("true".equals(disableRestart)) {
+            %>
+            <tr>
+                <td width="100%"><strong><fmt:message key="restart.disabled"/></strong></td>
+            </tr>
+            <%
+            } else {
+            %>
             <tr>
                 <td width="50%"><strong><fmt:message key="graceful.restart"/></strong></td>
                 <td width="50%"><strong><fmt:message key="forced.restart"/></strong></td>
@@ -102,6 +130,9 @@
                     </a>
                 </td>
             </tr>
+            <%
+                }
+            %>
             </tbody>
         </table>
         

--- a/distribution/kernel/carbon-home/repository/conf/carbon.xml
+++ b/distribution/kernel/carbon-home/repository/conf/carbon.xml
@@ -727,4 +727,10 @@
 	<LoadAPIContextsInServerStartup>true</LoadAPIContextsInServerStartup>
    </APIManagement>
 
+    <!-- Configure disable/enable shutdown and restart from the Management Console UI -->
+    <disableShutdownRestartFromUI>
+        <disableShutdown>false</disableShutdown>
+        <disableRestart>false</disableRestart>
+    </disableShutdownRestartFromUI>
+
 </Server>

--- a/distribution/kernel/carbon-home/repository/resources/conf/templates/repository/conf/carbon.xml.j2
+++ b/distribution/kernel/carbon-home/repository/resources/conf/templates/repository/conf/carbon.xml.j2
@@ -810,4 +810,13 @@
       {% if sts.time_to_live is defined %}
       <STSTimeToLive>{{sts.time_to_live}}</STSTimeToLive>
       {% endif %}
+
+
+    <!-- Configure disable/enable shutdown and restart from the Management Console UI -->
+
+     <disableShutdownRestartFromUI>
+        <disableShutdown>{{server.disable_shutdown_from_ui | default('false')}}</disableShutdown>
+        <disableRestart>{{server.disable_restart_from_ui | default('false')}}</disableRestart>
+     </disableShutdownRestartFromUI>
+
 </Server>


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

As $subject this will add a new enable/disable configuration for the server from management console UI.

The default configuration for **disable_shutdown_from_ui** and **disable_restart_from_ui** is false. If user want to disable shutdown and restart from UI, he can add the following configs in deployment.toml.
```

[server]
disable_shutdown_from_ui = true
disable_restart_from_ui = true

```

Fixes wso2/product-ei#5147
Doc issues https://github.com/wso2/docs-apim/issues/1821


