### PR TITLE
Add configs for MgtHostName

### DIFF
--- a/distribution/kernel/carbon-home/repository/resources/conf/templates/repository/conf/carbon.xml.j2
+++ b/distribution/kernel/carbon-home/repository/resources/conf/templates/repository/conf/carbon.xml.j2
@@ -50,7 +50,9 @@
     <!--
     Host name to be used for the Carbon management console
     -->
-     {%if server.hostname is defined %}
+     {%if server.mgt_console_hostname is defined %}
+    <MgtHostName>{{server.mgt_console_hostname}}</MgtHostName>
+     {%elif server.hostname is defined %}
     <MgtHostName>{{server.hostname}}</MgtHostName>
      {% endif %}
 


### PR DESCRIPTION
**Resolves** : wso2/product-is#11459

This PR adds the following templated configuration support.

- Adding a different hostname for carbon management console

To add a different hostname, add the following configuration in deployment.toml

```
[server]
mgt_console_hostname = "sampleHostName"
```
This will add the following configuration in carbon.xml.

```
<!--
Host name to be used for the Carbon management console
-->
<MgtHostName>sampleHostName</MgtHostName>
```