### PR TITLE
Check for the empty classpath is empty before appending.

### DIFF
--- a/distribution/kernel/carbon-home/bin/wso2server.sh
+++ b/distribution/kernel/carbon-home/bin/wso2server.sh
@@ -234,7 +234,11 @@ fi
 for f in "$CARBON_HOME"/bin/*.jar
 do
     if [ "$f" != "$CARBON_HOME/bin/*.jar" ];then
-        CARBON_CLASSPATH="$CARBON_CLASSPATH":$f
+      if [ -z "$CARBON_CLASSPATH" ];then
+            CARBON_CLASSPATH=$f
+      else
+            CARBON_CLASSPATH="$CARBON_CLASSPATH":$f
+      fi
     fi
 done
 for t in "$CARBON_HOME"/lib/*.jar


### PR DESCRIPTION
## Purpose

In the jdk11, the $JAVA_HOME/lib/tools.jar will not be present. So when creating the appending the CARBON_CLASSPATHs we need to check for the empty before appending ":<new_path>"

Fix https://github.com/wso2/carbon-kernel/issues/2935