### PR TITLE
Fix issue when filtering with groups in the SCIM2 Users endpoint

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/hybrid/HybridRoleManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/hybrid/HybridRoleManager.java
@@ -242,6 +242,13 @@ public class HybridRoleManager {
             searchTime = DEFAULT_MAX_SEARCH_TIME;
         }
 
+        // Convert 'Application' domain from uppercase to PascalCase to accurately perform the DB search.
+        if (filter.toLowerCase().startsWith(UserCoreConstants.APPLICATION_DOMAIN.toLowerCase())) {
+            int index;
+            if ((index = filter.indexOf(CarbonConstants.DOMAIN_SEPARATOR)) >= 0) {
+                filter = UserCoreConstants.APPLICATION_DOMAIN + filter.substring(index);
+            }
+        }
         try {
             if (filter != null && filter.trim().length() != 0) {
                 filter = filter.trim();


### PR DESCRIPTION
**Purpose**
Fix the issue when filtering with groups(hybrid roles) in the SCIM2 Users endpoint if the domain(Application/Internal) is appended.

Related Issue: wso2/product-is#12445
This is a redo of the PR https://github.com/wso2/carbon-kernel/pull/3081