### PR TITLE
Fix same site being null

### DIFF
--- a/core/org.wso2.carbon.tomcat.ext/src/main/java/org/wso2/carbon/tomcat/ext/transport/CarbonResponseWrapper.java
+++ b/core/org.wso2.carbon.tomcat.ext/src/main/java/org/wso2/carbon/tomcat/ext/transport/CarbonResponseWrapper.java
@@ -98,7 +98,11 @@ public class CarbonResponseWrapper extends Response {
 
         String cookieString = super.generateCookieString(cookie);
         if (cookie instanceof ServletCookie) {
-            cookieString = cookieString + "; SameSite=" + ((ServletCookie) cookie).getSameSite().getName();
+            if (((ServletCookie) cookie).getSameSite() == null) {
+                cookieString = cookieString + "; SameSite=" + SameSiteCookie.STRICT.getName();
+            } else {
+                cookieString = cookieString + "; SameSite=" + ((ServletCookie) cookie).getSameSite().getName();
+            }
         } else {
             cookieString = cookieString + "; SameSite=" + SameSiteCookie.STRICT.getName();
         }


### PR DESCRIPTION
Part of the fix for https://github.com/wso2/product-is/issues/11230
## Purpose
Avoid NPE and set default to Strict when the samesite cookie is not available.