### PR TITLE
Introduce an error code for invalid domain scenario

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
@@ -14751,8 +14751,10 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
                     filteredUsers = userUniqueIDManger.listUsers(users.getUsers(), this);
                 }
             }
-        } else if (secManager == null && StringUtils.isNotEmpty(domain)) {
-            throw new UserStoreClientException("Invalid Domain Name.");
+        } else if (StringUtils.isNotEmpty(domain)) {
+            String message = ErrorMessages.ERROR_CODE_INVALID_DOMAIN_NAME.getMessage();
+            String errorCode = ErrorMessages.ERROR_CODE_INVALID_DOMAIN_NAME.getCode();
+            throw new UserStoreClientException(errorCode + " - " + String.format(message, domain), errorCode);
         }
 
         handlePostGetUserListWithID(condition, domain, profileName, limit, offset, sortBy, sortOrder, filteredUsers,

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/constants/UserCoreErrorConstants.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/constants/UserCoreErrorConstants.java
@@ -220,7 +220,8 @@ public class UserCoreErrorConstants {
         // Error code related with updating permissions of role.
         ERROR_CODE_ERROR_WHILE_UPDATING_PERMISSIONS_OF_ROLE("32101", "Un-expected error while updating permissions of  "
                 + "updating role,  %s"),
-        ERROR_CODE_USERNAME_CANNOT_BE_EMPTY("32102", "Username %s is not valid. User name cannot be empty.");
+        ERROR_CODE_USERNAME_CANNOT_BE_EMPTY("32102", "Username %s is not valid. User name cannot be empty."),
+        ERROR_CODE_INVALID_DOMAIN_NAME("32103", "Domain name: %s, is not valid");
 
         private final String code;
         private final String message;


### PR DESCRIPTION
## Purpose
Fixes https://github.com/wso2/product-is/issues/10611.

If the provided domain name is invalid a user store client exception is thrown, which is correct. However, identifying the root cause of this error could be required for consuming services, thus this PR modifies the code to introduce a new error code.