### PR TITLE
Add options to config outbound ports in Hazelcast in AWS

### DIFF
--- a/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/clustering/hazelcast/aws/AWSBasedMembershipScheme.java
+++ b/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/clustering/hazelcast/aws/AWSBasedMembershipScheme.java
@@ -100,6 +100,22 @@ public class AWSBasedMembershipScheme implements HazelcastMembershipScheme {
     public void init() throws ClusteringFault {
         networkConfig.getJoin().getMulticastConfig().setEnabled(false);
         networkConfig.getJoin().getTcpIpConfig().setEnabled(false);
+
+        Parameter outboundPortDefinition = getParameter(AWSConstants.OUTBOUND_PORT_DEFINITION);
+        if (outboundPortDefinition != null) {
+            networkConfig.addOutboundPortDefinition(((String) outboundPortDefinition.getValue()).trim());
+        }
+
+        Parameter outboundPort = getParameter(AWSConstants.OUTBOUND_PORT);
+        if (outboundPort != null) {
+            String outboundPortString = ((String) outboundPort.getValue()).trim();
+            try {
+                networkConfig.addOutboundPort(Integer.parseInt(outboundPortString));
+            } catch (NumberFormatException e) {
+                log.error("Invalid value for the parameter: " + AWSConstants.OUTBOUND_PORT, e);
+            }
+        }
+
         AwsConfig awsConfig = networkConfig.getJoin().getAwsConfig();
         awsConfig.setEnabled(true);
 

--- a/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/clustering/hazelcast/aws/AWSConstants.java
+++ b/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/clustering/hazelcast/aws/AWSConstants.java
@@ -32,4 +32,6 @@ public class AWSConstants {
     public static final String TAG_VALUE = "tagValue";
     public static final String IAM_ROLE = "iamRole";
     public static final String NETWORK_INTERFACE = "networkInterface";
+    public static final String OUTBOUND_PORT_DEFINITION = "outboundPortDefinition";
+    public static final String OUTBOUND_PORT = "outboundPort";
 }


### PR DESCRIPTION
## Purpose
Adding options to config outbound ports in Hazelcast in AWS.

In order to configure Hazelcast outbound ports in AWS, add the following parameters to axis2 configs inside clustering configs.
To give a range of ports or set of ports, add a new parameter named outboundPortDefinition.
E.g,
```<parameter name="outboundPortDefinition">5000-6000</parameter>```
Find more info about port definitions in [1]

To define a single port, use a parameter named outboundPort.
E.g,
```<parameter name="outboundPort">5000</parameter>```

[1] - https://docs.hazelcast.org/docs/3.9/manual/html-single/index.html#outbound-ports

Related issue: wso2/product-ei#5323