### PR TITLE
Fix RolenameJavaScriptRegEx, RolenameJavaRegEx differance

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/JDBCUserStoreConstants.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/JDBCUserStoreConstants.java
@@ -96,7 +96,7 @@ public class JDBCUserStoreConstants {
         setProperty("RolenameJavaRegEx", "Group Name RegEx (Java)", "[a-zA-Z0-9._\\-|//]{3,30}$",
                 "A regular expression to validate group names",
                 new Property[] { GROUP.getProperty(), STRING.getProperty(), TRUE.getProperty() });
-        setProperty("RolenameJavaScriptRegEx", "Group Name RegEx (Javascript)", "^[\\S]{5,30}$",
+        setProperty("RolenameJavaScriptRegEx", "Group Name RegEx (Javascript)", "^[\\S]{3,30}$",
                 "The regular expression used by the font-end components for group name validation",
                 new Property[] { GROUP.getProperty(), STRING.getProperty(), TRUE.getProperty() });
         setProperty(UserStoreConfigConstants.CASE_INSENSITIVE_USERNAME, "Case Insensitive Username", "false",


### PR DESCRIPTION
## Purpose
`RolenameJavaScriptRegEx` and `RolenameJavaRegEx` need to be same.
In the existing regex:
RolenameJavaRegEx has min length - 3
RolenameJavaScriptRegEx has min length -5 

Min length 3 is the default config in every other place. This PR fixes that issue.