### PR TITLE
GetUserProfiles of a non-existent user in a UniqueIDJDBCUserStore altered to throw an error

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
@@ -1833,11 +1833,7 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
         }
 
         if (!isUserExist) {
-            String errorCode = ErrorMessages.ERROR_CODE_NON_EXISTING_USER.getCode();
-            String errorMessage = String.format(ErrorMessages.ERROR_CODE_NON_EXISTING_USER.getMessage(), userName,
-                    realmConfig.getUserStoreProperty(UserCoreConstants.RealmConfig.PROPERTY_DOMAIN_NAME));
-            handleGetUserClaimValueFailure(errorCode, errorMessage, userName, claim, profileName);
-            throw new UserStoreException(errorCode + " - " + errorMessage);
+            handleGetNonExistentUser(userName, claim, profileName);
         }
 
         Map<String, String> finalValues;
@@ -15529,5 +15525,22 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
                             e.getMessage()), userID, claims, profileName);
             throw e;
         }
+    }
+
+    /**
+     * Throw an error if the requested user does not exist.
+     *
+     * @param userName              Username.
+     * @param profileName           Profile name.
+     * @throws UserStoreException   Exception when the user does not exist.
+     */
+    protected void handleGetNonExistentUser(String userName, String claim, String profileName)
+            throws UserStoreException {
+
+        String errorCode = ErrorMessages.ERROR_CODE_NON_EXISTING_USER.getCode();
+        String errorMessage = String.format(ErrorMessages.ERROR_CODE_NON_EXISTING_USER.getMessage(), userName,
+                realmConfig.getUserStoreProperty(UserCoreConstants.RealmConfig.PROPERTY_DOMAIN_NAME));
+        handleGetUserClaimValueFailure(errorCode, errorMessage, userName, claim, profileName);
+        throw new UserStoreException(errorCode + " - " + errorMessage);
     }
 }

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCUserStoreManager.java
@@ -358,6 +358,9 @@ public class UniqueIDJDBCUserStoreManager extends JDBCUserStoreManager {
     public String[] getProfileNames(String userName) throws UserStoreException {
 
         String userID = getUserIDFromUserName(userName);
+        if (StringUtils.isBlank(userID)) {
+            handleGetNonExistentUser(userName, null, null);
+        }
         return getProfileNamesWithID(userID);
     }
 

--- a/core/org.wso2.carbon.user.core/src/test/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCRealmPrimaryUserStoreTest.java
+++ b/core/org.wso2.carbon.user.core/src/test/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCRealmPrimaryUserStoreTest.java
@@ -656,8 +656,9 @@ public class UniqueIDJDBCRealmPrimaryUserStoreTest extends BaseTestCase {
 
         try {
             admin.getProfileNames("nonExistentUser");
-        } catch (UserStoreException e) {
+        } catch (Exception e) {
             // Expected exception.
+            assertTrue(e instanceof UserStoreException);
             assertEquals("30007 - UserNotFound: User nonExistentUser does not exist in: PRIMARY",
                     e.getMessage());
         }

--- a/core/org.wso2.carbon.user.core/src/test/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCRealmPrimaryUserStoreTest.java
+++ b/core/org.wso2.carbon.user.core/src/test/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCRealmPrimaryUserStoreTest.java
@@ -652,6 +652,17 @@ public class UniqueIDJDBCRealmPrimaryUserStoreTest extends BaseTestCase {
         }
     }
 
+    public void test204GetProfileOfNonExistentUser() {
+
+        try {
+            admin.getProfileNames("nonExistentUser");
+        } catch (UserStoreException e) {
+            // Expected exception.
+            assertEquals("30007 - UserNotFound: User nonExistentUser does not exist in: PRIMARY",
+                    e.getMessage());
+        }
+    }
+
     private void clearUserIdResolverCache() {
 
         UserIdResolverCache.getInstance()


### PR DESCRIPTION
#### Approach
> An NPE was being thrown in this case earlier. This flow has been changed to throw an error if the requested user does not exist.

#### Purpose
> Resolves https://github.com/wso2/product-is/issues/11120