### PR TITLE
Bump axis2 version

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -455,7 +455,7 @@
         <version.spring>3.1.0.RELEASE</version.spring>
 
         <!-- Apache Axis2 -->
-        <version.axis2>1.6.1-wso2v41</version.axis2>
+        <version.axis2>1.6.1-wso2v72</version.axis2>
         <imp.pkg.version.axis2>[1.6.1, 1.7.0)</imp.pkg.version.axis2>
         <version.addressing>${version.axis2}</version.addressing>
         <orbit.version.axis2>${version.axis2}</orbit.version.axis2>


### PR DESCRIPTION
Related Issues: wso2/product-is#12485
## Purpose
> Bump axis2 version to 1.6.1-wso2v72