### PR TITLE
Enabling Asynchronous Logging

### DIFF
--- a/core/org.wso2.carbon.pax-logging-log4j2-plugins/src/main/java/org/wso2/carbon/log4j2/plugins/AppNameConverter.java
+++ b/core/org.wso2.carbon.pax-logging-log4j2-plugins/src/main/java/org/wso2/carbon/log4j2/plugins/AppNameConverter.java
@@ -19,11 +19,8 @@ import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.config.plugins.Plugin;
 import org.apache.logging.log4j.core.pattern.ConverterKeys;
 import org.apache.logging.log4j.core.pattern.LogEventPatternConverter;
-import org.wso2.carbon.context.CarbonContext;
-import org.wso2.carbon.utils.logging.handler.TenantDomainSetter;
-
-import java.security.AccessController;
-import java.security.PrivilegedAction;
+import org.apache.logging.log4j.util.ReadOnlyStringMap;
+import org.apache.logging.log4j.util.StringBuilders;
 
 /**
  * This Converter is used to append the appName as a parameter in the log message.
@@ -62,21 +59,13 @@ public class AppNameConverter extends LogEventPatternConverter {
 
     @Override
     public void format(LogEvent event, StringBuilder toAppendTo) {
-        if (getAppName() != null) {
-            toAppendTo.append(getAppName());
-        }
-    }
 
-    /**
-     * Obtains the application name.
-     *
-     * @return application name in type String
-     */
-    private String getAppName() {
-        String appName = CarbonContext.getThreadLocalCarbonContext().getApplicationName();
-        if (appName == null) {
-            appName = TenantDomainSetter.getServiceName();
+        ReadOnlyStringMap contextData = event.getContextData();
+        if (contextData != null && contextData.size() != 0) {
+            Object value = contextData.getValue("appName");
+            if (value != null) {
+                StringBuilders.appendValue(toAppendTo, value);
+            }
         }
-        return appName;
     }
 }

--- a/core/org.wso2.carbon.pax-logging-log4j2-plugins/src/main/java/org/wso2/carbon/log4j2/plugins/TenantDomainConverter.java
+++ b/core/org.wso2.carbon.pax-logging-log4j2-plugins/src/main/java/org/wso2/carbon/log4j2/plugins/TenantDomainConverter.java
@@ -22,10 +22,9 @@ import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.config.plugins.Plugin;
 import org.apache.logging.log4j.core.pattern.ConverterKeys;
 import org.apache.logging.log4j.core.pattern.LogEventPatternConverter;
-import org.wso2.carbon.context.CarbonContext;
-
-import java.security.AccessController;
-import java.security.PrivilegedAction;
+import org.apache.logging.log4j.util.ReadOnlyStringMap;
+import org.apache.logging.log4j.util.StringBuilders;
+import org.wso2.carbon.base.MultitenantConstants;
 
 /**
  * This Converter is used to register the tenantDomain as a parameter in the log message.
@@ -64,24 +63,13 @@ public class TenantDomainConverter extends LogEventPatternConverter {
 
     @Override
     public void format(LogEvent event, StringBuilder toAppendTo) {
-        String tenantDomain = getTenantDomain();
-        if (tenantDomain != null) {
-            toAppendTo.append(tenantDomain);
-        }
-    }
 
-    /**
-     * Obtains the tenantDomain from CarbonContext.
-     *
-     * @return tenantDomain of ThreadLocalCarbonContext
-     */
-    public String getTenantDomain() {
-        String tenantDomain = String.valueOf(AccessController.doPrivileged(new PrivilegedAction<String>() {
-            public String run() {
-                return CarbonContext.getThreadLocalCarbonContext().getTenantDomain();
+        ReadOnlyStringMap contextData = event.getContextData();
+        if (contextData != null && contextData.size() != 0) {
+            Object value = contextData.getValue(MultitenantConstants.TENANT_DOMAIN);
+            if (value != null) {
+                StringBuilders.appendValue(toAppendTo, value);
             }
-        }));
-
-        return tenantDomain;
+        }
     }
 }

--- a/core/org.wso2.carbon.pax-logging-log4j2-plugins/src/main/java/org/wso2/carbon/log4j2/plugins/TenantIdConverter.java
+++ b/core/org.wso2.carbon.pax-logging-log4j2-plugins/src/main/java/org/wso2/carbon/log4j2/plugins/TenantIdConverter.java
@@ -19,10 +19,9 @@ import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.config.plugins.Plugin;
 import org.apache.logging.log4j.core.pattern.ConverterKeys;
 import org.apache.logging.log4j.core.pattern.LogEventPatternConverter;
-import org.wso2.carbon.context.CarbonContext;
-
-import java.security.AccessController;
-import java.security.PrivilegedAction;
+import org.apache.logging.log4j.util.ReadOnlyStringMap;
+import org.apache.logging.log4j.util.StringBuilders;
+import org.wso2.carbon.base.MultitenantConstants;
 
 /**
  * This Converter is used to register the tenantId as a parameter in the log message.
@@ -59,24 +58,15 @@ public class TenantIdConverter extends LogEventPatternConverter {
         return INSTANCE;
     }
 
-    @Override public void format(LogEvent event, StringBuilder toAppendTo) {
-        if (getTenantID() != null) {
-            toAppendTo.append(getTenantID());
-        }
-    }
+    @Override
+    public void format(LogEvent event, StringBuilder toAppendTo) {
 
-    /**
-     * Obtains the tenantId from CarbonContext.
-     *
-     * @return tenantId tenantId of ThreadLocalCarbonContext
-     */
-    public String getTenantID() {
-        String tenantId = String.valueOf(AccessController.doPrivileged(new PrivilegedAction<Integer>() {
-            public Integer run() {
-                return CarbonContext.getThreadLocalCarbonContext().getTenantId();
+        ReadOnlyStringMap contextData = event.getContextData();
+        if (contextData != null && contextData.size() != 0) {
+            Object value = contextData.getValue(MultitenantConstants.TENANT_ID);
+            if (value != null) {
+                StringBuilders.appendValue(toAppendTo, value);
             }
-        }));
-
-        return tenantId;
+        }
     }
 }

--- a/core/org.wso2.carbon.pax-logging-log4j2-plugins/src/test/java/org/wso2/carbon/log4j2/plugins/AppNameConverterTest.java
+++ b/core/org.wso2.carbon.pax-logging-log4j2-plugins/src/test/java/org/wso2/carbon/log4j2/plugins/AppNameConverterTest.java
@@ -16,42 +16,35 @@
 package org.wso2.carbon.log4j2.plugins;
 
 import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.ThreadContext;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.impl.Log4jLogEvent;
 import org.apache.logging.log4j.message.Message;
 import org.apache.logging.log4j.message.SimpleMessage;
-import org.mockito.Mockito;
-import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.testng.PowerMockTestCase;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
-import org.wso2.carbon.utils.ServerConstants;
 import org.wso2.carbon.utils.logging.handler.TenantDomainSetter;
 
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.nio.file.StandardCopyOption;
-
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
 
 /**
  * Tests AppNameConverter class.
  */
 @PrepareForTest(TenantDomainSetter.class)
 public class AppNameConverterTest extends PowerMockTestCase {
+
     private AppNameConverter appNameConverter;
     private LogEvent logEvent;
+    private static final String APP_NAME = "appName";
 
     /**
      * Creates a log event to test appending of the AppName.
      */
     @BeforeMethod
     public void setUp() {
+
         appNameConverter = AppNameConverter.newInstance(null);
         Message msg = new SimpleMessage("Test logging");
         logEvent = Log4jLogEvent.newBuilder()
@@ -62,30 +55,20 @@ public class AppNameConverterTest extends PowerMockTestCase {
 
     /**
      * Tests appending the AppName into the log message.
-     *
-     * @throws IOException for failed or interrupted file creation
      */
     @Test
-    public void testFormat() throws IOException {
-        Path carbonHome = Files.createTempDirectory("carbonHome");
-        File repository = new File(carbonHome.toFile(), "repository");
-        repository.mkdir();
-        File conf = new File(repository, "conf");
-        conf.mkdir();
-        ClassLoader classLoader = getClass().getClassLoader();
-        File file = new File(classLoader.getResource("carbon.xml").getFile());
+    public void testFormat() {
 
-        Path src = file.toPath();
-        Path dest = Paths.get(conf.getAbsolutePath() + File.separator + file.getName());
-        Files.copy(src, dest, StandardCopyOption.REPLACE_EXISTING);
-        assertTrue(dest.toFile().exists());
-        System.setProperty(ServerConstants.CARBON_HOME, carbonHome.toString());
         final StringBuilder sb = new StringBuilder();
+        String appName = "TestApp";
+        ThreadContext.put(APP_NAME, appName);
+        LogEvent event = Log4jLogEvent.newBuilder()
+                .setLoggerName("AppNameTestLogger")
+                .setLevel(Level.INFO)
+                .setMessage(null).build();
 
-        PowerMockito.mockStatic(TenantDomainSetter.class);
-        Mockito.when(TenantDomainSetter.getServiceName()).thenReturn("TestApp");
-
-        appNameConverter.format(logEvent, sb);
-        assertEquals("TestApp", sb.toString());
+        appNameConverter.format(event, sb);
+        assertEquals(appName, sb.toString());
+        ThreadContext.remove(APP_NAME);
     }
 }


### PR DESCRIPTION
This PR will set the tenantId, tenantDomain and appName to the MDC and change TenantIdConverter, TenantDomainConverter and AppNameConverter to get these IDs from the Context Data instead of the Thread Local Carbon Context.

Related Issues: https://github.com/wso2/product-is/issues/11947