### PR TITLE
Improve jdbc userstore queries to have underscore

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/JDBCRealmConstants.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/JDBCRealmConstants.java
@@ -27,6 +27,7 @@ public final class JDBCRealmConstants {
     public static final String SELECT_USER_NAME_FROM_USER_ID = "SelectUserNameFromUserIDSQL";
     public static final String SELECT_USER_ID = "SelectUserIDSQL";
     public static final String GET_ROLE_LIST = "GetRoleListSQL";
+    public static final String GET_ROLE_LIST_WITH_ESCAPE = "GetRoleListSQLWithEscape";
     public static final String GET_SHARED_ROLE_LIST = "GetSharedRoleListSQL";
     public static final String GET_USER_FILTER = "UserFilterSQL";
     public static final String GET_USER_FILTER_WITH_ID = "UserFilterWithIDSQL";
@@ -63,6 +64,7 @@ public final class JDBCRealmConstants {
     public static final String GET_PROP_FOR_PROFILE = "GetUserPropertyForProfileSQL";
     public static final String GET_PROP_FOR_PROFILE_WITH_ID = "GetUserPropertyForProfileWithIDSQL";
     public static final String GET_USERS_FOR_PROP = "GetUserLisForPropertySQL";
+    public static final String GET_USERS_FOR_PROP_WITH_ESCAPE = "GetUserListForPropertySQLWithEscape";
     public static final String GET_USERS_FOR_CLAIM_VALUE = "GetUserListForClaimValueSQL";
     public static final String GET_USERS_FOR_PROP_WITH_ID = "GetUserLisForPropertyWithIDSQL";
     public static final String GET_USERS_FOR_CLAIM_VALUE_WITH_ID = "GetUserListForClaimValueWithIDSQL";
@@ -151,6 +153,9 @@ public final class JDBCRealmConstants {
     public static final String SELECT_USER_NAME_FROM_USER_ID_SQL = "SELECT UM_USER_NAME FROM UM_USER WHERE "
             + "UM_USER_ID=? AND UM_TENANT_ID=?";
     public static final String GET_ROLE_LIST_SQL = "SELECT UM_ROLE_NAME, UM_TENANT_ID, UM_SHARED_ROLE FROM UM_ROLE WHERE UM_ROLE_NAME LIKE ? AND UM_TENANT_ID=? AND UM_SHARED_ROLE ='0' ORDER BY UM_ROLE_NAME";
+    public static final String GET_ROLE_LIST_SQL_WITH_ESCAPE = "SELECT UM_ROLE_NAME, UM_TENANT_ID, UM_SHARED_ROLE " +
+            "FROM UM_ROLE WHERE UM_ROLE_NAME LIKE ? ESCAPE ? AND UM_TENANT_ID=? AND UM_SHARED_ROLE ='0' ORDER BY " +
+            "UM_ROLE_NAME";
     public static final String GET_SHARED_ROLE_LIST_SQL = "SELECT UM_ROLE_NAME, UM_TENANT_ID, UM_SHARED_ROLE FROM UM_ROLE WHERE UM_ROLE_NAME LIKE ? AND UM_SHARED_ROLE ='1' ORDER BY UM_ROLE_NAME";
     public static final String GET_USER_FILTER_SQL = "SELECT UM_USER_NAME FROM UM_USER WHERE UM_USER_NAME LIKE ? AND UM_TENANT_ID=? ORDER BY UM_USER_NAME";
     public static final String GET_USER_FILTER_WITH_ID_SQL = "SELECT UM_USER_ID, UM_USER_NAME FROM UM_USER WHERE "
@@ -278,8 +283,12 @@ public final class JDBCRealmConstants {
             "WHERE UM_USER_ATTRIBUTE.UM_USER_ID = UM_USER.UM_ID AND UM_USER_ATTRIBUTE.UM_ATTR_NAME =? " +
             "AND UM_USER_ATTRIBUTE.UM_ATTR_VALUE LIKE ? AND UM_USER_ATTRIBUTE.UM_PROFILE_ID=? " +
             "AND UM_USER_ATTRIBUTE.UM_TENANT_ID=? AND UM_USER.UM_TENANT_ID=?";
-    public static final String GET_USERS_FOR_CLAIM_VALUE_SQL = "SELECT DISTINCT UM_USER_NAME FROM UM_USER, UM_USER_ATTRIBUTE " +
-            "WHERE UM_USER_ATTRIBUTE.UM_USER_ID = UM_USER.UM_ID AND UM_USER_ATTRIBUTE.UM_ATTR_NAME =? " +
+    public static final String GET_USERS_FOR_PROP_SQL_WITH_ESCAPE = "SELECT DISTINCT UM_USER_NAME FROM UM_USER, " +
+            "UM_USER_ATTRIBUTE WHERE UM_USER_ATTRIBUTE.UM_USER_ID = UM_USER.UM_ID AND UM_USER_ATTRIBUTE.UM_ATTR_NAME =? " +
+            "AND UM_USER_ATTRIBUTE.UM_ATTR_VALUE LIKE ? ESCAPE ? AND UM_USER_ATTRIBUTE.UM_PROFILE_ID=? " +
+            "AND UM_USER_ATTRIBUTE.UM_TENANT_ID=? AND UM_USER.UM_TENANT_ID=?";
+    public static final String GET_USERS_FOR_CLAIM_VALUE_SQL = "SELECT DISTINCT UM_USER_NAME FROM UM_USER, " +
+            "UM_USER_ATTRIBUTE WHERE UM_USER_ATTRIBUTE.UM_USER_ID = UM_USER.UM_ID AND UM_USER_ATTRIBUTE.UM_ATTR_NAME =? " +
             "AND UM_USER_ATTRIBUTE.UM_ATTR_VALUE =? AND UM_USER_ATTRIBUTE.UM_PROFILE_ID=? " +
             "AND UM_USER_ATTRIBUTE.UM_TENANT_ID=? AND UM_USER.UM_TENANT_ID=?";
     public static final String GET_USERS_FOR_PROP_WITH_ID_SQL = "SELECT DISTINCT UM_USER.UM_USER_ID FROM UM_USER, "

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/JDBCUserStoreConstants.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/JDBCUserStoreConstants.java
@@ -437,6 +437,9 @@ public class JDBCUserStoreConstants {
         setAdvancedProperty(JDBCRealmConstants.GET_USERS_FOR_PROP, "Get User List for Property SQL",
                 JDBCRealmConstants.GET_USERS_FOR_PROP_SQL, "",
                 new Property[] { USER.getProperty(), SQL.getProperty(), FALSE.getProperty() });
+        setAdvancedProperty(JDBCRealmConstants.GET_USERS_FOR_PROP_WITH_ESCAPE, "Get User List for Property SQL With " +
+                "Escape", JDBCRealmConstants.GET_USERS_FOR_PROP_SQL, "",
+                new Property[] { USER.getProperty(), SQL.getProperty(), FALSE.getProperty() });
         setAdvancedProperty(JDBCRealmConstants.GET_USERS_FOR_CLAIM_VALUE, "Get User List for Claim Value SQL",
                 JDBCRealmConstants.GET_USERS_FOR_CLAIM_VALUE_SQL, "",
                 new Property[] { USER.getProperty(), SQL.getProperty(), FALSE.getProperty() });

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/util/JDBCRealmUtil.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/util/JDBCRealmUtil.java
@@ -62,6 +62,11 @@ public class JDBCRealmUtil {
             properties.put(JDBCRealmConstants.GET_ROLE_LIST, JDBCRealmConstants.GET_ROLE_LIST_SQL);
         }
 
+        if (!properties.containsKey(JDBCRealmConstants.GET_ROLE_LIST_WITH_ESCAPE)) {
+            properties.put(JDBCRealmConstants.GET_ROLE_LIST_WITH_ESCAPE,
+                    JDBCRealmConstants.GET_ROLE_LIST_SQL_WITH_ESCAPE);
+        }
+
         if (!properties.containsKey(JDBCRealmConstants.GET_SHARED_ROLE_LIST)) {
             properties.put(JDBCRealmConstants.GET_SHARED_ROLE_LIST, JDBCRealmConstants.GET_SHARED_ROLE_LIST_SQL);
         }
@@ -214,6 +219,10 @@ public class JDBCRealmUtil {
         if (!properties.containsKey(JDBCCaseInsensitiveConstants.GET_USERS_FOR_CLAIM_VALUE_WITH_ID_CASE_INSENSITIVE)) {
             properties.put(JDBCCaseInsensitiveConstants.GET_USERS_FOR_CLAIM_VALUE_WITH_ID_CASE_INSENSITIVE,
                     JDBCCaseInsensitiveConstants.GET_USERS_FOR_CLAIM_VALUE_WITH_ID_SQL_CASE_INSENSITIVE);
+        }
+        if (!properties.containsKey(JDBCRealmConstants.GET_USERS_FOR_PROP_WITH_ESCAPE)) {
+            properties.put(JDBCRealmConstants.GET_USERS_FOR_PROP_WITH_ESCAPE,
+                    JDBCRealmConstants.GET_USERS_FOR_PROP_SQL_WITH_ESCAPE);
         }
         if (!properties.containsKey(JDBCRealmConstants.GET_PAGINATED_USERS_FOR_PROP)) {
             properties.put(JDBCRealmConstants.GET_PAGINATED_USERS_FOR_PROP,


### PR DESCRIPTION
Fixes wso2/product-is#12649

Similar to the above issue, when searching the roles also if there is an underscore in the filter, the jdbc userstores will treat it as a wild card.

This PR allows having the underscore in the search query

