### PR TITLE
Check not empty instead of null.

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCUserStoreManager.java
@@ -597,7 +597,7 @@ public class UniqueIDJDBCUserStoreManager extends JDBCUserStoreManager {
         if (userID == null) {
             return false;
         }
-        return doGetUserNameFromUserID(userID) != null;
+        return StringUtils.isNotEmpty(doGetUserNameFromUserID(userID));
     }
 
     @Override


### PR DESCRIPTION
This check is modified to check not empty instead of null to cover wider area. Username cannot be empty as well.