### PR TITLE
Add tenant UUID to the RealmConfiguration

### DIFF
--- a/core/org.wso2.carbon.user.api/src/main/java/org/wso2/carbon/user/api/RealmConfiguration.java
+++ b/core/org.wso2.carbon.user.api/src/main/java/org/wso2/carbon/user/api/RealmConfiguration.java
@@ -39,7 +39,7 @@ public class RealmConfiguration {
     protected String everyOneRoleName = null;
     protected String realmClassName = null;
     protected String description = null;
-    protected String tenantUuid = null;
+    protected String tenantUniqueId = null;
     protected List<String> restrictedDomainsForSelfSignUp = new ArrayList<String>();
     protected List<String> reservedRoleNames = new ArrayList<String>();
     protected String isOverrideUsernameClaimFromInternalUsername = "false";
@@ -58,23 +58,23 @@ public class RealmConfiguration {
     }
 
     /**
-     * Get tenant UUID.
+     * Get tenant unique id.
      *
-     * @return UUID of the tenant.
+     * @return Unique id of the tenant.
      */
-    public String getTenantUuid() {
+    public String getTenantUniqueId() {
 
-        return tenantUuid;
+        return tenantUniqueId;
     }
 
     /**
-     * Set the tenant UUID.
+     * Set the unique id of the tenant.
      *
-     * @param tenantUuid UUID of the tenant.
+     * @param tenantUniqueId Unique id of the tenant.
      */
-    public void setTenantUuid(String tenantUuid) {
+    public void setTenantUniqueId(String tenantUniqueId) {
 
-        this.tenantUuid = tenantUuid;
+        this.tenantUniqueId = tenantUniqueId;
     }
 
     public boolean isRestrictedDomainForSlefSignUp(String domain) {

--- a/core/org.wso2.carbon.user.api/src/main/java/org/wso2/carbon/user/api/RealmConfiguration.java
+++ b/core/org.wso2.carbon.user.api/src/main/java/org/wso2/carbon/user/api/RealmConfiguration.java
@@ -39,6 +39,7 @@ public class RealmConfiguration {
     protected String everyOneRoleName = null;
     protected String realmClassName = null;
     protected String description = null;
+    protected String tenantUuid = null;
     protected List<String> restrictedDomainsForSelfSignUp = new ArrayList<String>();
     protected List<String> reservedRoleNames = new ArrayList<String>();
     protected String isOverrideUsernameClaimFromInternalUsername = "false";
@@ -54,6 +55,26 @@ public class RealmConfiguration {
 
     public RealmConfiguration() {
         tenantId = MultitenantConstants.SUPER_TENANT_ID;
+    }
+
+    /**
+     * Get tenant UUID.
+     *
+     * @return UUID of the tenant.
+     */
+    public String getTenantUuid() {
+
+        return tenantUuid;
+    }
+
+    /**
+     * Set the tenant UUID.
+     *
+     * @param tenantUuid UUID of the tenant.
+     */
+    public void setTenantUuid(String tenantUuid) {
+
+        this.tenantUuid = tenantUuid;
     }
 
     public boolean isRestrictedDomainForSlefSignUp(String domain) {

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/tenant/JDBCTenantManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/tenant/JDBCTenantManager.java
@@ -227,8 +227,14 @@ public class JDBCTenantManager implements TenantManager {
                 createdTimeMs = createdTime.getTime();
             }
             prepStmt.setTimestamp(4, new Timestamp(createdTimeMs));
-            String realmConfigString = RealmConfigXMLProcessor.serialize(
-                    (RealmConfiguration) tenant.getRealmConfig()).toString();
+
+            // Add the tenant UUID to the realm config and update the tenant object.
+            RealmConfiguration tenantRealmConfiguration = tenant.getRealmConfig();
+            if (isTenantUniqueIdColumnAvailable()) {
+                tenantRealmConfiguration.setTenantUuid(tenant.getTenantUniqueID());
+                tenant.setRealmConfig(tenantRealmConfiguration);
+            }
+            String realmConfigString = RealmConfigXMLProcessor.serialize(tenantRealmConfiguration).toString();
             InputStream is = new ByteArrayInputStream(realmConfigString.getBytes());
             prepStmt.setBinaryStream(5, is, is.available());
 

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/tenant/JDBCTenantManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/tenant/JDBCTenantManager.java
@@ -145,7 +145,7 @@ public class JDBCTenantManager implements TenantManager {
             // Add the tenant UUID to the realm config and update the tenant object.
             RealmConfiguration tenantRealmConfiguration = tenant.getRealmConfig();
             if (isTenantUniqueIdColumnAvailable()) {
-                tenantRealmConfiguration.setTenantUuid(tenantUniqueID);
+                tenantRealmConfiguration.setTenantUniqueId(tenantUniqueID);
                 tenant.setRealmConfig(tenantRealmConfiguration);
             }
             String realmConfigString = RealmConfigXMLProcessor.serialize(tenantRealmConfiguration).toString();
@@ -231,7 +231,7 @@ public class JDBCTenantManager implements TenantManager {
             // Add the tenant UUID to the realm config and update the tenant object.
             RealmConfiguration tenantRealmConfiguration = tenant.getRealmConfig();
             if (isTenantUniqueIdColumnAvailable()) {
-                tenantRealmConfiguration.setTenantUuid(tenant.getTenantUniqueID());
+                tenantRealmConfiguration.setTenantUniqueId(tenant.getTenantUniqueID());
                 tenant.setRealmConfig(tenantRealmConfiguration);
             }
             String realmConfigString = RealmConfigXMLProcessor.serialize(tenantRealmConfiguration).toString();

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/tenant/JDBCTenantManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/tenant/JDBCTenantManager.java
@@ -141,8 +141,14 @@ public class JDBCTenantManager implements TenantManager {
                 createdTimeMs = createdTime.getTime();
             }
             prepStmt.setTimestamp(3, new Timestamp(createdTimeMs));
-            String realmConfigString = RealmConfigXMLProcessor.serialize(
-                    (RealmConfiguration) tenant.getRealmConfig()).toString();
+
+            // Add the tenant UUID to the realm config and update the tenant object.
+            RealmConfiguration tenantRealmConfiguration = tenant.getRealmConfig();
+            if (isTenantUniqueIdColumnAvailable()) {
+                tenantRealmConfiguration.setTenantUuid(tenantUniqueID);
+                tenant.setRealmConfig(tenantRealmConfiguration);
+            }
+            String realmConfigString = RealmConfigXMLProcessor.serialize(tenantRealmConfiguration).toString();
             InputStream is = new ByteArrayInputStream(realmConfigString.getBytes());
             prepStmt.setBinaryStream(4, is, is.available());
 

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/tenant/JDBCTenantManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/tenant/JDBCTenantManager.java
@@ -142,13 +142,12 @@ public class JDBCTenantManager implements TenantManager {
             }
             prepStmt.setTimestamp(3, new Timestamp(createdTimeMs));
 
-            // Add the tenant UUID to the realm config and update the tenant object.
-            RealmConfiguration tenantRealmConfiguration = tenant.getRealmConfig();
+            // Add the tenant UUID to the realm config.
             if (isTenantUniqueIdColumnAvailable()) {
-                tenantRealmConfiguration.setTenantUniqueId(tenantUniqueID);
-                tenant.setRealmConfig(tenantRealmConfiguration);
+                tenant.getRealmConfig().setTenantUniqueId(tenantUniqueID);
             }
-            String realmConfigString = RealmConfigXMLProcessor.serialize(tenantRealmConfiguration).toString();
+            String realmConfigString = RealmConfigXMLProcessor.serialize(
+                    (RealmConfiguration) tenant.getRealmConfig()).toString();
             InputStream is = new ByteArrayInputStream(realmConfigString.getBytes());
             prepStmt.setBinaryStream(4, is, is.available());
 
@@ -228,13 +227,12 @@ public class JDBCTenantManager implements TenantManager {
             }
             prepStmt.setTimestamp(4, new Timestamp(createdTimeMs));
 
-            // Add the tenant UUID to the realm config and update the tenant object.
-            RealmConfiguration tenantRealmConfiguration = tenant.getRealmConfig();
+            // Add the tenant UUID to the realm config.
             if (isTenantUniqueIdColumnAvailable()) {
-                tenantRealmConfiguration.setTenantUniqueId(tenant.getTenantUniqueID());
-                tenant.setRealmConfig(tenantRealmConfiguration);
+                tenant.getRealmConfig().setTenantUniqueId(tenant.getTenantUniqueID());
             }
-            String realmConfigString = RealmConfigXMLProcessor.serialize(tenantRealmConfiguration).toString();
+            String realmConfigString = RealmConfigXMLProcessor.serialize(
+                    (RealmConfiguration) tenant.getRealmConfig()).toString();
             InputStream is = new ByteArrayInputStream(realmConfigString.getBytes());
             prepStmt.setBinaryStream(5, is, is.available());
 


### PR DESCRIPTION
## Purpose
Adding the tenant UUID to the RealmConfiguration during the tenant add scenario.

## Approach
A new attribute has been introduced to RealmConfiguration to track tenant UUID. While adding the tenant, the tenant UUID was added to the RealmConfiguration and also added to the initial tenant object. This is done only if the tenant uuid column is available. 