### PR TITLE
Fix - When group is in sub directory of the group search base (in LDAP) user to group assignment is failing

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/ReadWriteLDAPUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/ReadWriteLDAPUserStoreManager.java
@@ -1403,7 +1403,7 @@ public class ReadWriteLDAPUserStoreManager extends ReadOnlyLDAPUserStoreManager 
                             String groupDN = null;
                             if (groupResults.hasMore()) {
                                 resultedGroup = groupResults.next();
-                                groupDN = getGroupName(resultedGroup);
+                                groupDN = getGroupName(resultedGroup, searchBase);
                             }
                             if (resultedGroup != null) {
                                 this.modifyUserInRole(userNameDN, groupDN, DirContext.REMOVE_ATTRIBUTE,
@@ -1458,9 +1458,13 @@ public class ReadWriteLDAPUserStoreManager extends ReadOnlyLDAPUserStoreManager 
                                             SearchControls.SUBTREE_SCOPE,
                                             mainDirContext,
                                             searchBase);
-                            // assume only one group with given group name
-                            String groupDN = "cn=" + newRole;
-                            if (!groupResults.hasMore()) {
+                            SearchResult resultedGroup = null;
+                            String groupDN = null;
+                            if (groupResults.hasMore()) {
+                                resultedGroup = groupResults.next();
+                                groupDN = getGroupName(resultedGroup, searchBase);
+                            }
+                            if (resultedGroup != null) {
                                 modifyUserInRole(userNameDN, groupDN, DirContext.ADD_ATTRIBUTE,
                                         searchBase);
                             } else {
@@ -1531,16 +1535,18 @@ public class ReadWriteLDAPUserStoreManager extends ReadOnlyLDAPUserStoreManager 
         }
     }
 
-    private String getGroupName(SearchResult resultedGroup) throws NamingException {
+    private String getGroupName(SearchResult resultedGroup, String searchBase) throws NamingException {
 
         Attribute attribute = resultedGroup.getAttributes()
                 .get(realmConfig.getUserStoreProperty(LDAPConstants.GROUP_NAME_ATTRIBUTE));
         if (attribute == null) {
             return resultedGroup.getName();
         } else {
-            String groupNameAttributeValue = (String) attribute.get();
-            return realmConfig.getUserStoreProperty(LDAPConstants.GROUP_NAME_ATTRIBUTE) +
-                    "=" + groupNameAttributeValue;
+            String groupDN = StringUtils.replace(resultedGroup.getName(), searchBase, EMPTY_ATTRIBUTE_STRING);
+            if (StringUtils.isNotBlank(groupDN) && StringUtils.endsWith(groupDN, ",")) {
+                groupDN = StringUtils.substring(groupDN,0, -1);
+            }
+            return groupDN;
         }
     }
 
@@ -1583,7 +1589,7 @@ public class ReadWriteLDAPUserStoreManager extends ReadOnlyLDAPUserStoreManager 
                 String groupName = null;
                 while (groupSearchResults.hasMoreElements()) {
                     resultedGroup = groupSearchResults.next();
-                    groupName = getGroupName(resultedGroup);
+                    groupName = getGroupName(resultedGroup, searchBase);
                 }
                 // check whether update operations are going to violate non
                 // empty role


### PR DESCRIPTION
Public Issue : https://github.com/wso2/product-is/issues/11776

**Cause** : 

- Current get group name from the group search filter is not traverse through the subdirectory.

**Fix** : 

- resultedGroup has name (full name) to exact group DN (able to go through sub-DIR)
- Hence Modify the private method to return after replacing the search base with an empty string if exists.