### PR TITLE
Fix uid claim not populating for JDBC user stores

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/JDBCUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/JDBCUserStoreManager.java
@@ -1387,6 +1387,9 @@ public class JDBCUserStoreManager extends AbstractUserStoreManager {
                           Map<String, String> claims, String profileName, boolean requirePasswordChange)
             throws UserStoreException {
 
+        // Assign username to the username claim.
+        claims = addUserNameAttribute(userName, claims);
+
         // persist the user info. in the database.
         persistUser(userName, credential, roleList, claims, profileName, requirePasswordChange);
 

--- a/core/org.wso2.carbon.user.core/src/test/java/org/wso2/carbon/user/core/jdbc/JDBCRealmPrimaryUserStoreTest.java
+++ b/core/org.wso2.carbon.user.core/src/test/java/org/wso2/carbon/user/core/jdbc/JDBCRealmPrimaryUserStoreTest.java
@@ -203,8 +203,8 @@ public class JDBCRealmPrimaryUserStoreTest extends BaseTestCase {
         assertEquals("usergivenname3", obtained.get(ClaimTestUtil.CLAIM_URI3));
         assertNull(obtained.get(ClaimTestUtil.CLAIM_URI2));
 
-        // With the username and userID claim in default profile.
-        assertEquals(2, admin.getUserClaimValues("user2", null).length);
+        // With the username claim in default profile.
+        assertEquals(3, admin.getUserClaimValues("user2", null).length);
         assertEquals(2, admin.getUserClaimValues("user2", ClaimTestUtil.HOME_PROFILE_NAME).length);
     }
 

--- a/core/org.wso2.carbon.user.core/src/test/java/org/wso2/carbon/user/core/jdbc/JDBCRealmSecondaryUserStoreTest.java
+++ b/core/org.wso2.carbon.user.core/src/test/java/org/wso2/carbon/user/core/jdbc/JDBCRealmSecondaryUserStoreTest.java
@@ -230,8 +230,8 @@ public class JDBCRealmSecondaryUserStoreTest extends BaseTestCase {
         assertEquals("usergivenname3", obtained.get(ClaimTestUtil.CLAIM_URI3));
         assertNull(obtained.get(ClaimTestUtil.CLAIM_URI2));
 
-        // With the username and userID claim in default profile.
-        assertEquals(2, admin.getUserClaimValues("SECONDARYJDBC/user2", null).length);
+        // With the username claim in default profile.
+        assertEquals(3, admin.getUserClaimValues("SECONDARYJDBC/user2", null).length);
         assertEquals(2, admin.getUserClaimValues("SECONDARYJDBC/user2", ClaimTestUtil.HOME_PROFILE_NAME).length);
     }
 


### PR DESCRIPTION
Resolves https://github.com/wso2/product-is/issues/9576

### Approach
Error occurs when the userstore manager class is `JDBCUserStoreManager`. In this case, when the attributes were added, username was missing from the attributes map. 

**FIX:** Append username claim to the user attributes.

### Tests
Units tests are already available and fixed in this PR.