### PR TITLE
Disable Existing audit logs based on a property

### DIFF
--- a/core/org.wso2.carbon.core.services/src/main/java/org/wso2/carbon/core/services/authentication/AuthenticationAdmin.java
+++ b/core/org.wso2.carbon.core.services/src/main/java/org/wso2/carbon/core/services/authentication/AuthenticationAdmin.java
@@ -56,6 +56,7 @@ public class AuthenticationAdmin implements CarbonServerAuthenticator {
 
     private static final Log log = LogFactory.getLog(AuthenticationAdmin.class);
     private static Log audit = CarbonConstants.AUDIT_LOG;
+    private static final String DISABLE_LEGACY_LOGS = "disableLegacyLogs";
     protected static final String AUTHENTICATION_ADMIN_SERVICE = "AuthenticationAdminService";
     private static final int DEFAULT_PRIORITY_LEVEL = 5;
     private static final String AUTHENTICATOR_NAME = "DefaultCarbonAuthenticator";
@@ -238,12 +239,16 @@ public class AuthenticationAdmin implements CarbonServerAuthenticator {
             if (delegatedBy == null && loggedInUser != null) {
                 String logMsg = "'" + loggedInUser + "@" + tenantDomain + " [" + tenantId + "]' logged out at " + date.format(currentTime);
                 log.info(logMsg);
-                audit.info(logMsg);
+		if (!Boolean.parseBoolean(System.getProperty(DISABLE_LEGACY_LOGS))) {
+                    audit.info(logMsg);
+                }
             } else if (loggedInUser != null) {
                 String logMsg = "'" + loggedInUser + "@" + tenantDomain + " [" + tenantId + "]' logged out at " + date.format(currentTime)
                         + " delegated by " + delegatedBy;
                 log.info(logMsg);
-                audit.info(logMsg);
+                if (!Boolean.parseBoolean(System.getProperty(DISABLE_LEGACY_LOGS))) {
+                    audit.info(logMsg);
+                }
             }
             //We should not invalidate the session if the system is running on local transport
             if (!isRequestedFromLocalTransport()) {

--- a/core/org.wso2.carbon.core.services/src/main/java/org/wso2/carbon/core/services/authentication/AuthenticationAdmin.java
+++ b/core/org.wso2.carbon.core.services/src/main/java/org/wso2/carbon/core/services/authentication/AuthenticationAdmin.java
@@ -48,6 +48,8 @@ import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
 
+import static org.wso2.carbon.CarbonConstants.DISABLE_LEGACY_LOGS;
+
 /**
  * This is not an AdminService, but we are retainig the name for historical reasons.
  * This service will have to be eventually removed
@@ -56,7 +58,6 @@ public class AuthenticationAdmin implements CarbonServerAuthenticator {
 
     private static final Log log = LogFactory.getLog(AuthenticationAdmin.class);
     private static Log audit = CarbonConstants.AUDIT_LOG;
-    private static final String DISABLE_LEGACY_LOGS = "disableLegacyLogs";
     protected static final String AUTHENTICATION_ADMIN_SERVICE = "AuthenticationAdminService";
     private static final int DEFAULT_PRIORITY_LEVEL = 5;
     private static final String AUTHENTICATOR_NAME = "DefaultCarbonAuthenticator";

--- a/core/org.wso2.carbon.core.services/src/main/java/org/wso2/carbon/core/services/authentication/AuthenticationAdmin.java
+++ b/core/org.wso2.carbon.core.services/src/main/java/org/wso2/carbon/core/services/authentication/AuthenticationAdmin.java
@@ -239,7 +239,7 @@ public class AuthenticationAdmin implements CarbonServerAuthenticator {
             if (delegatedBy == null && loggedInUser != null) {
                 String logMsg = "'" + loggedInUser + "@" + tenantDomain + " [" + tenantId + "]' logged out at " + date.format(currentTime);
                 log.info(logMsg);
-		if (!Boolean.parseBoolean(System.getProperty(DISABLE_LEGACY_LOGS))) {
+                if (!Boolean.parseBoolean(System.getProperty(DISABLE_LEGACY_LOGS))) {
                     audit.info(logMsg);
                 }
             } else if (loggedInUser != null) {

--- a/core/org.wso2.carbon.core.services/src/main/java/org/wso2/carbon/core/services/authentication/AuthenticationAdmin.java
+++ b/core/org.wso2.carbon.core.services/src/main/java/org/wso2/carbon/core/services/authentication/AuthenticationAdmin.java
@@ -48,7 +48,7 @@ import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
 
-import static org.wso2.carbon.CarbonConstants.DISABLE_LEGACY_LOGS;
+import static org.wso2.carbon.utils.CarbonUtils.isLegacyAuditLogsDisabled;
 
 /**
  * This is not an AdminService, but we are retainig the name for historical reasons.
@@ -240,14 +240,14 @@ public class AuthenticationAdmin implements CarbonServerAuthenticator {
             if (delegatedBy == null && loggedInUser != null) {
                 String logMsg = "'" + loggedInUser + "@" + tenantDomain + " [" + tenantId + "]' logged out at " + date.format(currentTime);
                 log.info(logMsg);
-                if (!Boolean.parseBoolean(System.getProperty(DISABLE_LEGACY_LOGS))) {
+                if (!isLegacyAuditLogsDisabled()) {
                     audit.info(logMsg);
                 }
             } else if (loggedInUser != null) {
                 String logMsg = "'" + loggedInUser + "@" + tenantDomain + " [" + tenantId + "]' logged out at " + date.format(currentTime)
                         + " delegated by " + delegatedBy;
                 log.info(logMsg);
-                if (!Boolean.parseBoolean(System.getProperty(DISABLE_LEGACY_LOGS))) {
+                if (!isLegacyAuditLogsDisabled()) {
                     audit.info(logMsg);
                 }
             }

--- a/core/org.wso2.carbon.core.services/src/main/java/org/wso2/carbon/core/services/util/CarbonAuthenticationUtil.java
+++ b/core/org.wso2.carbon.core.services/src/main/java/org/wso2/carbon/core/services/util/CarbonAuthenticationUtil.java
@@ -27,7 +27,6 @@ import org.wso2.carbon.core.services.authentication.stats.LoginAttempt;
 import org.wso2.carbon.core.services.authentication.stats.LoginStatDatabase;
 import org.wso2.carbon.core.services.callback.LoginSubscriptionManagerServiceImpl;
 import org.wso2.carbon.core.services.internal.CarbonServicesServiceComponent;
-import org.wso2.carbon.user.core.util.UserCoreUtil;
 import org.wso2.carbon.utils.CarbonUtils;
 import org.wso2.carbon.utils.ThriftSession;
 import org.wso2.carbon.registry.core.RegistryConstants;
@@ -41,7 +40,7 @@ import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Date;
 
-import static org.wso2.carbon.CarbonConstants.DISABLE_LEGACY_LOGS;
+import static org.wso2.carbon.utils.CarbonUtils.isLegacyAuditLogsDisabled;
 
 public class CarbonAuthenticationUtil {
 
@@ -77,7 +76,7 @@ public class CarbonAuthenticationUtil {
            msg +=  " from IP address " + remoteAddress;
         }
         log.warn(msg);
-        if (!Boolean.parseBoolean(System.getProperty(DISABLE_LEGACY_LOGS))) {
+        if (!isLegacyAuditLogsDisabled()) {
             audit.warn(msg);
         }
         if (httpSess != null) {
@@ -103,7 +102,7 @@ public class CarbonAuthenticationUtil {
             msg +=  " from IP address " + remoteAddress;
         }
         log.info(msg);
-        if (!Boolean.parseBoolean(System.getProperty(DISABLE_LEGACY_LOGS))) {
+        if (!isLegacyAuditLogsDisabled()) {
             audit.info(msg);
         }
         // trigger the callbacks subscribe to the login event
@@ -163,7 +162,7 @@ public class CarbonAuthenticationUtil {
                     httpSession.setAttribute(MultitenantConstants.IS_SUPER_TENANT, "true");
                 }
             } else {
-                if (!Boolean.parseBoolean(System.getProperty(DISABLE_LEGACY_LOGS))) {
+                if (!isLegacyAuditLogsDisabled()) {
                     audit.info("User with null domain tried to login.");
                 }
                 return;
@@ -211,7 +210,7 @@ public class CarbonAuthenticationUtil {
             if (tenantDomain != null) {
                 thriftSession.setAttribute(MultitenantConstants.TENANT_DOMAIN, tenantDomain);
             } else {
-                if (!Boolean.parseBoolean(System.getProperty(DISABLE_LEGACY_LOGS))) {
+                if (!isLegacyAuditLogsDisabled()) {
                     audit.info("User with null domain tried to login.");
                 }
             	return;
@@ -240,7 +239,7 @@ public class CarbonAuthenticationUtil {
         String msg = "\'" + username + "@" + tenantDomain + " [" + tenantId + "]\' logged in at " +
                    date.format(currentTime) + " from IP address " + remoteAddress;
         log.info(msg);
-        if (!Boolean.parseBoolean(System.getProperty(DISABLE_LEGACY_LOGS))) {
+        if (!isLegacyAuditLogsDisabled()) {
             audit.info(msg);
         }
 

--- a/core/org.wso2.carbon.core.services/src/main/java/org/wso2/carbon/core/services/util/CarbonAuthenticationUtil.java
+++ b/core/org.wso2.carbon.core.services/src/main/java/org/wso2/carbon/core/services/util/CarbonAuthenticationUtil.java
@@ -45,6 +45,7 @@ public class CarbonAuthenticationUtil {
 
     private static final Log log = LogFactory.getLog(CarbonAuthenticationUtil.class);
     private static Log audit = CarbonConstants.AUDIT_LOG;
+    private static final String DISABLE_LEGACY_LOGS = "disableLegacyLogs";
     public static String LOGGED_IN_DOMAIN = "logged_in_domain";
 
     public static void onFailedAdminLogin(HttpSession httpSess, String username, int tenantId,
@@ -75,8 +76,9 @@ public class CarbonAuthenticationUtil {
            msg +=  " from IP address " + remoteAddress;
         }
         log.warn(msg);
-        audit.warn(msg);
-
+        if (!Boolean.parseBoolean(System.getProperty(DISABLE_LEGACY_LOGS))) {
+            audit.warn(msg);
+        }
         if (httpSess != null) {
             httpSess.invalidate();
         }
@@ -100,8 +102,9 @@ public class CarbonAuthenticationUtil {
             msg +=  " from IP address " + remoteAddress;
         }
         log.info(msg);
-        audit.info(msg);
-
+        if (!Boolean.parseBoolean(System.getProperty(DISABLE_LEGACY_LOGS))) {
+            audit.info(msg);
+        }
         // trigger the callbacks subscribe to the login event
         LoginSubscriptionManagerServiceImpl loginSubscriptionManagerServiceImpl = CarbonServicesServiceComponent
                 .getLoginSubscriptionManagerServiceImpl();
@@ -159,7 +162,9 @@ public class CarbonAuthenticationUtil {
                     httpSession.setAttribute(MultitenantConstants.IS_SUPER_TENANT, "true");
                 }
             } else {
-                audit.info("User with null domain tried to login.");
+                if (!Boolean.parseBoolean(System.getProperty(DISABLE_LEGACY_LOGS))) {
+                    audit.info("User with null domain tried to login.");
+                }
                 return;
             }
 
@@ -205,7 +210,9 @@ public class CarbonAuthenticationUtil {
             if (tenantDomain != null) {
                 thriftSession.setAttribute(MultitenantConstants.TENANT_DOMAIN, tenantDomain);
             } else {
-            	audit.info("User with null domain tried to login.");
+                if (!Boolean.parseBoolean(System.getProperty(DISABLE_LEGACY_LOGS))) {
+                    audit.info("User with null domain tried to login.");
+                }
             	return;
             }
             thriftSession.setAttribute(RegistryConstants.ROOT_REGISTRY_INSTANCE, registryService
@@ -232,8 +239,9 @@ public class CarbonAuthenticationUtil {
         String msg = "\'" + username + "@" + tenantDomain + " [" + tenantId + "]\' logged in at " +
                    date.format(currentTime) + " from IP address " + remoteAddress;
         log.info(msg);
-        audit.info(msg);
-       
+        if (!Boolean.parseBoolean(System.getProperty(DISABLE_LEGACY_LOGS))) {
+            audit.info(msg);
+        }
 
         // trigger the callbacks subscribe to the login event
         LoginSubscriptionManagerServiceImpl loginSubscriptionManagerServiceImpl = CarbonServicesServiceComponent

--- a/core/org.wso2.carbon.core.services/src/main/java/org/wso2/carbon/core/services/util/CarbonAuthenticationUtil.java
+++ b/core/org.wso2.carbon.core.services/src/main/java/org/wso2/carbon/core/services/util/CarbonAuthenticationUtil.java
@@ -41,11 +41,12 @@ import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Date;
 
+import static org.wso2.carbon.CarbonConstants.DISABLE_LEGACY_LOGS;
+
 public class CarbonAuthenticationUtil {
 
     private static final Log log = LogFactory.getLog(CarbonAuthenticationUtil.class);
     private static Log audit = CarbonConstants.AUDIT_LOG;
-    private static final String DISABLE_LEGACY_LOGS = "disableLegacyLogs";
     public static String LOGGED_IN_DOMAIN = "logged_in_domain";
 
     public static void onFailedAdminLogin(HttpSession httpSess, String username, int tenantId,

--- a/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/security/CarbonJMXAuthenticator.java
+++ b/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/security/CarbonJMXAuthenticator.java
@@ -34,6 +34,8 @@ import javax.management.remote.JMXPrincipal;
 import javax.security.auth.Subject;
 import java.util.Collections;
 
+import static org.wso2.carbon.CarbonConstants.DISABLE_LEGACY_LOGS;
+
 /**
  * JMX Authenticator for WSAS
  */
@@ -48,7 +50,6 @@ public class CarbonJMXAuthenticator implements JMXAuthenticator {
     private static final String JMX_USER_READWRITE_PERMISSION = "/permission/protected/server-admin/jmx/readwrite";
 
     private static Log audit = CarbonConstants.AUDIT_LOG;
-    private static final String DISABLE_LEGACY_LOGS = "disableLegacyLogs";
 
     public static void setUserRealm(UserRealm userRealm) {
         CarbonJMXAuthenticator.userRealm = userRealm;

--- a/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/security/CarbonJMXAuthenticator.java
+++ b/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/security/CarbonJMXAuthenticator.java
@@ -48,6 +48,7 @@ public class CarbonJMXAuthenticator implements JMXAuthenticator {
     private static final String JMX_USER_READWRITE_PERMISSION = "/permission/protected/server-admin/jmx/readwrite";
 
     private static Log audit = CarbonConstants.AUDIT_LOG;
+    private static final String DISABLE_LEGACY_LOGS = "disableLegacyLogs";
 
     public static void setUserRealm(UserRealm userRealm) {
         CarbonJMXAuthenticator.userRealm = userRealm;
@@ -109,8 +110,9 @@ public class CarbonJMXAuthenticator implements JMXAuthenticator {
                 int tenantId = tenantManager.getTenantId(tenantDomain);
                 carbonContext.setTenantId(tenantId);
                 carbonContext.setTenantDomain(tenantDomain);
-
-                audit.info("User " + userName + " successfully authenticated to perform JMX operations.");
+                if (!Boolean.parseBoolean(System.getProperty(DISABLE_LEGACY_LOGS))) {
+                    audit.info("User " + userName + " successfully authenticated to perform JMX operations.");
+                }
                 return new Subject(true, Collections.singleton(new JMXPrincipal(authorize(userName))),
                         Collections.EMPTY_SET, Collections.EMPTY_SET);
 
@@ -120,7 +122,9 @@ public class CarbonJMXAuthenticator implements JMXAuthenticator {
         } catch (SecurityException se) {
 
             String msg = "Unauthorized access attempt to JMX operation. ";
-            audit.warn(msg, se);
+            if (!Boolean.parseBoolean(System.getProperty(DISABLE_LEGACY_LOGS))) {
+                audit.warn(msg, se);
+            }
             throw new SecurityException(msg, se);
 
         } catch (Exception e) {
@@ -143,8 +147,10 @@ public class CarbonJMXAuthenticator implements JMXAuthenticator {
                 roleName = JMX_MONITOR_ROLE;
             }
             if (roleName != null) {
-                audit.info("User: " + userName + " successfully authorized as " +
-                        roleName + " to perform JMX operations.");
+                if (!Boolean.parseBoolean(System.getProperty(DISABLE_LEGACY_LOGS))) {
+                    audit.info("User: " + userName + " successfully authorized as " +
+                            roleName + " to perform JMX operations.");
+                }
                 return roleName;
 
             } else {

--- a/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/security/CarbonJMXAuthenticator.java
+++ b/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/security/CarbonJMXAuthenticator.java
@@ -34,7 +34,7 @@ import javax.management.remote.JMXPrincipal;
 import javax.security.auth.Subject;
 import java.util.Collections;
 
-import static org.wso2.carbon.CarbonConstants.DISABLE_LEGACY_LOGS;
+import static org.wso2.carbon.utils.CarbonUtils.isLegacyAuditLogsDisabled;
 
 /**
  * JMX Authenticator for WSAS
@@ -111,7 +111,7 @@ public class CarbonJMXAuthenticator implements JMXAuthenticator {
                 int tenantId = tenantManager.getTenantId(tenantDomain);
                 carbonContext.setTenantId(tenantId);
                 carbonContext.setTenantDomain(tenantDomain);
-                if (!Boolean.parseBoolean(System.getProperty(DISABLE_LEGACY_LOGS))) {
+                if (!isLegacyAuditLogsDisabled()) {
                     audit.info("User " + userName + " successfully authenticated to perform JMX operations.");
                 }
                 return new Subject(true, Collections.singleton(new JMXPrincipal(authorize(userName))),
@@ -123,7 +123,7 @@ public class CarbonJMXAuthenticator implements JMXAuthenticator {
         } catch (SecurityException se) {
 
             String msg = "Unauthorized access attempt to JMX operation. ";
-            if (!Boolean.parseBoolean(System.getProperty(DISABLE_LEGACY_LOGS))) {
+            if (!isLegacyAuditLogsDisabled()) {
                 audit.warn(msg, se);
             }
             throw new SecurityException(msg, se);
@@ -148,7 +148,7 @@ public class CarbonJMXAuthenticator implements JMXAuthenticator {
                 roleName = JMX_MONITOR_ROLE;
             }
             if (roleName != null) {
-                if (!Boolean.parseBoolean(System.getProperty(DISABLE_LEGACY_LOGS))) {
+                if (!isLegacyAuditLogsDisabled()) {
                     audit.info("User: " + userName + " successfully authorized as " +
                             roleName + " to perform JMX operations.");
                 }

--- a/core/org.wso2.carbon.registry.core/src/main/java/org/wso2/carbon/registry/core/caching/CacheBackedRegistry.java
+++ b/core/org.wso2.carbon.registry.core/src/main/java/org/wso2/carbon/registry/core/caching/CacheBackedRegistry.java
@@ -53,7 +53,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.wso2.carbon.CarbonConstants.DISABLE_LEGACY_LOGS;
+import static org.wso2.carbon.utils.CarbonUtils.isLegacyAuditLogsDisabled;
 
 /**
  * CacheBackedRegistry has wrapped from original Registry interface to support caching
@@ -193,7 +193,7 @@ public class CacheBackedRegistry implements Registry {
         if (!AuthorizationUtils.authorize(path, ActionConstants.GET)) {
             String msg = "User " + CurrentSession.getUser() + " is not authorized to " +
                     "read the resource " + path + ".";
-            if (!Boolean.parseBoolean(System.getProperty(DISABLE_LEGACY_LOGS))) {
+            if (!isLegacyAuditLogsDisabled()) {
                 audit.warn(msg);
             }
             throw new AuthorizationFailedException(msg);
@@ -326,7 +326,7 @@ public class CacheBackedRegistry implements Registry {
         if (!AuthorizationUtils.authorize(path, ActionConstants.GET)) {
             String msg = "User " + CurrentSession.getUser() + " is not authorized to " +
                     "read the resource " + path + ".";
-            if (!Boolean.parseBoolean(System.getProperty(DISABLE_LEGACY_LOGS))) {
+            if (!isLegacyAuditLogsDisabled()) {
                 audit.warn(msg);
             }
             throw new AuthorizationFailedException(msg);

--- a/core/org.wso2.carbon.registry.core/src/main/java/org/wso2/carbon/registry/core/caching/CacheBackedRegistry.java
+++ b/core/org.wso2.carbon.registry.core/src/main/java/org/wso2/carbon/registry/core/caching/CacheBackedRegistry.java
@@ -82,6 +82,7 @@ public class CacheBackedRegistry implements Registry {
 
     private static final Log log = LogFactory.getLog(CacheBackedRegistry.class);
     private static final Log audit = CarbonConstants.AUDIT_LOG;
+    private static final String DISABLE_LEGACY_LOGS = "disableLegacyLogs";
 
 
     public CacheBackedRegistry(Registry registry) {
@@ -191,7 +192,9 @@ public class CacheBackedRegistry implements Registry {
         if (!AuthorizationUtils.authorize(path, ActionConstants.GET)) {
             String msg = "User " + CurrentSession.getUser() + " is not authorized to " +
                     "read the resource " + path + ".";
-            audit.warn(msg);
+            if (!Boolean.parseBoolean(System.getProperty(DISABLE_LEGACY_LOGS))) {
+                audit.warn(msg);
+            }
             throw new AuthorizationFailedException(msg);
         }
 
@@ -322,7 +325,9 @@ public class CacheBackedRegistry implements Registry {
         if (!AuthorizationUtils.authorize(path, ActionConstants.GET)) {
             String msg = "User " + CurrentSession.getUser() + " is not authorized to " +
                     "read the resource " + path + ".";
-            audit.warn(msg);
+            if (!Boolean.parseBoolean(System.getProperty(DISABLE_LEGACY_LOGS))) {
+                audit.warn(msg);
+            }
             throw new AuthorizationFailedException(msg);
         }
 

--- a/core/org.wso2.carbon.registry.core/src/main/java/org/wso2/carbon/registry/core/caching/CacheBackedRegistry.java
+++ b/core/org.wso2.carbon.registry.core/src/main/java/org/wso2/carbon/registry/core/caching/CacheBackedRegistry.java
@@ -53,6 +53,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.wso2.carbon.CarbonConstants.DISABLE_LEGACY_LOGS;
+
 /**
  * CacheBackedRegistry has wrapped from original Registry interface to support caching
  */
@@ -82,7 +84,6 @@ public class CacheBackedRegistry implements Registry {
 
     private static final Log log = LogFactory.getLog(CacheBackedRegistry.class);
     private static final Log audit = CarbonConstants.AUDIT_LOG;
-    private static final String DISABLE_LEGACY_LOGS = "disableLegacyLogs";
 
 
     public CacheBackedRegistry(Registry registry) {

--- a/core/org.wso2.carbon.server.admin/src/main/java/org/wso2/carbon/server/admin/module/handler/AuthenticationHandler.java
+++ b/core/org.wso2.carbon.server.admin/src/main/java/org/wso2/carbon/server/admin/module/handler/AuthenticationHandler.java
@@ -44,6 +44,7 @@ import java.util.Date;
 public class AuthenticationHandler extends AbstractHandler {
     private static final Log log = LogFactory.getLog(AuthenticationHandler.class);
     private static final Log audit = CarbonConstants.AUDIT_LOG;
+    private static final String DISABLE_LEGACY_LOGS = "disableLegacyLogs";
 
     public InvocationResponse invoke(MessageContext msgContext) throws AxisFault {
 
@@ -86,7 +87,9 @@ public class AuthenticationHandler extends AbstractHandler {
                         && !userTenantDomain.equals(currentTenantDomain)) {
                     String msg = "Access Denied. A user " + userName + "@" + userTenantDomain +
                             " is trying to access services in domain " + currentTenantDomain;
-                    audit.error(msg);
+                    if (!Boolean.parseBoolean(System.getProperty(DISABLE_LEGACY_LOGS))) {
+                        audit.error(msg);
+                    }
                     throw new AxisFault(msg, ServerConstants.AUTHENTICATION_FAULT_CODE);
                 }
                 msgContext.setProperty(MultitenantConstants.TENANT_DOMAIN, userTenantDomain);
@@ -184,9 +187,11 @@ public class AuthenticationHandler extends AbstractHandler {
                     invalidateSession(msgContext);
                     String serviceName = getServiceName(msgContext);
                     String msg = "Illegal access attempt at " + date.format(new Date()) + " from IP address "
-                                 + remoteIP + " while trying to authenticate access to service " + serviceName;
+                            + remoteIP + " while trying to authenticate access to service " + serviceName;
                     log.warn(msg);
-                    audit.error(msg);
+                    if (!Boolean.parseBoolean(System.getProperty(DISABLE_LEGACY_LOGS))) {
+                        audit.error(msg);
+                    }
                     throw e;
                 }
             }
@@ -206,7 +211,9 @@ public class AuthenticationHandler extends AbstractHandler {
                     String msg = "Illegal access attempt at " + date.format(new Date()) + " from IP address "
                                + remoteIP + " : Service is " + serviceName;
                     log.warn(msg);
-                    audit.warn(msg);
+                    if (!Boolean.parseBoolean(System.getProperty(DISABLE_LEGACY_LOGS))) {
+                        audit.warn(msg);
+                    }
                 }
             }
         }

--- a/core/org.wso2.carbon.server.admin/src/main/java/org/wso2/carbon/server/admin/module/handler/AuthenticationHandler.java
+++ b/core/org.wso2.carbon.server.admin/src/main/java/org/wso2/carbon/server/admin/module/handler/AuthenticationHandler.java
@@ -38,7 +38,7 @@ import javax.servlet.http.HttpSession;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 
-import static org.wso2.carbon.CarbonConstants.DISABLE_LEGACY_LOGS;
+import static org.wso2.carbon.utils.CarbonUtils.isLegacyAuditLogsDisabled;
 
 /**
  *
@@ -88,7 +88,7 @@ public class AuthenticationHandler extends AbstractHandler {
                         && !userTenantDomain.equals(currentTenantDomain)) {
                     String msg = "Access Denied. A user " + userName + "@" + userTenantDomain +
                             " is trying to access services in domain " + currentTenantDomain;
-                    if (!Boolean.parseBoolean(System.getProperty(DISABLE_LEGACY_LOGS))) {
+                    if (!isLegacyAuditLogsDisabled()) {
                         audit.error(msg);
                     }
                     throw new AxisFault(msg, ServerConstants.AUTHENTICATION_FAULT_CODE);
@@ -190,7 +190,7 @@ public class AuthenticationHandler extends AbstractHandler {
                     String msg = "Illegal access attempt at " + date.format(new Date()) + " from IP address "
                             + remoteIP + " while trying to authenticate access to service " + serviceName;
                     log.warn(msg);
-                    if (!Boolean.parseBoolean(System.getProperty(DISABLE_LEGACY_LOGS))) {
+                    if (!isLegacyAuditLogsDisabled()) {
                         audit.error(msg);
                     }
                     throw e;
@@ -212,7 +212,7 @@ public class AuthenticationHandler extends AbstractHandler {
                     String msg = "Illegal access attempt at " + date.format(new Date()) + " from IP address "
                                + remoteIP + " : Service is " + serviceName;
                     log.warn(msg);
-                    if (!Boolean.parseBoolean(System.getProperty(DISABLE_LEGACY_LOGS))) {
+                    if (!isLegacyAuditLogsDisabled()) {
                         audit.warn(msg);
                     }
                 }

--- a/core/org.wso2.carbon.server.admin/src/main/java/org/wso2/carbon/server/admin/module/handler/AuthenticationHandler.java
+++ b/core/org.wso2.carbon.server.admin/src/main/java/org/wso2/carbon/server/admin/module/handler/AuthenticationHandler.java
@@ -38,13 +38,14 @@ import javax.servlet.http.HttpSession;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 
+import static org.wso2.carbon.CarbonConstants.DISABLE_LEGACY_LOGS;
+
 /**
  *
  */
 public class AuthenticationHandler extends AbstractHandler {
     private static final Log log = LogFactory.getLog(AuthenticationHandler.class);
     private static final Log audit = CarbonConstants.AUDIT_LOG;
-    private static final String DISABLE_LEGACY_LOGS = "disableLegacyLogs";
 
     public InvocationResponse invoke(MessageContext msgContext) throws AxisFault {
 

--- a/core/org.wso2.carbon.server.admin/src/main/java/org/wso2/carbon/server/admin/module/handler/AuthorizationHandler.java
+++ b/core/org.wso2.carbon.server.admin/src/main/java/org/wso2/carbon/server/admin/module/handler/AuthorizationHandler.java
@@ -46,6 +46,7 @@ public class AuthorizationHandler extends AbstractHandler {
 
     private static Log log = LogFactory.getLog(AuthorizationHandler.class.getClass());
     private static Log audit = CarbonConstants.AUDIT_LOG;
+    private static final String DISABLE_LEGACY_LOGS = "disableLegacyLogs";
 
     public InvocationResponse invoke(MessageContext msgContext) throws AxisFault {
         if (this.callToGeneralService(msgContext) || skipAuthentication(msgContext) ) {
@@ -66,9 +67,11 @@ public class AuthorizationHandler extends AbstractHandler {
 
         Parameter actionParam = operation.getParameter("AuthorizationAction");
         if (actionParam == null) {
-            audit.warn("Unauthorized call by tenant " + carbonCtx.getTenantDomain() +
-                       ",user " + carbonCtx.getUsername() + " to service:" + service.getName() +
-                       ",operation:" + opName);
+            if (!Boolean.parseBoolean(System.getProperty(DISABLE_LEGACY_LOGS))) {
+                audit.warn("Unauthorized call by tenant " + carbonCtx.getTenantDomain() +
+                        ",user " + carbonCtx.getUsername() + " to service:" + service.getName() +
+                        ",operation:" + opName);
+            }
             throw new AxisFault("Unauthorized call!. AuthorizationAction has not been specified for service:" +
                                 service.getName() + ", operation:" + opName);
         }

--- a/core/org.wso2.carbon.server.admin/src/main/java/org/wso2/carbon/server/admin/module/handler/AuthorizationHandler.java
+++ b/core/org.wso2.carbon.server.admin/src/main/java/org/wso2/carbon/server/admin/module/handler/AuthorizationHandler.java
@@ -38,6 +38,8 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 
+import static org.wso2.carbon.CarbonConstants.DISABLE_LEGACY_LOGS;
+
 /**
  * This Axis2 handler checks whether the caller is authorized to invoke the
  * admin service.
@@ -46,7 +48,6 @@ public class AuthorizationHandler extends AbstractHandler {
 
     private static Log log = LogFactory.getLog(AuthorizationHandler.class.getClass());
     private static Log audit = CarbonConstants.AUDIT_LOG;
-    private static final String DISABLE_LEGACY_LOGS = "disableLegacyLogs";
 
     public InvocationResponse invoke(MessageContext msgContext) throws AxisFault {
         if (this.callToGeneralService(msgContext) || skipAuthentication(msgContext) ) {

--- a/core/org.wso2.carbon.server.admin/src/main/java/org/wso2/carbon/server/admin/module/handler/AuthorizationHandler.java
+++ b/core/org.wso2.carbon.server.admin/src/main/java/org/wso2/carbon/server/admin/module/handler/AuthorizationHandler.java
@@ -38,7 +38,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 
-import static org.wso2.carbon.CarbonConstants.DISABLE_LEGACY_LOGS;
+import static org.wso2.carbon.utils.CarbonUtils.isLegacyAuditLogsDisabled;
 
 /**
  * This Axis2 handler checks whether the caller is authorized to invoke the
@@ -68,7 +68,7 @@ public class AuthorizationHandler extends AbstractHandler {
 
         Parameter actionParam = operation.getParameter("AuthorizationAction");
         if (actionParam == null) {
-            if (!Boolean.parseBoolean(System.getProperty(DISABLE_LEGACY_LOGS))) {
+            if (!isLegacyAuditLogsDisabled()) {
                 audit.warn("Unauthorized call by tenant " + carbonCtx.getTenantDomain() +
                         ",user " + carbonCtx.getUsername() + " to service:" + service.getName() +
                         ",operation:" + opName);

--- a/core/org.wso2.carbon.server.admin/src/main/java/org/wso2/carbon/server/admin/module/handler/TenantAuthorizationHandler.java
+++ b/core/org.wso2.carbon.server.admin/src/main/java/org/wso2/carbon/server/admin/module/handler/TenantAuthorizationHandler.java
@@ -31,7 +31,7 @@ import org.wso2.carbon.CarbonConstants;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 
-import static org.wso2.carbon.CarbonConstants.DISABLE_LEGACY_LOGS;
+import static org.wso2.carbon.utils.CarbonUtils.isLegacyAuditLogsDisabled;
 
 /**
  * This handler will restrict super tenant services from non super tenant services..
@@ -61,7 +61,7 @@ public class TenantAuthorizationHandler extends AbstractHandler {
                     .append(". Tenant domain - ")
                     .append(PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain(false))
                     .append(", tenant id - ").append(tenantId);
-            if (!Boolean.parseBoolean(System.getProperty(DISABLE_LEGACY_LOGS))) {
+            if (!isLegacyAuditLogsDisabled()) {
                 audit.warn(message.toString());
             }
 

--- a/core/org.wso2.carbon.server.admin/src/main/java/org/wso2/carbon/server/admin/module/handler/TenantAuthorizationHandler.java
+++ b/core/org.wso2.carbon.server.admin/src/main/java/org/wso2/carbon/server/admin/module/handler/TenantAuthorizationHandler.java
@@ -42,6 +42,7 @@ public class TenantAuthorizationHandler extends AbstractHandler {
     public static final String TENANT_AUTHZ_FAULT_CODE = "WSO2CarbonTenantAuthorizationFailure";
 
     private static Log audit = CarbonConstants.AUDIT_LOG;
+    private static final String DISABLE_LEGACY_LOGS = "disableLegacyLogs";
 
     public InvocationResponse invoke(MessageContext msgContext) throws AxisFault {
         if (this.callToGeneralService(msgContext)) {
@@ -60,8 +61,9 @@ public class TenantAuthorizationHandler extends AbstractHandler {
                     .append(". Tenant domain - ")
                     .append(PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain(false))
                     .append(", tenant id - ").append(tenantId);
-
-            audit.warn(message.toString());
+            if (!Boolean.parseBoolean(System.getProperty(DISABLE_LEGACY_LOGS))) {
+                audit.warn(message.toString());
+            }
 
             // for non tenantId = 0 access throw an exception
             String errorMsg = "Denied accessing super tenant service.";

--- a/core/org.wso2.carbon.server.admin/src/main/java/org/wso2/carbon/server/admin/module/handler/TenantAuthorizationHandler.java
+++ b/core/org.wso2.carbon.server.admin/src/main/java/org/wso2/carbon/server/admin/module/handler/TenantAuthorizationHandler.java
@@ -31,6 +31,7 @@ import org.wso2.carbon.CarbonConstants;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 
+import static org.wso2.carbon.CarbonConstants.DISABLE_LEGACY_LOGS;
 
 /**
  * This handler will restrict super tenant services from non super tenant services..
@@ -42,7 +43,6 @@ public class TenantAuthorizationHandler extends AbstractHandler {
     public static final String TENANT_AUTHZ_FAULT_CODE = "WSO2CarbonTenantAuthorizationFailure";
 
     private static Log audit = CarbonConstants.AUDIT_LOG;
-    private static final String DISABLE_LEGACY_LOGS = "disableLegacyLogs";
 
     public InvocationResponse invoke(MessageContext msgContext) throws AxisFault {
         if (this.callToGeneralService(msgContext)) {

--- a/core/org.wso2.carbon.ui/src/main/java/org/wso2/carbon/ui/valve/CSRFValve.java
+++ b/core/org.wso2.carbon.ui/src/main/java/org/wso2/carbon/ui/valve/CSRFValve.java
@@ -34,6 +34,7 @@ import java.io.IOException;
 public class CSRFValve extends ValveBase {
     private static final Log log = LogFactory.getLog(CSRFValve.class);
     private static Log audit = CarbonConstants.AUDIT_LOG;
+    private static final String DISABLE_LEGACY_LOGS = "disableLegacyLogs";
 
     private final static String REFERER_HEADER = "referer";
     private final static String CSRF_VALVE_PROPERTY = "Security.CSRFPreventionConfig.CSRFValve";
@@ -141,7 +142,9 @@ public class CSRFValve extends ValveBase {
             if (!allow) {
                 String msg = "Possible CSRF attack. Refer header : " + refererHeader;
                 log.warn(msg);
-                audit.warn(msg);
+                if (!Boolean.parseBoolean(System.getProperty(DISABLE_LEGACY_LOGS))) {
+                    audit.warn(msg);
+                }
                 response.setStatus(HttpServletResponse.SC_FORBIDDEN);
                 throw new ServletException(msg);
             }
@@ -153,7 +156,9 @@ public class CSRFValve extends ValveBase {
                     currentSession.invalidate();
                     String msg = "Possible CSRF attack. Request to '" + requestURI + "' does not have a Referer header";
                     log.warn(msg);
-                    audit.warn(msg);
+                    if (!Boolean.parseBoolean(System.getProperty(DISABLE_LEGACY_LOGS))) {
+                        audit.warn(msg);
+                    }
                     response.setStatus(HttpServletResponse.SC_FORBIDDEN);
                     throw new ServletException(msg);
                 }

--- a/core/org.wso2.carbon.ui/src/main/java/org/wso2/carbon/ui/valve/CSRFValve.java
+++ b/core/org.wso2.carbon.ui/src/main/java/org/wso2/carbon/ui/valve/CSRFValve.java
@@ -31,10 +31,11 @@ import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 import java.io.IOException;
 
+import static org.wso2.carbon.CarbonConstants.DISABLE_LEGACY_LOGS;
+
 public class CSRFValve extends ValveBase {
     private static final Log log = LogFactory.getLog(CSRFValve.class);
     private static Log audit = CarbonConstants.AUDIT_LOG;
-    private static final String DISABLE_LEGACY_LOGS = "disableLegacyLogs";
 
     private final static String REFERER_HEADER = "referer";
     private final static String CSRF_VALVE_PROPERTY = "Security.CSRFPreventionConfig.CSRFValve";

--- a/core/org.wso2.carbon.ui/src/main/java/org/wso2/carbon/ui/valve/CSRFValve.java
+++ b/core/org.wso2.carbon.ui/src/main/java/org/wso2/carbon/ui/valve/CSRFValve.java
@@ -31,7 +31,7 @@ import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 import java.io.IOException;
 
-import static org.wso2.carbon.CarbonConstants.DISABLE_LEGACY_LOGS;
+import static org.wso2.carbon.utils.CarbonUtils.isLegacyAuditLogsDisabled;
 
 public class CSRFValve extends ValveBase {
     private static final Log log = LogFactory.getLog(CSRFValve.class);
@@ -143,7 +143,7 @@ public class CSRFValve extends ValveBase {
             if (!allow) {
                 String msg = "Possible CSRF attack. Refer header : " + refererHeader;
                 log.warn(msg);
-                if (!Boolean.parseBoolean(System.getProperty(DISABLE_LEGACY_LOGS))) {
+                if (!isLegacyAuditLogsDisabled()) {
                     audit.warn(msg);
                 }
                 response.setStatus(HttpServletResponse.SC_FORBIDDEN);
@@ -157,7 +157,7 @@ public class CSRFValve extends ValveBase {
                     currentSession.invalidate();
                     String msg = "Possible CSRF attack. Request to '" + requestURI + "' does not have a Referer header";
                     log.warn(msg);
-                    if (!Boolean.parseBoolean(System.getProperty(DISABLE_LEGACY_LOGS))) {
+                    if (!isLegacyAuditLogsDisabled()) {
                         audit.warn(msg);
                     }
                     response.setStatus(HttpServletResponse.SC_FORBIDDEN);

--- a/core/org.wso2.carbon.ui/src/main/java/org/wso2/carbon/ui/valve/CSRFValve.java
+++ b/core/org.wso2.carbon.ui/src/main/java/org/wso2/carbon/ui/valve/CSRFValve.java
@@ -34,7 +34,6 @@ import java.io.IOException;
 public class CSRFValve extends ValveBase {
     private static final Log log = LogFactory.getLog(CSRFValve.class);
     private static Log audit = CarbonConstants.AUDIT_LOG;
-    private static final String DISABLE_LEGACY_LOGS = "disableLegacyLogs";
 
     private final static String REFERER_HEADER = "referer";
     private final static String CSRF_VALVE_PROPERTY = "Security.CSRFPreventionConfig.CSRFValve";

--- a/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/CarbonConstants.java
+++ b/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/CarbonConstants.java
@@ -33,7 +33,7 @@ public final class CarbonConstants {
 
     public static final Log AUDIT_LOG = LogFactory.getLog("AUDIT_LOG");
     public static final String AUDIT_MESSAGE = "Initiator : %s | Action : %s | Target : %s | Data : { %s } | Result : %s ";
-    public static final String DISABLE_LEGACY_LOGS = "disableLegacyLogs";
+    public static final String DISABLE_LEGACY_AUDIT_LOGS = "disableLegacyAuditLogs";
 
     /**
      * This is used to get root context within CarbonJNDIContext when we need to operate

--- a/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/CarbonConstants.java
+++ b/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/CarbonConstants.java
@@ -33,6 +33,7 @@ public final class CarbonConstants {
 
     public static final Log AUDIT_LOG = LogFactory.getLog("AUDIT_LOG");
     public static final String AUDIT_MESSAGE = "Initiator : %s | Action : %s | Target : %s | Data : { %s } | Result : %s ";
+    public static final String DISABLE_LEGACY_LOGS = "disableLegacyLogs";
 
     /**
      * This is used to get root context within CarbonJNDIContext when we need to operate

--- a/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/CarbonUtils.java
+++ b/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/CarbonUtils.java
@@ -87,6 +87,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
+import static org.wso2.carbon.CarbonConstants.DISABLE_LEGACY_AUDIT_LOGS;
+
 /**
  * A collection of useful utility methods
  */
@@ -1345,5 +1347,15 @@ public class CarbonUtils {
         dbf.setAttribute(org.apache.xerces.impl.Constants.XERCES_PROPERTY_PREFIX +
                 org.apache.xerces.impl.Constants.SECURITY_MANAGER_PROPERTY, securityManager);
         return dbf;
+    }
+
+    /**
+     * Check whether the legacy audit logs are disabled.
+     *
+     * @return Whether legacy audit logs are disabled.
+     */
+    public static boolean isLegacyAuditLogsDisabled() {
+
+        return Boolean.parseBoolean(System.getProperty(DISABLE_LEGACY_AUDIT_LOGS));
     }
 }

--- a/distribution/kernel/carbon-home/repository/resources/conf/default.json
+++ b/distribution/kernel/carbon-home/repository/resources/conf/default.json
@@ -176,7 +176,7 @@
   "tasks.resolver_class": "org.wso2.carbon.ntask.core.impl.RoundRobinTaskLocationResolver",
   "server.base_path" : "${carbon.protocol}://${carbon.host}:${carbon.management.port}",
   "system.parameter.\u0027org.wso2.CipherTransformation\u0027": "RSA/ECB/OAEPwithSHA1andMGF1Padding",
-  "system.parameter.disableLegacyLogs": "false",
+  "system.parameter.disableLegacyLogs": false,
   "admin_service.wsdl.enable": false,
   "monitoring.jmx.rmi_registry_port": "9999",
   "monitoring.jmx.rmi_server_port": "11111",

--- a/distribution/kernel/carbon-home/repository/resources/conf/default.json
+++ b/distribution/kernel/carbon-home/repository/resources/conf/default.json
@@ -176,7 +176,7 @@
   "tasks.resolver_class": "org.wso2.carbon.ntask.core.impl.RoundRobinTaskLocationResolver",
   "server.base_path" : "${carbon.protocol}://${carbon.host}:${carbon.management.port}",
   "system.parameter.\u0027org.wso2.CipherTransformation\u0027": "RSA/ECB/OAEPwithSHA1andMGF1Padding",
-
+  "system.parameter.disableLegacyLogs": "false",
   "admin_service.wsdl.enable": false,
   "monitoring.jmx.rmi_registry_port": "9999",
   "monitoring.jmx.rmi_server_port": "11111",

--- a/distribution/kernel/carbon-home/repository/resources/conf/default.json
+++ b/distribution/kernel/carbon-home/repository/resources/conf/default.json
@@ -176,7 +176,7 @@
   "tasks.resolver_class": "org.wso2.carbon.ntask.core.impl.RoundRobinTaskLocationResolver",
   "server.base_path" : "${carbon.protocol}://${carbon.host}:${carbon.management.port}",
   "system.parameter.\u0027org.wso2.CipherTransformation\u0027": "RSA/ECB/OAEPwithSHA1andMGF1Padding",
-  "system.parameter.disableLegacyLogs": false,
+  "system.parameter.disableLegacyAuditLogs": false,
   "admin_service.wsdl.enable": false,
   "monitoring.jmx.rmi_registry_port": "9999",
   "monitoring.jmx.rmi_server_port": "11111",


### PR DESCRIPTION
## Purpose
Fix part of https://github.com/wso2/product-is/issues/5037

This is the deployment.toml config to disable legacy audit logs. The default value for the disableLegacyAuditLogs is set to true once the new audit logs are added to every component.
```
[system.parameter]
disableLegacyAuditLogs=true
```