### PR TITLE
Fix issue ##3148: wrong indexing from ResultSet JDBC

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/JDBCUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/JDBCUserStoreManager.java
@@ -1430,15 +1430,15 @@ public class JDBCUserStoreManager extends AbstractUserStoreManager {
             rs = prepStmt.executeQuery();
 
             if (rs.next() == true) {
-                String storedPassword = rs.getString(3);
+                String storedPassword = rs.getString(4);
                 String saltValue = null;
                 if ("true".equalsIgnoreCase(realmConfig
                         .getUserStoreProperty(JDBCRealmConstants.STORE_SALTED_PASSWORDS))) {
-                    saltValue = rs.getString(4);
+                    saltValue = rs.getString(5);
                 }
 
-                boolean requireChange = rs.getBoolean(5);
-                Timestamp changedTime = rs.getTimestamp(6);
+                boolean requireChange = rs.getBoolean(6);
+                Timestamp changedTime = rs.getTimestamp(7);
 
                 GregorianCalendar gc = new GregorianCalendar();
                 gc.add(GregorianCalendar.HOUR, -24);


### PR DESCRIPTION
## Purpose
Fix exception that is described in: #3148 

## Goals
Here is the table of UM_USER in database MySQL
```
CREATE TABLE UM_USER (
             UM_ID INTEGER NOT NULL AUTO_INCREMENT,
             UM_USER_ID VARCHAR(255) NOT NULL,
             UM_USER_NAME VARCHAR(255) NOT NULL,
             UM_USER_PASSWORD VARCHAR(255) NOT NULL,
             UM_SALT_VALUE VARCHAR(31),
             UM_REQUIRE_CHANGE BOOLEAN DEFAULT FALSE,
             UM_CHANGED_TIME TIMESTAMP NOT NULL,
             UM_TENANT_ID INTEGER DEFAULT 0,
             PRIMARY KEY (UM_ID, UM_TENANT_ID),
             UNIQUE(UM_USER_ID, UM_TENANT_ID)
)ENGINE INNODB;
```
Since ResultSet start index from 1, therefore, password is at column 4, saltValues is at column 5, requireChange is at column 6 and changedTime is at column 7. However the previous code get password from column 3, saltValues from column 4 and so on. The exception occurred when it tried to get boolean from column 5 which is VARCHAR

## Approach
Change indices as mention above

## Release note
Fix issue ##3148: wrong indexing from ResultSet JDBC

## Documentation
N/A: this is an internal bug therefore there isn't doc impact

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
- OS: CentOS Linux 7 (Core)
- Kernel version: 3.10.0-1160.42.2.el7.x86_64
- DB: MySQL Ver 14.14 Distrib 5.7.34, for Linux (x86_64) using EditLine wrapper
 