### PR TITLE
Fix LDAP TLS authentication issue

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/LdapContextWrapper.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/LdapContextWrapper.java
@@ -153,6 +153,8 @@ public class LdapContextWrapper implements LdapContext {
                         "TLS LdapContext environment");
             }
         }
+
+        ldapContext.getAttributes("");
     }
 
     @Override


### PR DESCRIPTION
## Purpose
When StartTLS is enabled users can log in to Carbon Admin Portal with any wrong non-blank password. Fixing that issue for carbon-kernal 4.5.x with this PR.