### PR TITLE
Faulty userstores skipped when obtaining realm configurations

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/tenant/JDBCTenantManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/tenant/JDBCTenantManager.java
@@ -1046,9 +1046,9 @@ public class JDBCTenantManager implements TenantManager {
      * @param tenantId           tenant id
      * @throws UserStoreException throws
      */
-    private void setSecondaryUserStoreConfig(RealmConfiguration realmConfiguration, int tenantId)
-            throws UserStoreException {
-        // Get the last realm configuration
+    private void setSecondaryUserStoreConfig(RealmConfiguration realmConfiguration, int tenantId) {
+
+        // Get the last realm configuration.
         RealmConfiguration lastRealm = realmConfiguration;
         if (realmConfiguration != null) {
             while (lastRealm.getSecondaryRealmConfig() != null) {
@@ -1067,13 +1067,17 @@ public class JDBCTenantManager implements TenantManager {
             });
             if (files != null) {
                 for (File file : files) {
-                    RealmConfiguration newRealmConfig = userStoreDeploymentManager.
-                            getUserStoreConfiguration(file.getAbsolutePath());
-                    if (newRealmConfig != null) {
-                        lastRealm.setSecondaryRealmConfig(newRealmConfig);
-                        lastRealm = lastRealm.getSecondaryRealmConfig();
-                    } else {
-                        log.error("Error while creating realm configuration from file " + file.getAbsolutePath());
+                    try {
+                        RealmConfiguration newRealmConfig = userStoreDeploymentManager.
+                                getUserStoreConfiguration(file.getAbsolutePath());
+                        if (newRealmConfig != null) {
+                            lastRealm.setSecondaryRealmConfig(newRealmConfig);
+                            lastRealm = lastRealm.getSecondaryRealmConfig();
+                        } else {
+                            log.error("Error while creating realm configuration from file " + file.getAbsolutePath());
+                        }
+                    } catch (UserStoreException e) {
+                        log.error("Error while creating realm configuration from file " + file.getAbsolutePath(), e);
                     }
                 }
             }


### PR DESCRIPTION
**Fixes: https://github.com/wso2/product-is/issues/9623**

**Description:**
Having a faulty userstore xml in tenants causes the realm configuration obtaining flow to fail, causing most functionalities in tenant context to fail. Skipping the faulty userstores fixes this issue. 