### PR TITLE
Dependancy version update of jackson, jinjava, jsoup, guava and log4j.

### DIFF
--- a/distribution/kernel/carbon-home/repository/conf/tomcat/catalina.properties
+++ b/distribution/kernel/carbon-home/repository/conf/tomcat/catalina.properties
@@ -46,6 +46,7 @@ cava-toml-*.jar,\
 gson-*.jar,\
 guava-*.jar,\
 jackson-annotations-*.jar,\
+jackson-dataformat-yaml-*.jar,\
 jackson-core-*.jar,\
 jackson-databind-*.jar,\
 jinjava-*.jar,\

--- a/distribution/kernel/src/assembly/bin.xml
+++ b/distribution/kernel/src/assembly/bin.xml
@@ -147,6 +147,7 @@
                 <include>com.fasterxml.jackson.core:jackson-core:jar</include>
                 <include>com.fasterxml.jackson.core:jackson-databind:jar</include>
                 <include>com.fasterxml.jackson.core:jackson-annotations:jar</include>
+                <include>com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:jar</include>
                 <include>com.google.re2j:re2j:jar</include>
                 <include>commons-codec:commons-codec:jar</include>
                 <include>ant-contrib:ant-contrib:jar</include>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -559,7 +559,7 @@
         <version.drools>5.1.1</version.drools>
         <version.jsr94>1.1</version.jsr94>
 
-        <version.log4j.core>2.12.0</version.log4j.core>
+        <version.log4j.core>2.13.2</version.log4j.core>
         <version.log4j.jul>2.12.0</version.log4j.jul>
         <version.commons.logging>1.2</version.commons.logging>
         <version.xmlunit>1.1</version.xmlunit>
@@ -640,12 +640,14 @@
         <maven.spotbugsplugin.version>3.1.10</maven.spotbugsplugin.version>
         <maven.spotbugsplugin.exclude.file>spotbugs-exclude.xml</maven.spotbugsplugin.exclude.file>
         <maven.spotbugs.dependency.version>3.1.11</maven.spotbugs.dependency.version>
-        <version.jinjava>2.4.14</version.jinjava>
+        <version.jinjava>2.5.9</version.jinjava>
         <version.cava-toml>0.5.0</version.cava-toml>
         <version.checkstyle>7.8.2</version.checkstyle>
-        <version.jackson>2.9.8</version.jackson>
-        <version.jackson.databind>2.9.9.2</version.jackson.databind>
-        <version.guava>27.0.1-jre</version.guava>
+        <version.jackson>2.10.5</version.jackson>
+        <version.jackson.databind>2.10.5.1</version.jackson.databind>
+        <version.jackson.dataformat>2.10.5</version.jackson.dataformat>
+        <version.jsoup>1.14.2</version.jsoup>
+        <version.guava>30.0-jre</version.guava>
         <version.ciphertool>1.1.0</version.ciphertool>
         <xml.unit.verions>2.6.2</xml.unit.verions>
         <version.org.apache.felix.scr.ds-annotations>1.2.10</version.org.apache.felix.scr.ds-annotations>
@@ -1803,6 +1805,16 @@
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-annotations</artifactId>
                 <version>${version.jackson}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.dataformat</groupId>
+                <artifactId>jackson-dataformat-yaml</artifactId>
+                <version>${version.jackson.dataformat}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jsoup</groupId>
+                <artifactId>jsoup</artifactId>
+                <version>${version.jsoup}</version>
             </dependency>
             <dependency>
                 <groupId>com.google.guava</groupId>


### PR DESCRIPTION
Related Issues: https://github.com/wso2/product-is/issues/12485
## Purpose
> Dependency version update of
- jackson-core - 2.9.8 -> 2.10.5
- jackson-databind - 2.9.9.2 -> 2.10.5.1
- jackson-annotations - 2.9.8 -> 2.10.5
- jackson-core - 2.9.8 -> 2.10.5
- jinjava - 2.4.14 -> 2.5.9
- log4j - 2.12.0 -> 2.13.2
- guava - 27.0.1-jre -> 30.0-jre
> Add new dependency
- jackson-dataformat-yaml - 2.10.5
- jsoup - 1.14.2