### PR TITLE
[Fix] Not triggering CON_APP_KEY recovery flow when CorrelationLogs are enabled

### DIFF
--- a/core/org.wso2.carbon.ndatasource.rdbms/src/main/java/org/wso2/carbon/ndatasource/rdbms/CorrelationLogInterceptor.java
+++ b/core/org.wso2.carbon.ndatasource.rdbms/src/main/java/org/wso2/carbon/ndatasource/rdbms/CorrelationLogInterceptor.java
@@ -25,6 +25,7 @@ import org.wso2.carbon.utils.xml.StringUtils;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.sql.DatabaseMetaData;
 import java.sql.PreparedStatement;
@@ -169,9 +170,11 @@ public class CorrelationLogInterceptor extends AbstractQueryReport {
 
                     return result;
                 }
-            } catch (Exception e) {
-                log.error("Unable get query run-time", e);
-                return null;
+            } catch (InvocationTargetException e) {
+                if (e.getCause() != null) {
+                    throw e.getCause();
+                }
+                throw e;
             }
         }
 


### PR DESCRIPTION
Resolves https://github.com/wso2/product-is/issues/9350

### Approach:
The reason is, CorrelationLogInterceptor is throwing a wrapped exception and the CON_APP_KEY recovery flow is not getting triggered.
Re-throw the exact exception thrown from the underlying DB driver will trigger the CON_APP_KEY recovery flow.