### PR TITLE
Add error code when throwing UserStoreException

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
@@ -4394,7 +4394,8 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
         if (isReadOnly() && !claims.isEmpty()) {
             handleSetUserClaimValuesFailure(ErrorMessages.ERROR_CODE_READONLY_USER_STORE.getCode(),
                     ErrorMessages.ERROR_CODE_READONLY_USER_STORE.getMessage(), userName, claims, profileName);
-            throw new UserStoreException(ErrorMessages.ERROR_CODE_READONLY_USER_STORE.toString());
+            throw new UserStoreException(ErrorMessages.ERROR_CODE_READONLY_USER_STORE.getMessage(),
+                    ErrorMessages.ERROR_CODE_READONLY_USER_STORE.getCode());
         }
 
         // set claim values if user store is not read only.


### PR DESCRIPTION
## Purpose
Add error code when throwing UserStoreException when updating the claims of a user who are in a read-only userstore to capture the error scenario for the fix: wso2-support/carbon-identity-framework#1810

Resolves: wso2/product-is#12382

### When should this PR be merged
This PR should merge before https://github.com/wso2/carbon-identity-framework/pull/3704