### PR TITLE
Revert commit bf35a50 temporary due to test failure

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/ReadWriteLDAPUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/ReadWriteLDAPUserStoreManager.java
@@ -1504,7 +1504,7 @@ public class ReadWriteLDAPUserStoreManager extends ReadOnlyLDAPUserStoreManager 
                                             mainDirContext,
                                             searchBase);
                             // assume only one group with given group name
-                            String groupDN = resolveGroupDN(searchFilter, newRole, context);
+                            String groupDN = "cn=" + newRole;
                             if (!groupResults.hasMore()) {
                                 modifyUserInRole(userNameDN, groupDN, DirContext.ADD_ATTRIBUTE,
                                         searchBase);

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/UniqueIDReadWriteLDAPUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/UniqueIDReadWriteLDAPUserStoreManager.java
@@ -1657,7 +1657,7 @@ public class UniqueIDReadWriteLDAPUserStoreManager extends UniqueIDReadOnlyLDAPU
                             NamingEnumeration<SearchResult> groupResults = searchInGroupBase(roleSearchFilter,
                                     returningAttributes, SearchControls.SUBTREE_SCOPE, mainDirContext, searchBase);
                             // assume only one group with given group name
-                            String groupDN = resolveGroupDN(searchFilter, newRole, context);
+                            String groupDN = "cn=" + newRole;
                             if (!groupResults.hasMore()) {
                                 modifyUserInRole(userNameDN, groupDN, DirContext.ADD_ATTRIBUTE, searchBase);
                             } else {


### PR DESCRIPTION
Revert temporary https://github.com/wso2/carbon-kernel/commit/bf35a50e10457a6f71be032b95a5369563c80446 due to product-is integration test failure. 