### PR TITLE
Make not throwing an error when iterating though the userstores

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
@@ -3172,14 +3172,18 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
                         + claimValueWithDomain);
             }
 
-            // Recursively call the getUserList method appending the domain to claim value.
-            List<User> userList = ((AbstractUserStoreManager) userStoreManager).getUserListWithID(claim,
-                    claimValueWithDomain, profileName);
-            if (log.isDebugEnabled()) {
-                log.debug("Secondary user list for domain: " + domainName + " : " + userList);
+            try {
+                // Recursively call the getUserList method appending the domain to claim value.
+                List<User> userList = ((AbstractUserStoreManager) userStoreManager).getUserListWithID(claim,
+                        claimValueWithDomain, profileName);
+                if (log.isDebugEnabled()) {
+                    log.debug("Secondary user list for domain: " + domainName + " : " + userList);
+                }
+                usersFromAllStoresList.addAll(userList);
+            } catch (UserStoreException e) {
+                log.error(String.format("Error occurred while getting the users list for domain: %s Therefore, " +
+                        "proceeding remaining domains", domainName), e);
             }
-
-            usersFromAllStoresList.addAll(userList);
         }
 
         // Done with all user store processing. Return the user array if not empty.


### PR DESCRIPTION
Resolve https://github.com/wso2/product-is/issues/9907

### Approach
Not throwing an error when iterating through the user stores. Therefore when an error occurred in one user store, the user search of other user stores will not get affected due to this.