### PR TITLE
Synchronize user role retrieval from DB and adding it to user role cache

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
@@ -8436,6 +8436,9 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
 
     private String[] getUserRolesWithIDFromDatabase(String userID, String filter) throws UserStoreException {
 
+        if (log.isDebugEnabled()) {
+            log.debug("Retrieving user role list for userID: " + userID + " from database");
+        }
         List<String> internalRoles = doGetInternalRoleListOfUserWithID(userID, filter);
         Set<String> modifiedInternalRoles = new HashSet<>();
         String[] modifiedExternalRoleList = new String[0];
@@ -8508,6 +8511,9 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
 
     private String[] getUserRolesFromDatabase(String username, String filter) throws UserStoreException {
 
+        if (log.isDebugEnabled()) {
+            log.debug("Retrieving user role list for user: " + username + " from database");
+        }
         String[] internalRoles = doGetInternalRoleListOfUser(username, filter);
         String[] modifiedExternalRoleList = new String[0];
 


### PR DESCRIPTION
## Purpose
This PR introduces thread synchronization to the process of 'user role retrieval from DB and adding it to user role cache' to avoid multiple threads querying the user roles from DB for the same user concurrently, and update the user role cache with the same value retrieved from DB concurrently.

Resolves : https://github.com/wso2/product-is/issues/10869
