### PR TITLE
Fix the issue with displaying dialog box in management console

### DIFF
--- a/core/org.wso2.carbon.ui/src/main/resources/web/dialog/display_messages.jsp
+++ b/core/org.wso2.carbon.ui/src/main/resources/web/dialog/display_messages.jsp
@@ -23,7 +23,7 @@
 <script type="text/javascript">
     var msgId;
     <%
-    if(Encode.forJavaScript(request.getParameter("msgId")) == null){
+    if (Encode.forJavaScript(request.getParameter("msgId")).equals("null")){
     %>
     msgId = '<%="MSG" + System.currentTimeMillis() + Math.random()%>';
     <%


### PR DESCRIPTION
## Purpose
Resolves https://github.com/wso2/product-is/issues/10016. 

Encode.forJavaScript() https://owasp.org/owasp-java-encoder/encoder/apidocs/org/owasp/encoder/Encode.html#forJavaScript-java.lang.String- is always return a string value of encoded input string.  Due to this. `Encode.forJavaScript(request.getParameter("msgId")) == null` is always false. So the msgId  cookie is not generated with timestamp (cookie: MSG`<timestamp>`=true). Instead a msgId cookie  as `null` is getting created since the msgId is always null. 

After this fix, management cosole will show the below dialog box

<img width="1104" alt="Screenshot 2020-11-05 at 13 21 44" src="https://user-images.githubusercontent.com/17597293/98212645-e80b1680-1f69-11eb-84cb-f99723d3266f.png">
