### PR TITLE
Add support for ge and le operations for SCIM user filtering with LDAP

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
@@ -9985,7 +9985,9 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
         return !(ExpressionOperation.EQ.toString().equals(condition.getOperation()) ||
                 ExpressionOperation.CO.toString().equals(condition.getOperation()) ||
                 ExpressionOperation.SW.toString().equals(condition.getOperation()) ||
-                ExpressionOperation.EW.toString().equals(condition.getOperation()));
+                ExpressionOperation.EW.toString().equals(condition.getOperation()) ||
+                ExpressionOperation.GE.toString().equals(condition.getOperation()) ||
+                ExpressionOperation.LE.toString().equals(condition.getOperation()));
     }
 
     private boolean isAnInternalRole(String roleName) {

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCUserStoreManager.java
@@ -29,6 +29,7 @@ import org.wso2.carbon.user.api.RealmConfiguration;
 import org.wso2.carbon.user.core.NotImplementedException;
 import org.wso2.carbon.user.core.UserCoreConstants;
 import org.wso2.carbon.user.core.UserRealm;
+import org.wso2.carbon.user.core.UserStoreClientException;
 import org.wso2.carbon.user.core.UserStoreException;
 import org.wso2.carbon.user.core.UserStoreManager;
 import org.wso2.carbon.user.core.claim.ClaimManager;
@@ -3223,6 +3224,11 @@ public class UniqueIDJDBCUserStoreManager extends JDBCUserStoreManager {
         getExpressionConditions(condition, expressionConditions);
 
         for (ExpressionCondition expressionCondition : expressionConditions) {
+            // TODO: This validation has to be removed once ge and le operations are implemented for JDBC userstores.
+            if (ExpressionOperation.GE.toString().equals(expressionCondition.getOperation()) ||
+                    ExpressionOperation.LE.toString().equals(expressionCondition.getOperation())) {
+                throw new UserStoreClientException("ge and le operations are not supported for JDBC userstores.");
+            }
             if (ExpressionAttribute.ROLE.toString().equals(expressionCondition.getAttributeName())) {
                 isGroupFiltering = true;
                 totalMultiGroupFilters++;

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/LDAPFilterQueryBuilder.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/LDAPFilterQueryBuilder.java
@@ -32,6 +32,8 @@ public class LDAPFilterQueryBuilder {
     private static final String AND_OPERATION = "&";
     private static final String OR_OPERATION = "|";
     private static final String EQUALS_SIGN = "=";
+    private static final String GREATER_THAN_SIGN = ">";
+    private static final String LESS_THAN_SIGN = "<";
     private static final String ANY_STRING = "*";
 
     private StringBuilder searchFilter;
@@ -80,6 +82,10 @@ public class LDAPFilterQueryBuilder {
             queryBuilder.append(endWithFilterBuilder(property, value));
         } else if (ExpressionOperation.SW.toString().equals(operation)) {
             queryBuilder.append(startWithFilterBuilder(property, value));
+        } else if (ExpressionOperation.GE.toString().equals(operation)) {
+            queryBuilder.append(greaterThanOrEqualFilterBuilder(property, value));
+        } else if (ExpressionOperation.LE.toString().equals(operation)) {
+            queryBuilder.append(lessThanOrEqualFilterBuilder(property, value));
         }
     }
 
@@ -138,6 +144,36 @@ public class LDAPFilterQueryBuilder {
 
         StringBuilder filter = new StringBuilder();
         filter.append(OPEN_PARENTHESIS).append(property).append(EQUALS_SIGN).append(value).append(ANY_STRING).
+                append(CLOSE_PARENTHESIS);
+        return filter.toString();
+    }
+
+    /**
+     * Generate "LE" filter.
+     *
+     * @param property Attribute name.
+     * @param value    Attribute value.
+     * @return Filter query with less than or equal filter.
+     */
+    private String lessThanOrEqualFilterBuilder(String property, String value) {
+
+        StringBuilder filter = new StringBuilder();
+        filter.append(OPEN_PARENTHESIS).append(property).append(LESS_THAN_SIGN).append(EQUALS_SIGN).append(value).
+                append(CLOSE_PARENTHESIS);
+        return filter.toString();
+    }
+
+    /**
+     * Generate "GE" filter.
+     *
+     * @param property Attribute name.
+     * @param value    Attribute value.
+     * @return Filter query with greater than or equal filter.
+     */
+    private String greaterThanOrEqualFilterBuilder(String property, String value) {
+
+        StringBuilder filter = new StringBuilder();
+        filter.append(OPEN_PARENTHESIS).append(property).append(GREATER_THAN_SIGN).append(EQUALS_SIGN).append(value).
                 append(CLOSE_PARENTHESIS);
         return filter.toString();
     }

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/model/ExpressionOperation.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/model/ExpressionOperation.java
@@ -21,5 +21,5 @@ package org.wso2.carbon.user.core.model;
  * This represents expression operations.
  */
 public enum ExpressionOperation {
-    EQ, SW, EW, CO
+    EQ, SW, EW, CO, GE, LE
 }


### PR DESCRIPTION
Related to https://github.com/wso2/product-is/issues/11214

This PR is to add the following operations for SCIM user filtering with LDAP user stores. 
- ge (greater than or equal)
- le (less than or equal)

Sample curl request,
```
curl -X POST \
  https://localhost:9443/scim2/Users/.search \
  -H 'Authorization: Basic YWRtaW46YWRtaW4=' \
  -H 'Content-Type: application/scim+json' \
  -H 'Postman-Token: df7d2747-4e2c-417d-a938-b3fa137a6198' \
  -H 'cache-control: no-cache' \
  -d '{
   "schemas":[
      "urn:ietf:params:scim:api:messages:2.0:SearchRequest"
   ],
   "attributes":[
      "name.familyName",
      "userName"
   ],
   "filter":"meta.lastModified ge 2021-02-08T11:12:55.614Z",
   "domain":"PRIMARY",
   "startIndex":1,
   "count":10
}'
```