### PR TITLE
Add a mapping to GroupAndRoleSeparationEnabled config

### DIFF
--- a/distribution/kernel/carbon-home/repository/resources/conf/key-mappings.json
+++ b/distribution/kernel/carbon-home/repository/resources/conf/key-mappings.json
@@ -92,5 +92,7 @@
 
   "clustering.shutdown_hook_enable": "hazelcast.'hazelcast.shutdownhook.enabled'",
   "clustering.logging_type": "hazelcast.'hazelcast.logging.type'",
-  "clustering.properties.vpcCidrBlock": "clustering.properties.networkInterface"
+  "clustering.properties.vpcCidrBlock": "clustering.properties.networkInterface",
+
+  "authorization_manager.properties.group_and_role_separation_enabled": "authorization_manager.properties.GroupAndRoleSeparationEnabled"
 }


### PR DESCRIPTION
## Purpose
> The following configuration can be added to deployment.toml to disable the GroupAndRoleSeparation feature.

```
[authorization_manager.properties]
group_and_role_separation_enabled = false
```

> Resolves https://github.com/wso2/product-is/issues/9641