### PR TITLE
 Add SQL query to get user list for property with case insensitive username 

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/JDBCUserStoreConstants.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/JDBCUserStoreConstants.java
@@ -412,6 +412,10 @@ public class JDBCUserStoreConstants {
         setAdvancedProperty(JDBCRealmConstants.GET_USERS_FOR_PROP_WITH_ID, "Get User List for Property With ID SQL",
                 JDBCRealmConstants.GET_USERS_FOR_PROP_WITH_ID_SQL, "",
                 new Property[] { USER.getProperty(), SQL.getProperty(), FALSE.getProperty() });
+        setAdvancedProperty(JDBCCaseInsensitiveConstants.GET_USERS_FOR_PROP_WITH_ID_CASE_INSENSITIVE,
+                "Get User List For Property With ID SQL With Case Insensitive Username",
+                JDBCCaseInsensitiveConstants.GET_USERS_FOR_PROP_WITH_ID_SQL_CASE_INSENSITIVE, "",
+                new Property[] { USER.getProperty(), SQL.getProperty(), FALSE.getProperty() });
         setAdvancedProperty(JDBCRealmConstants.GET_PROFILE_NAMES, "Get Profile Names SQL",
                 JDBCRealmConstants.GET_PROFILE_NAMES_SQL, "",
                 new Property[] { USER.getProperty(), SQL.getProperty(), FALSE.getProperty() });

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCUserStoreManager.java
@@ -98,6 +98,7 @@ public class UniqueIDJDBCUserStoreManager extends JDBCUserStoreManager {
             "This is the separator for multiple claim " + "values";
     private static final String VALIDATION_INTERVAL = "validationInterval";
     private static final List<Property> UNIQUE_ID_JDBC_UM_ADVANCED_PROPERTIES = new ArrayList<>();
+    private static final String UID = "uid";
 
     public UniqueIDJDBCUserStoreManager() {
 
@@ -2315,7 +2316,12 @@ public class UniqueIDJDBCUserStoreManager extends JDBCUserStoreManager {
         List<String> userList = new ArrayList<>();
         try {
             dbConnection = getDBConnection();
-            sqlStmt = realmConfig.getUserStoreProperty(JDBCRealmConstants.GET_USERS_FOR_PROP_WITH_ID);
+            if (!isCaseSensitiveUsername() && UID.equals(property)) {
+                sqlStmt = realmConfig.getUserStoreProperty(JDBCCaseInsensitiveConstants.
+                        GET_USERS_FOR_PROP_WITH_ID_CASE_INSENSITIVE);
+            } else {
+                sqlStmt = realmConfig.getUserStoreProperty(JDBCRealmConstants.GET_USERS_FOR_PROP_WITH_ID);
+            }
             prepStmt = dbConnection.prepareStatement(sqlStmt);
             prepStmt.setString(1, property);
             prepStmt.setString(2, value);

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/caseinsensitive/JDBCCaseInsensitiveConstants.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/caseinsensitive/JDBCCaseInsensitiveConstants.java
@@ -48,6 +48,8 @@ public class JDBCCaseInsensitiveConstants {
             "GetUsersPropertiesForProfileSQLCaseInsensitive";
     public static final String GET_PROP_FOR_PROFILE_CASE_INSENSITIVE = "GetUserPropertyForProfileSQLCaseInsensitive";
     public static final String GET_PROFILE_NAMES_FOR_USER_CASE_INSENSITIVE = "GetUserProfileNamesSQLCaseInsensitive";
+    public static final String GET_USERS_FOR_PROP_WITH_ID_CASE_INSENSITIVE =
+            "GetUserListForPropertyWithIDSQLCaseInsensitive";
     public static final String GET_USERID_FROM_USERNAME_CASE_INSENSITIVE = "GetUserIDFromUserNameSQLCaseInsensitive";
     public static final String GET_TENANT_ID_FROM_USERNAME_CASE_INSENSITIVE =
             "GetTenantIDFromUserNameSQLCaseInsensitive";
@@ -142,7 +144,10 @@ public class JDBCCaseInsensitiveConstants {
             " UM_ATTR_VALUE FROM UM_USER_ATTRIBUTE, UM_USER WHERE UM_USER.UM_ID = UM_USER_ATTRIBUTE.UM_USER_ID AND " +
             "LOWER(UM_USER.UM_USER_NAME) IN (?) AND UM_PROFILE_ID=? AND UM_USER_ATTRIBUTE.UM_TENANT_ID=? AND UM_USER" +
             ".UM_TENANT_ID=?";
-
+    public static final String GET_USERS_FOR_PROP_WITH_ID_SQL_CASE_INSENSITIVE = "SELECT DISTINCT UM_USER.UM_USER_ID " +
+            "FROM UM_USER, UM_USER_ATTRIBUTE WHERE UM_USER_ATTRIBUTE.UM_USER_ID = UM_USER.UM_ID AND " +
+            "UM_USER_ATTRIBUTE.UM_ATTR_NAME =? AND LOWER(UM_USER_ATTRIBUTE.UM_ATTR_VALUE) LIKE LOWER(?) AND " +
+            "UM_USER_ATTRIBUTE.UM_PROFILE_ID=? AND UM_USER_ATTRIBUTE.UM_TENANT_ID=? AND UM_USER.UM_TENANT_ID=?";
     public static final String GET_PROP_FOR_PROFILE_SQL_CASE_INSENSITIVE = "SELECT UM_ATTR_VALUE FROM " +
             "UM_USER_ATTRIBUTE, UM_USER WHERE UM_USER.UM_ID = UM_USER_ATTRIBUTE.UM_USER_ID AND LOWER(UM_USER" +
             ".UM_USER_NAME)=LOWER(?) AND UM_ATTR_NAME=? AND UM_PROFILE_ID=? AND UM_USER_ATTRIBUTE.UM_TENANT_ID=? AND " +

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/util/JDBCRealmUtil.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/util/JDBCRealmUtil.java
@@ -199,6 +199,10 @@ public class JDBCRealmUtil {
             properties.put(JDBCRealmConstants.GET_USERS_FOR_PROP_WITH_ID,
                     JDBCRealmConstants.GET_USERS_FOR_PROP_WITH_ID_SQL);
         }
+        if (!properties.containsKey(JDBCCaseInsensitiveConstants.GET_USERS_FOR_PROP_WITH_ID_CASE_INSENSITIVE)) {
+            properties.put(JDBCCaseInsensitiveConstants.GET_USERS_FOR_PROP_WITH_ID_CASE_INSENSITIVE,
+                    JDBCCaseInsensitiveConstants.GET_USERS_FOR_PROP_WITH_ID_SQL_CASE_INSENSITIVE);
+        }
         if (!properties.containsKey(JDBCRealmConstants.GET_PAGINATED_USERS_FOR_PROP)) {
             properties.put(JDBCRealmConstants.GET_PAGINATED_USERS_FOR_PROP,
                     JDBCRealmConstants.GET_PAGINATED_USERS_FOR_PROP_SQL);


### PR DESCRIPTION
### Description
This PR will add new SQL query to get user list for property with case insensitive username.

### Approach
A new query has introduced since SCIM username filter API and password recover API doesn't obey the `CaseInsensitiveUsername` property of the user store. With this PR changes it will check the case insensitivity of the username to select the SQL query accordingly.

**Resolves:** https://github.com/wso2/product-is/issues/9552