### PR TITLE
Revoke access-token when an internal role is updated

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserOperationEventListener.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserOperationEventListener.java
@@ -341,6 +341,24 @@ public class AbstractUserOperationEventListener implements UniqueIDUserOperation
         return true;
     }
 
+    /**
+     * Define any additional actions after updating internal role list of user.
+     *
+     * @param userName
+     * @param deletedInternalRoles
+     * @param newInternalRoles
+     * @param userStoreManager
+     * @return
+     * @throws org.wso2.carbon.user.core.UserStoreException
+     */
+    @Override
+    public boolean doPostUpdateInternalRoleListOfUser(String userName, String[] deletedInternalRoles,
+                                                      String[] newInternalRoles, UserStoreManager userStoreManager)
+            throws UserStoreException {
+
+        return true;
+    }
+
     @Override
     public boolean doPreGetUserClaimValueWithID(String userID, String claim, String profileName,
             UserStoreManager userStoreManager) throws UserStoreException {

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
@@ -5509,18 +5509,20 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
         boolean isPreUpdateInternalRoleListOfUserSuccess = true;
         boolean isPreUpdateRoleListOfUserSuccess = true;
         String[] deletedInternalRolesArray = new String[0];
+        String[] deletedInternalRolesArrayWithDomain = new String[0];
         String[] addInternalRolesArray = new String[0];
+        String[] newInternalRolesArrayWithDomain = new String[0];
 
         if (CollectionUtils.isNotEmpty(internalRoleDel) || CollectionUtils.isNotEmpty(internalRoleNew)) {
             deletedInternalRolesArray = internalRoleDel.toArray(new String[internalRoleDel.size()]);
-            String[] deletedRolesArrayWithDomain = internalRoleDelWithDomain.toArray(new
+            deletedInternalRolesArrayWithDomain = internalRoleDelWithDomain.toArray(new
                     String[internalRoleDelWithDomain.size()]);
             addInternalRolesArray = internalRoleNew.toArray(new String[internalRoleNew.size()]);
-            String[] addRolesArrayWithDomain =
+            newInternalRolesArrayWithDomain =
                     internalRoleNewWithDomain.toArray(new String[internalRoleNewWithDomain.size()]);
             isPreUpdateInternalRoleListOfUserSuccess =
-                    handlePreUpdateRoleListOfUser(userName, deletedRolesArrayWithDomain,
-                            addRolesArrayWithDomain, false, true);
+                    handlePreUpdateRoleListOfUser(userName, deletedInternalRolesArrayWithDomain,
+                                                  newInternalRolesArrayWithDomain, false, true);
         }
 
         if (ArrayUtils.isNotEmpty(deletedRoles) || ArrayUtils.isNotEmpty(newRoles)) {
@@ -5584,6 +5586,27 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
             handleUpdateRoleListOfUserFailure(ErrorMessages.ERROR_CODE_ERROR_DURING_POST_UPDATE_ROLE_OF_USER.getCode(),
                     String.format(ErrorMessages.ERROR_CODE_ERROR_DURING_POST_UPDATE_ROLE_OF_USER.getMessage(),
                             ex.getMessage()), userName, deletedRoles, newRoles);
+            throw ex;
+        }
+
+        try {
+            for (UserOperationEventListener listener : UMListenerServiceComponent.getUserOperationEventListeners()) {
+                if (!listener.doPostUpdateInternalRoleListOfUser(userName, deletedInternalRolesArrayWithDomain,
+                                                                 newInternalRolesArrayWithDomain, this)) {
+                    handleUpdateRoleListOfUserFailure(
+                            ErrorMessages.ERROR_CODE_ERROR_DURING_POST_UPDATE_ROLE_OF_USER.getCode(),
+                            String.format(ErrorMessages.ERROR_CODE_ERROR_DURING_POST_UPDATE_ROLE_OF_USER.getMessage(),
+                                          UserCoreErrorConstants.POST_LISTENER_TASKS_FAILED_MESSAGE),
+                            userName, deletedRoles, newRoles);
+                    return;
+                }
+            }
+        } catch (UserStoreException ex) {
+            handleUpdateRoleListOfUserFailure(
+                    ErrorMessages.ERROR_CODE_ERROR_DURING_POST_UPDATE_ROLE_OF_USER.getCode(),
+                    String.format(ErrorMessages.ERROR_CODE_ERROR_DURING_POST_UPDATE_ROLE_OF_USER.getMessage(),
+                                                            ex.getMessage()),
+                    userName, deletedRoles, newRoles);
             throw ex;
         }
     }

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/listener/UserOperationEventListener.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/listener/UserOperationEventListener.java
@@ -518,6 +518,23 @@ public interface UserOperationEventListener {
             throws UserStoreException;
 
     /**
+     * Define any additional actions after updating internal role list of user.
+     *
+     * @param userName
+     * @param deletedInternalRoles
+     * @param newInternalRoles
+     * @param userStoreManager
+     * @return
+     * @throws UserStoreException
+     */
+    default boolean doPostUpdateInternalRoleListOfUser(String userName, String[] deletedInternalRoles,
+                                                       String[] newInternalRoles, UserStoreManager userStoreManager)
+            throws UserStoreException {
+
+        return true;
+    }
+
+    /**
      * Pre listener for the get user claim value method.
      *
      * @param userName     username.


### PR DESCRIPTION
Remove tokens from cache and revoke tokens when internal roles are updated