### PR TITLE
Introduce a new thread local to keep ask password option state

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
@@ -4730,7 +4730,7 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
             // Set a thread local if the user creation flow is ask password enabled.
             if (claims.containsKey(UserCoreClaimConstants.ASK_PASSWORD_CLAIM_URI) &&
                     Boolean.parseBoolean(claims.get(UserCoreClaimConstants.ASK_PASSWORD_CLAIM_URI))) {
-                UserCoreUtil.setThreadLocalToSetAskPasswordEnabled(true);
+                UserCoreUtil.setSkipPasswordPatternValidationThreadLocal(true);
             }
 
             // This happens only once during first startup - adding administrator user/role.
@@ -4860,7 +4860,7 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
             }
 
             // Validate the password against provided regular expressions.
-            if (!UserCoreUtil.getAskPasswordEnabledFromThreadLocal() && !checkUserPasswordValid(credentialObj)) {
+            if (!checkUserPasswordValid(credentialObj)) {
                 String regEx = realmConfig.getUserStoreProperty(UserCoreConstants.RealmConfig.PROPERTY_JAVA_REG_EX);
                 String message = String.format(ErrorMessages.ERROR_CODE_INVALID_PASSWORD.getMessage(), regEx);
                 String errorCode = ErrorMessages.ERROR_CODE_INVALID_PASSWORD.getCode();
@@ -4985,7 +4985,7 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
             }
             // #################### </Post-Listeners> #####################################################
         } finally {
-            UserCoreUtil.removeAskPasswordEnabledInThreadLocal();
+            UserCoreUtil.removeSkipPasswordPatternValidationThreadLocal();
             credentialObj.clear();
         }
 
@@ -7939,6 +7939,10 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
      */
     protected boolean checkUserPasswordValid(Object credential) throws UserStoreException {
 
+        // Skip password pattern validation if the skipPasswordValidationThreadLocal is set to true.
+        if (UserCoreUtil.getSkipPasswordPatternValidationThreadLocal()) {
+            return true;
+        }
         if (!isSecureCall.get()) {
             Class argTypes[] = new Class[]{Object.class};
             Object object = callSecure("checkUserPasswordValid", new Object[]{credential}, argTypes);
@@ -13868,7 +13872,7 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
             // Set a thread local if the user creation flow is ask password enabled.
             if (claims.containsKey(UserCoreClaimConstants.ASK_PASSWORD_CLAIM_URI) &&
                     Boolean.parseBoolean(claims.get(UserCoreClaimConstants.ASK_PASSWORD_CLAIM_URI))) {
-                UserCoreUtil.setThreadLocalToSetAskPasswordEnabled(true);
+                UserCoreUtil.setSkipPasswordPatternValidationThreadLocal(true);
             }
 
             // This happens only once during first startup - adding administrator user/role.
@@ -13997,7 +14001,7 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
             }
 
             // Validate the password against provided regular expressions.
-            if (!UserCoreUtil.getAskPasswordEnabledFromThreadLocal() && !checkUserPasswordValid(credentialObj)) {
+            if (!checkUserPasswordValid(credentialObj)) {
                 String regEx = realmConfig.getUserStoreProperty(UserCoreConstants.RealmConfig.PROPERTY_JAVA_REG_EX);
                 String message = String.format(ErrorMessages.ERROR_CODE_INVALID_PASSWORD.getMessage(), regEx);
                 String errorCode = ErrorMessages.ERROR_CODE_INVALID_PASSWORD.getCode();
@@ -14125,7 +14129,7 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
             }
             // #################### </Post-Listeners> #####################################################
         } finally {
-            UserCoreUtil.removeAskPasswordEnabledInThreadLocal();
+            UserCoreUtil.removeSkipPasswordPatternValidationThreadLocal();
             credentialObj.clear();
         }
 

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
@@ -4727,6 +4727,11 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
                         claims, profileName);
                 throw new UserStoreException(ErrorMessages.ERROR_CODE_READONLY_USER_STORE.toString());
             }
+            // Set a thread local if the user creation flow is ask password enabled.
+            if (claims.containsKey(UserCoreClaimConstants.ASK_PASSWORD_CLAIM_URI) &&
+                    Boolean.parseBoolean(claims.get(UserCoreClaimConstants.ASK_PASSWORD_CLAIM_URI))) {
+                UserCoreUtil.setThreadLocalToSetAskPasswordEnabled(true);
+            }
 
             // This happens only once during first startup - adding administrator user/role.
             if (userName.indexOf(CarbonConstants.DOMAIN_SEPARATOR) > 0) {
@@ -4855,7 +4860,7 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
             }
 
             // Validate the password against provided regular expressions.
-            if (!checkUserPasswordValid(credentialObj)) {
+            if (!UserCoreUtil.getAskPasswordEnabledFromThreadLocal() && !checkUserPasswordValid(credentialObj)) {
                 String regEx = realmConfig.getUserStoreProperty(UserCoreConstants.RealmConfig.PROPERTY_JAVA_REG_EX);
                 String message = String.format(ErrorMessages.ERROR_CODE_INVALID_PASSWORD.getMessage(), regEx);
                 String errorCode = ErrorMessages.ERROR_CODE_INVALID_PASSWORD.getCode();
@@ -4980,6 +4985,7 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
             }
             // #################### </Post-Listeners> #####################################################
         } finally {
+            UserCoreUtil.removeAskPasswordEnabledInThreadLocal();
             credentialObj.clear();
         }
 
@@ -13859,6 +13865,11 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
                         claims, profileName);
                 throw new UserStoreException(ErrorMessages.ERROR_CODE_READONLY_USER_STORE.toString());
             }
+            // Set a thread local if the user creation flow is ask password enabled.
+            if (claims.containsKey(UserCoreClaimConstants.ASK_PASSWORD_CLAIM_URI) &&
+                    Boolean.parseBoolean(claims.get(UserCoreClaimConstants.ASK_PASSWORD_CLAIM_URI))) {
+                UserCoreUtil.setThreadLocalToSetAskPasswordEnabled(true);
+            }
 
             // This happens only once during first startup - adding administrator user/role.
             if (userName.indexOf(CarbonConstants.DOMAIN_SEPARATOR) > 0) {
@@ -13986,7 +13997,7 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
             }
 
             // Validate the password against provided regular expressions.
-            if (!checkUserPasswordValid(credentialObj)) {
+            if (!UserCoreUtil.getAskPasswordEnabledFromThreadLocal() && !checkUserPasswordValid(credentialObj)) {
                 String regEx = realmConfig.getUserStoreProperty(UserCoreConstants.RealmConfig.PROPERTY_JAVA_REG_EX);
                 String message = String.format(ErrorMessages.ERROR_CODE_INVALID_PASSWORD.getMessage(), regEx);
                 String errorCode = ErrorMessages.ERROR_CODE_INVALID_PASSWORD.getCode();
@@ -14114,6 +14125,7 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
             }
             // #################### </Post-Listeners> #####################################################
         } finally {
+            UserCoreUtil.removeAskPasswordEnabledInThreadLocal();
             credentialObj.clear();
         }
 

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/constants/UserCoreClaimConstants.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/constants/UserCoreClaimConstants.java
@@ -4,4 +4,5 @@ public class UserCoreClaimConstants {
     public static final String INITIALIZE_NEW_CLAIM_MANAGER = "initializeNewClaimManager";
     public static final String USERNAME_CLAIM_URI = "http://wso2.org/claims/username";
     public static final String USER_ID_CLAIM_URI = "http://wso2.org/claims/userid";
+    public static final String ASK_PASSWORD_CLAIM_URI = "http://wso2.org/claims/identity/askPassword";
 }

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/util/UserCoreUtil.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/util/UserCoreUtil.java
@@ -22,7 +22,6 @@ import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.CarbonConstants;
-import org.wso2.carbon.base.ServerConfiguration;
 import org.wso2.carbon.context.CarbonContext;
 import org.wso2.carbon.user.api.RealmConfiguration;
 import org.wso2.carbon.user.core.common.User;
@@ -36,7 +35,6 @@ import org.wso2.carbon.user.core.dto.RoleDTO;
 import org.wso2.carbon.user.core.internal.UserStoreMgtDSComponent;
 import org.wso2.carbon.user.core.jdbc.JDBCRealmConstants;
 import org.wso2.carbon.user.core.service.RealmService;
-import org.wso2.carbon.utils.Secret;
 import org.wso2.carbon.utils.UnsupportedSecretTypeException;
 import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 import org.wso2.carbon.utils.xml.StringUtils;
@@ -52,7 +50,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -78,6 +75,11 @@ public final class UserCoreUtil {
     private static ThreadLocal<String> threadLocalToSetDomain = new ThreadLocal<String>();
     private static ThreadLocal<UserMgtContext> threadLocalToSetUserMgtContext = new
             ThreadLocal<UserMgtContext>();
+
+    /**
+     * This thread local is used to keep track whether Ask Password option is enabled during the user addition flow.
+     */
+    private static ThreadLocal<Boolean> threadLocalToSetAskPasswordEnabled = new ThreadLocal<>();
 
     /**
      * @param arr1
@@ -480,6 +482,25 @@ public final class UserCoreUtil {
     public static void removeUserMgtContextInThreadLocal() {
 
         threadLocalToSetUserMgtContext.remove();
+    }
+
+    public static void setThreadLocalToSetAskPasswordEnabled(Boolean askPasswordEnabled) {
+
+        threadLocalToSetAskPasswordEnabled.set(askPasswordEnabled);
+    }
+
+    public static boolean getAskPasswordEnabledFromThreadLocal() {
+
+        if (threadLocalToSetAskPasswordEnabled.get() != null) {
+            return threadLocalToSetAskPasswordEnabled.get().booleanValue();
+        } else {
+            return false;
+        }
+    }
+
+    public static void removeAskPasswordEnabledInThreadLocal() {
+
+        threadLocalToSetAskPasswordEnabled.remove();
     }
 
     /**

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/util/UserCoreUtil.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/util/UserCoreUtil.java
@@ -79,7 +79,7 @@ public final class UserCoreUtil {
     /**
      * This thread local is used to keep track whether Ask Password option is enabled during the user addition flow.
      */
-    private static ThreadLocal<Boolean> threadLocalToSetAskPasswordEnabled = new ThreadLocal<>();
+    private static ThreadLocal<Boolean> skipPasswordPatternValidationThreadLocal = new ThreadLocal<>();
 
     /**
      * @param arr1
@@ -484,23 +484,23 @@ public final class UserCoreUtil {
         threadLocalToSetUserMgtContext.remove();
     }
 
-    public static void setThreadLocalToSetAskPasswordEnabled(Boolean askPasswordEnabled) {
+    public static void setSkipPasswordPatternValidationThreadLocal(Boolean askPasswordEnabled) {
 
-        threadLocalToSetAskPasswordEnabled.set(askPasswordEnabled);
+        skipPasswordPatternValidationThreadLocal.set(askPasswordEnabled);
     }
 
-    public static boolean getAskPasswordEnabledFromThreadLocal() {
+    public static boolean getSkipPasswordPatternValidationThreadLocal() {
 
-        if (threadLocalToSetAskPasswordEnabled.get() != null) {
-            return threadLocalToSetAskPasswordEnabled.get().booleanValue();
+        if (skipPasswordPatternValidationThreadLocal.get() != null) {
+            return skipPasswordPatternValidationThreadLocal.get().booleanValue();
         } else {
             return false;
         }
     }
 
-    public static void removeAskPasswordEnabledInThreadLocal() {
+    public static void removeSkipPasswordPatternValidationThreadLocal() {
 
-        threadLocalToSetAskPasswordEnabled.remove();
+        skipPasswordPatternValidationThreadLocal.remove();
     }
 
     /**


### PR DESCRIPTION
## Purpose
> Fixing https://github.com/wso2/product-is/issues/10792
> When ask password option is enabled during the user creation flow, password attribute sent in the request is validated in several places. 
> This PR introduces a new thread local to keep track whether the user creation flow is ask password enabled. This thread local will be used to skip the password validations in different places such as [UserStoreActionListener](https://github.com/wso2-extensions/identity-user-workflow/blob/c83c25370913e7e4f8c0f29177467930500df447/components/org.wso2.carbon.user.mgt.workflow/src/main/java/org/wso2/carbon/user/mgt/workflow/userstore/UserStoreActionListener.java#L85), [PasswordPolicyValidationHandler](https://github.com/wso2-extensions/identity-governance/blob/master/components/org.wso2.carbon.identity.password.policy/src/main/java/org/wso2/carbon/identity/password/policy/handler/PasswordPolicyValidationHandler.java) and AbstractUserStoreManager.