### PR TITLE
made changes to supported the jartobundle script for all JDK versions

### DIFF
--- a/features/org.wso2.carbon.server.feature/resources/bin/jartobundle.bat
+++ b/features/org.wso2.carbon.server.feature/resources/bin/jartobundle.bat
@@ -51,19 +51,6 @@ goto findJdk
 
 set CMD=RUN %*
 
-:checkJdk16
-"%JAVA_HOME%\bin\java" -version 2>&1 | findstr /r "1.[8]" >NUL
-IF ERRORLEVEL 1 goto unknownJdk
-goto jdk16
-
-:unknownJdk
-echo Starting WSO2 Carbon (in unsupported JDK)
-echo [ERROR] CARBON is supported only on JDK 1.8
-goto jdk16
-
-:jdk16
-goto runTool
-
 :runTool
 
 set CURRENT_DIR=%cd%

--- a/features/org.wso2.carbon.server.feature/resources/bin/jartobundle.sh
+++ b/features/org.wso2.carbon.server.feature/resources/bin/jartobundle.sh
@@ -107,13 +107,6 @@ if [ -z "$JAVA_HOME" ]; then
   exit 1
 fi
 
-jdk_18=`$JAVA_HOME/bin/java -version 2>&1 | grep "1.[8]"`
-if [ "$jdk_18" = "" ]; then
-   echo " Starting WSO2 Carbon (in unsupported JDK)"
-   echo " [ERROR] CARBON is supported only on JDK 1.8"
-   exit 1
-fi
-
 echo JAVA_HOME environment variable is set to $JAVA_HOME
 echo CARBON_HOME environment variable is set to $CARBON_HOME
 


### PR DESCRIPTION
## Purpose
> Currently the jartobundle script is only supported with JDK 8. Made this script changes to support it with all compatible JDK versions with the WSO2 product.

## Approach
> Removed the JDK version checking condition.