### PR TITLE
Handle retrieving null properties from UserStoreManagerRegistry

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/config/UserStoreConfigXMLProcessor.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/config/UserStoreConfigXMLProcessor.java
@@ -151,12 +151,11 @@ public class UserStoreConfigXMLProcessor {
     }
 
     /**
-     * To build a User store Realm Configuration from a given User Store Element.
+     * To build an Userstore Realm Configuration from a given Userstore Element.
      *
-     * @param userStoreElement user store element
-     *
-     * @return RealmConfiguration for successful build or
-     *         null if any required user store properties are missing in UserStoreManagerRegistry.
+     * @param userStoreElement  Userstore element.
+     * @return RealmConfiguration for successful build or null if any required userstore property is missing in
+     * the UserStoreManagerRegistry.
      */
     public RealmConfiguration buildUserStoreConfiguration(OMElement userStoreElement) throws org.wso2.carbon.user.api.UserStoreException {
 

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/config/UserStoreConfigXMLProcessor.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/config/UserStoreConfigXMLProcessor.java
@@ -150,6 +150,14 @@ public class UserStoreConfigXMLProcessor {
 
     }
 
+    /**
+     * To build a User store Realm Configuration from a given User Store Element.
+     *
+     * @param userStoreElement user store element
+     *
+     * @return RealmConfiguration for successful build or
+     *         null if any required user store properties are missing in UserStoreManagerRegistry.
+     */
     public RealmConfiguration buildUserStoreConfiguration(OMElement userStoreElement) throws org.wso2.carbon.user.api.UserStoreException {
 
         RealmConfiguration realmConfig = null;
@@ -176,7 +184,6 @@ public class UserStoreConfigXMLProcessor {
 //        }
 
         if (UserStoreManagerRegistry.getUserStoreProperties(userStoreClass) == null) {
-            log.error(userStoreClass + " not found in the user store manager registry");
             return null;
         }
         if (!xmlProcessorUtils.isMandatoryFieldsProvided(userStoreProperties, UserStoreManagerRegistry.getUserStoreProperties(userStoreClass).getMandatoryProperties())) {

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/config/UserStoreConfigXMLProcessor.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/config/UserStoreConfigXMLProcessor.java
@@ -151,6 +151,7 @@ public class UserStoreConfigXMLProcessor {
     }
 
     public RealmConfiguration buildUserStoreConfiguration(OMElement userStoreElement) throws org.wso2.carbon.user.api.UserStoreException {
+
         RealmConfiguration realmConfig = null;
         String userStoreClass = null;
         Map<String, String> userStoreProperties = null;
@@ -174,6 +175,10 @@ public class UserStoreConfigXMLProcessor {
 //            throw new UserStoreException("Invalid domain name provided");
 //        }
 
+        if (UserStoreManagerRegistry.getUserStoreProperties(userStoreClass) == null) {
+            log.error(userStoreClass + " not found in the user store manager registry");
+            return null;
+        }
         if (!xmlProcessorUtils.isMandatoryFieldsProvided(userStoreProperties, UserStoreManagerRegistry.getUserStoreProperties(userStoreClass).getMandatoryProperties())) {
             throw new UserStoreException("A required mandatory field is missing.");
         }


### PR DESCRIPTION
Handle retrieving null properties from UserStoreManagerRegistry returning null value as the realm config which will handle by 

https://github.com/wso2/carbon-kernel/blob/96a309d08d7223a33af5d18b52f1d4f1773c607c/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/tenant/JDBCTenantManager.java#L1120-L1125