### PR TITLE
Improve logging in AuthenticationAdmin

### DIFF
--- a/core/org.wso2.carbon.core.services/src/main/java/org/wso2/carbon/core/services/authentication/AuthenticationAdmin.java
+++ b/core/org.wso2.carbon.core.services/src/main/java/org/wso2/carbon/core/services/authentication/AuthenticationAdmin.java
@@ -127,27 +127,17 @@ public class AuthenticationAdmin implements CarbonServerAuthenticator {
                 return false;
             }
         } catch (UserStoreException e) {
+            log.error("System error while authenticating/authorizing user.", e);
             if (isLoginFailureReasonEnabled()) {
                 throw new AuthenticationException(e.getMessage(), e);
             } else {
-                String msg = "System error while Authenticating/Authorizing User : " + e.getMessage();
-                log.error(msg);
                 return false;
             }
         } catch (AuthenticationException e) {
-            // remove login the exceptions.
-            log.error(e.getMessage());
+            log.error("System error while authenticating/authorizing user.", e);
             throw e;
         } catch (Exception e) {
-            // remove login the exceptions.
-            String msg = "System error while Authenticating/Authorizing User : " + e.getMessage();
-
-            if (log.isDebugEnabled()) {
-                log.error(msg, e);
-            } else {
-                log.error(msg);
-            }
-
+            log.error("System error while authenticating/authorizing user.", e);
             return false;
         }
     }


### PR DESCRIPTION
## Goals
Resolves https://github.com/wso2/product-is/issues/14869
Track the reason for the server errors without enabling debug logs or patching the product.

## Approach
Print full stack trace in error logs. Logging everything here since the upper components are not logging the full stack traces as the call goes through axis2 layers.