### PR TITLE
Throw UserStoreClientException to upper level

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
@@ -1683,12 +1683,14 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
                         String.format(ErrorMessages.ERROR_CODE_ERROR_WHILE_AUTHENTICATION.getMessage(), e.getMessage()),
                         userName, credential);
                 // We can ignore and proceed. Ignore the results from this user store.
-
-                if (log.isDebugEnabled()) {
-                  log.debug("Error occurred while authenticating user: " + userName, e);
-                } else {
-                  log.error(e);
+                // But throw the message to the upper level if it is a client exception.
+                if (e instanceof UserStoreClientException) {
+                    if (log.isDebugEnabled()) {
+                        log.debug("Error occurred while authenticating user: " + userName, e);
+                    }
+                    throw (UserStoreClientException) e;
                 }
+                log.error("Error occurred while authenticating user: " + userName, e);
                 authenticated = false;
             }
 
@@ -10841,12 +10843,14 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
                         String.format(ErrorMessages.ERROR_CODE_ERROR_WHILE_AUTHENTICATION.getMessage(), e.getMessage()),
                         preferredUserNameClaim, preferredUserNameValue, credential);
                 // We can ignore and proceed. Ignore the results from this user store.
-
-                if (log.isDebugEnabled()) {
-                    log.debug("Error occurred while authenticating user: " + preferredUserNameValue, e);
-                } else {
-                    log.error(e);
+                // But throw the message to the upper level if it is a client exception.
+                if (e instanceof UserStoreClientException) {
+                    if (log.isDebugEnabled()) {
+                        log.debug("Error occurred while authenticating user: " + preferredUserNameValue, e);
+                    }
+                    throw (UserStoreClientException) e;
                 }
+                log.error("Error occurred while authenticating user: " + preferredUserNameValue, e);
                 authenticated = false;
             }
 


### PR DESCRIPTION
Related to wso2/product-is#11332

If the UserStoreClientException is thrown from a userstore manager during the authentication, it needs to be passed to the upper level in order to convey the message to the end-user instead of trying to authenticate with the next userstore in the chain. This PR handles that requirement.