### PR TITLE
Fixing_datasource_connection_and_postgresql_queries

### DIFF
--- a/core/org.wso2.carbon.registry.core/src/main/java/org/wso2/carbon/registry/core/jdbc/dao/JDBCPathCache.java
+++ b/core/org.wso2.carbon.registry.core/src/main/java/org/wso2/carbon/registry/core/jdbc/dao/JDBCPathCache.java
@@ -31,6 +31,7 @@ import org.wso2.carbon.registry.core.jdbc.DatabaseConstants;
 import org.wso2.carbon.registry.core.jdbc.dataaccess.AbstractConnection;
 import org.wso2.carbon.registry.core.jdbc.dataaccess.ConnectionWrapper;
 import org.wso2.carbon.registry.core.jdbc.dataaccess.JDBCDataAccessManager;
+import org.wso2.carbon.registry.core.jdbc.dataaccess.JDBCDatabaseTransaction;
 import org.wso2.carbon.registry.core.session.CurrentSession;
 import org.wso2.carbon.registry.core.utils.RegistryUtils;
 import org.wso2.carbon.utils.DBUtils;
@@ -84,9 +85,8 @@ public class JDBCPathCache extends PathCache {
             log.error(msg);
             throw new RegistryException(msg);
         }
-        DataSource dataSource = ((JDBCDataAccessManager)dataAccessManager).getDataSource();
-        AbstractConnection conn = new ConnectionWrapper(dataSource.getConnection(),
-                RegistryUtils.getConnectionId(dataSource));
+
+        JDBCDatabaseTransaction.ManagedRegistryConnection conn = JDBCDatabaseTransaction.getConnection();
         if (conn != null) {
             if (conn.getTransactionIsolation() != Connection.TRANSACTION_READ_COMMITTED) {
                 conn.setTransactionIsolation(Connection.TRANSACTION_READ_COMMITTED);
@@ -179,12 +179,8 @@ public class JDBCPathCache extends PathCache {
                                     ps1.close();
                                 }
                             } finally {
-                                try {
-                                    if (ps != null) {
-                                        ps.close();
-                                    }
-                                } finally {
-                                    conn.close();
+                                if (ps != null) {
+                                    ps.close();
                                 }
                             }
                         }
@@ -209,14 +205,8 @@ public class JDBCPathCache extends PathCache {
                                 results.close();
                             }
                         } finally {
-                            try {
-                                if (ps != null) {
-                                    ps.close();
-                                }
-                            } finally {
-                                if (conn != null) {
-                                    conn.close();
-                                }
+                            if (ps != null) {
+                                ps.close();
                             }
                         }
                     } catch (SQLException e) {

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCUserStoreManager.java
@@ -95,6 +95,7 @@ public class UniqueIDJDBCUserStoreManager extends JDBCUserStoreManager {
     private static final String ORACLE = "oracle";
     private static final String MYSQL = "mysql";
     private static final String MARIADB = "mariadb";
+    private static final String POSTGRE_SQL = "postgresql";
     private static final String MULTI_ATTRIBUTE_SEPARATOR = "MultiAttributeSeparator";
     private static final String MULTI_ATTRIBUTE_SEPARATOR_DESCRIPTION =
             "This is the separator for multiple claim " + "values";
@@ -3443,6 +3444,12 @@ public class UniqueIDJDBCUserStoreManager extends JDBCUserStoreManager {
                                 + "FROM (SELECT  UM_USER_NAME FROM UM_ROLE R INNER JOIN UM_USER_ROLE UR ON R.UM_ID = UR"
                                 + ".UM_ROLE_ID INNER JOIN UM_USER U ON UR.UM_USER_ID =U.UM_ID INNER JOIN "
                                 + "UM_USER_ATTRIBUTE UA ON U.UM_ID = UA.UM_USER_ID");
+            } else if (POSTGRE_SQL.equals(dbType)) {
+                sqlStatement = new StringBuilder(
+                        "SELECT DISTINCT U.UM_USER_ID, U.UM_USER_NAME FROM UM_ROLE R INNER JOIN " +
+                                "UM_USER_ROLE UR ON R.UM_ID =  UR.UM_ROLE_ID INNER JOIN" +
+                                " UM_USER U ON UR.UM_USER_ID =U.UM_ID INNER JOIN " +
+                                "UM_USER_ATTRIBUTE UA ON  U.UM_ID = UA.UM_USER_ID");
             } else {
                 sqlStatement = new StringBuilder(
                         "SELECT DISTINCT U.UM_USER_ID, U.UM_USER_NAME FROM UM_ROLE R INNER JOIN "
@@ -3471,6 +3478,11 @@ public class UniqueIDJDBCUserStoreManager extends JDBCUserStoreManager {
                         "SELECT U.UM_USER_ID, U.UM_USER_NAME FROM (SELECT UM_USER_NAME, rownum AS rnum "
                                 + "FROM (SELECT  UM_USER_NAME FROM UM_ROLE R INNER JOIN UM_USER_ROLE UR ON R.UM_ID = UR"
                                 + ".UM_ROLE_ID INNER JOIN UM_USER U ON UR.UM_USER_ID =U.UM_ID");
+            } else if (POSTGRE_SQL.equals(dbType)) {
+                sqlStatement = new StringBuilder(
+                        "SELECT DISTINCT U.UM_USER_ID, U.UM_USER_NAME FROM UM_ROLE R INNER JOIN " +
+                                "UM_USER_ROLE UR ON R.UM_ID = UR.UM_ROLE_ID INNER JOIN " +
+                                "UM_USER U ON UR.UM_USER_ID=U.UM_ID");
             } else {
                 sqlStatement = new StringBuilder(
                         "SELECT DISTINCT U.UM_USER_ID, U.UM_USER_NAME FROM UM_ROLE R INNER JOIN "


### PR DESCRIPTION
Resolves https://github.com/wso2/product-is/issues/11781


The following issues were identified during the integration test urn of IS 5.10 test run with Postgres.

1. Instead of getting the SQL data source from JDBCDataAccessManager, a connection was established using jdbcDatabaseTransaction.ManagedRegistryConnection [1]. Also, the closing of the connection in the addEntry method was removed as the closing of the connections was automatically handled by+ endTransaction()+ In JDBCTransactionManager. Earlier, the connection seemed to be closed by the addEntry method while it was still being used in other methods.

2.In getQueryString() method, there was a syntax difference for PostgreSQL where inner joins are used between more than two tables [2], [3]. Therefore, the dbtype was checked for PostgreSQL and separate queries were added for those scenarios. 


 1. https://github.com/wso2-support/carbon-kernel/blob/65484d26feed31da4f6ea7673bfbe818c2adbe5e/core/org.wso2.carbon.registry.core/src/main/java/org/wso2/carbon/registry/core/jdbc/dao/JDBCPathCache.java#L87
  2. https://github.com/wso2-support/carbon-kernel/blob/support-4.6.0/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCUserStoreManager.java#L3409
  3.  https://github.com/wso2-support/carbon-kernel/blob/support-4.6.0/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCUserStoreManager.java#L3382