### PR TITLE
[public]Add case sensitive property for LDAP/AD based userstore properties

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/UserStoreConfigConstants.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/UserStoreConfigConstants.java
@@ -153,4 +153,8 @@ public class UserStoreConfigConstants {
             + " inorder to establish the connection after couple of failure attempts.";
     public static final int DEFAULT_CONNECTION_RETRY_DELAY_IN_MILLISECONDS = 120000;
     public static final String OBJECT_GUID = "objectGuid";
+
+    // Property for specify case insensitivity for User stores.
+    public static final String CASE_INSENSITIVE_USERNAME = "CaseInsensitiveUsername";
+    public static final String CASE_INSENSITIVE_USERNAME_DESCRIPTION = "Whether the username is case sensitive or not";
 }

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/JDBCUserStoreConstants.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/JDBCUserStoreConstants.java
@@ -99,8 +99,8 @@ public class JDBCUserStoreConstants {
         setProperty("RolenameJavaScriptRegEx", "Group Name RegEx (Javascript)", "^[\\S]{5,30}$",
                 "The regular expression used by the font-end components for group name validation",
                 new Property[] { GROUP.getProperty(), STRING.getProperty(), TRUE.getProperty() });
-        setProperty(JDBCCaseInsensitiveConstants.CASE_SENSITIVE_USERNAME, "Case Insensitive Username", "false",
-                JDBCCaseInsensitiveConstants.CASE_SENSITIVE_USERNAME_DESCRIPTION,
+        setProperty(UserStoreConfigConstants.CASE_INSENSITIVE_USERNAME, "Case Insensitive Username", "false",
+                UserStoreConfigConstants.CASE_INSENSITIVE_USERNAME_DESCRIPTION,
                 new Property[] { USER.getProperty(), BOOLEAN.getProperty(), FALSE.getProperty() });
 
         //set Advanced properties

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/caseinsensitive/JDBCCaseInsensitiveConstants.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/caseinsensitive/JDBCCaseInsensitiveConstants.java
@@ -247,6 +247,7 @@ public class JDBCCaseInsensitiveConstants {
             ".UM_TENANT_ID=? AND UM_HYBRID_USER_ROLE.UM_DOMAIN_ID=(SELECT UM_DOMAIN_ID FROM UM_DOMAIN WHERE " +
             "UM_TENANT_ID=? AND UM_DOMAIN_NAME=?)";
 
+    @Deprecated
     public static final String CASE_SENSITIVE_USERNAME = "CaseInsensitiveUsername";
     public static final String CASE_SENSITIVE_USERNAME_DESCRIPTION = "Whether the username is case sensitive or not";
 

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/ActiveDirectoryUserStoreConstants.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/ActiveDirectoryUserStoreConstants.java
@@ -98,6 +98,9 @@ public class ActiveDirectoryUserStoreConstants {
         setProperty(UserStoreConfigConstants.disabled, "Disabled", "false",
                 UserStoreConfigConstants.disabledDescription,
                 new Property[] { BASIC.getProperty(), BOOLEAN.getProperty(), TRUE.getProperty() });
+        setProperty(UserStoreConfigConstants.CASE_INSENSITIVE_USERNAME, "Case Insensitive Username", "true",
+                UserStoreConfigConstants.CASE_INSENSITIVE_USERNAME_DESCRIPTION,
+                new Property[] { USER.getProperty(), BOOLEAN.getProperty(), TRUE.getProperty() });
 
         Property readLDAPGroups = new Property(UserStoreConfigConstants.readGroups, "true",
                 "Read Groups#" + UserStoreConfigConstants.readLDAPGroupsDescription,

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/ReadOnlyLDAPUserStoreConstants.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/ReadOnlyLDAPUserStoreConstants.java
@@ -129,6 +129,9 @@ public class ReadOnlyLDAPUserStoreConstants {
                 new Property[] { CONNECTION.getProperty(), STRING.getProperty(), FALSE.getProperty() });
         setProperty(UserStoreConfigConstants.dateAndTimePattern, "", UserStoreConfigConstants
                 .dateAndTimePatternDisplayName, UserStoreConfigConstants.dateAndTimePatternDescription, new Property[]{CONNECTION.getProperty(), STRING.getProperty(), FALSE.getProperty()});
+        setProperty(UserStoreConfigConstants.CASE_INSENSITIVE_USERNAME, "Case Insensitive Username", "true",
+                UserStoreConfigConstants.CASE_INSENSITIVE_USERNAME_DESCRIPTION,
+                new Property[] { USER.getProperty(), BOOLEAN.getProperty(), TRUE.getProperty() });
     }
 
     private static void setMandatoryProperty(String name, String displayName, String value, String description,

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/ReadWriteLDAPUserStoreConstants.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/ReadWriteLDAPUserStoreConstants.java
@@ -164,6 +164,9 @@ public class ReadWriteLDAPUserStoreConstants {
                 new Property[] { CONNECTION.getProperty(), STRING.getProperty(), FALSE.getProperty() });
         setProperty(UserStoreConfigConstants.dateAndTimePattern, "", UserStoreConfigConstants
                 .dateAndTimePatternDisplayName, UserStoreConfigConstants.dateAndTimePatternDescription, new Property[]{CONNECTION.getProperty(), STRING.getProperty(), FALSE.getProperty()});
+        setProperty(UserStoreConfigConstants.CASE_INSENSITIVE_USERNAME, "Case Insensitive Username", "true",
+                UserStoreConfigConstants.CASE_INSENSITIVE_USERNAME_DESCRIPTION,
+                new Property[] { USER.getProperty(), BOOLEAN.getProperty(), TRUE.getProperty() });
     }
 
     private static void setMandatoryProperty(String name, String displayName, String value, String description,

--- a/distribution/kernel/carbon-home/repository/resources/conf/infer.json
+++ b/distribution/kernel/carbon-home/repository/resources/conf/infer.json
@@ -55,7 +55,8 @@
       "user_store.properties.ReplaceEscapeCharactersAtUserLogin": true,
       "user_store.properties.SCIMEnabled": true,
       "user_store.properties.UserRolesCacheEnabled": true,
-      "user_store.properties.ConnectionRetryDelay": "2m"
+      "user_store.properties.ConnectionRetryDelay": "2m",
+      "user_store.properties.CaseInsensitiveUsername": true
     },
     "read_only_ldap_unique_id": {
       "user_store.class": "org.wso2.carbon.user.core.ldap.UniqueIDReadOnlyLDAPUserStoreManager",
@@ -82,7 +83,8 @@
       "user_store.properties.UserRolesCacheEnabled": true,
       "user_store.properties.ConnectionRetryDelay": "2m",
       "user_store.properties.UserIDAttribute": "scimId",
-      "user_store.properties.UserIdSearchFilter": "(&amp;(objectClass=person)(uid=?))"
+      "user_store.properties.UserIdSearchFilter": "(&amp;(objectClass=person)(uid=?))",
+      "user_store.properties.CaseInsensitiveUsername": true
     },
     "read_write_ldap": {
       "user_store.class": "org.wso2.carbon.user.core.ldap.ReadWriteLDAPUserStoreManager",
@@ -115,7 +117,8 @@
       "user_store.properties.defaultRealmName": "WSO2.ORG",
       "user_store.properties.StartTLSEnabled": false,
       "user_store.properties.UserRolesCacheEnabled": true,
-      "user_store.properties.ConnectionRetryDelay": "2m"
+      "user_store.properties.ConnectionRetryDelay": "2m",
+      "user_store.properties.CaseInsensitiveUsername": true
     },
     "read_write_ldap_unique_id": {
       "user_store.class": "org.wso2.carbon.user.core.ldap.UniqueIDReadWriteLDAPUserStoreManager",
@@ -150,7 +153,8 @@
       "user_store.properties.UserRolesCacheEnabled": true,
       "user_store.properties.ConnectionRetryDelay": "2m",
       "user_store.properties.UserIDAttribute": "scimId",
-      "user_store.properties.UserIdSearchFilter": "(&amp;(objectClass=person)(uid=?))"
+      "user_store.properties.UserIdSearchFilter": "(&amp;(objectClass=person)(uid=?))",
+      "user_store.properties.CaseInsensitiveUsername": true
     },
     "active_directory": {
       "user_store.class": "org.wso2.carbon.user.core.ldap.ActiveDirectoryUserStoreManager",
@@ -188,7 +192,8 @@
       "user_store.properties.StartTLSEnabled": false,
       "user_store.properties.SCIMEnabled": false,
       "user_store.properties.UserRolesCacheEnabled": true,
-      "user_store.properties.ConnectionRetryDelay": "2m"
+      "user_store.properties.ConnectionRetryDelay": "2m",
+      "user_store.properties.CaseInsensitiveUsername": true
     },
     "active_directory_unique_id": {
       "user_store.class": "org.wso2.carbon.user.core.ldap.UniqueIDActiveDirectoryUserStoreManager",
@@ -230,7 +235,8 @@
       "user_store.properties.UserIDAttribute": "objectGuid",
       "user_store.properties.'java.naming.ldap.attributes.binary'": "objectGuid",
       "user_store.properties.ImmutableAttributes": "objectGuid",
-      "user_store.properties.UserIdSearchFilter": "(&amp;(objectClass=person)(uid=?))"
+      "user_store.properties.UserIdSearchFilter": "(&amp;(objectClass=person)(uid=?))",
+      "user_store.properties.CaseInsensitiveUsername": true
     }
   },
   "database.$1.type": {


### PR DESCRIPTION
## Purpose
> Added the case insensitive property for LDAP and AD based userstore properties and the default value for the infer.json file.
> Existing CASE_SENSITIVE_USERNAME was deprecated.
> Fixes : https://github.com/wso2/product-is/issues/9854

## Goals
> Validate the username with userstore case sensitivity.

## Related PRs
> Please merge this PR before https://github.com/wso2-extensions/identity-inbound-provisioning-scim2/pull/302