### PR TITLE
Handle  domain supplied user listing with secondary userstore managers

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
@@ -14745,15 +14745,22 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
         }
 
         List<User> filteredUsers = new ArrayList<>();
-        UserStoreManager secManager = getSecondaryUserStoreManager(domain);
-        if (secManager != null) {
-            if (secManager instanceof AbstractUserStoreManager) {
-                if (isUniqueUserIdEnabled(secManager)) {
-                    UniqueIDPaginatedSearchResult users = ((AbstractUserStoreManager) secManager)
+        UserStoreManager userManager = this;
+        /*
+         * This method("getUserListWithID") can be called for secondary userstore managers.
+         * At that time the "domain" is the name of the "this" usertore manager.
+         */
+        if (StringUtils.isNotEmpty(domain) && !StringUtils.equalsIgnoreCase(getMyDomainName(), domain)) {
+            userManager = getSecondaryUserStoreManager(domain);
+        }
+        if (userManager != null) {
+            if (userManager instanceof AbstractUserStoreManager) {
+                if (isUniqueUserIdEnabled(userManager)) {
+                    UniqueIDPaginatedSearchResult users = ((AbstractUserStoreManager) userManager)
                             .doGetUserListWithID(condition, profileName, limit, offset, sortBy, sortOrder);
                     filteredUsers = users.getUsers();
                 } else {
-                    PaginatedSearchResult users = ((AbstractUserStoreManager) secManager)
+                    PaginatedSearchResult users = ((AbstractUserStoreManager) userManager)
                             .doGetUserList(condition, profileName, limit, offset, sortBy, sortOrder);
                     filteredUsers = userUniqueIDManger.listUsers(users.getUsers(), this);
                 }


### PR DESCRIPTION
😍 Fixes wso2/product-is#10509.

💬 Sometimes the `getUserListWithID` method of the secondary user store managers is invoked with a domain name. The correct use of this pattern should be that only the primary user stores method should be called with a valid domain name. However, in some flows, even the secondary user store manager's same method is invoked with the secondary user store manager's domain name. This is a valid case as the secondary user store manager should be aware of its domain name. This PR handles this scenario accordingly.