### PR TITLE
Template axis2_client.xml.j2 file to configure transport senders

### DIFF
--- a/distribution/kernel/carbon-home/repository/resources/conf/templates/repository/conf/axis2/axis2_client.xml.j2
+++ b/distribution/kernel/carbon-home/repository/resources/conf/templates/repository/conf/axis2/axis2_client.xml.j2
@@ -178,22 +178,13 @@
     <!--class="org.apache.axis2.transport.jms.JMSSender"/>-->
     <!--transportSender name="tcp"
                      class="org.apache.axis2.transport.tcp.TCPTransportSender"/-->
-    <transportSender name="local"
-                     class="org.apache.axis2.transport.local.LocalTransportSender"/>
-    <transportSender name="http"
-                     class="org.apache.axis2.transport.http.CommonsHTTPTransportSender">
-        <parameter name="PROTOCOL">HTTP/1.1</parameter>
-        <parameter name="Transfer-Encoding">chunked</parameter>
-        <parameter name="SO_TIMEOUT">60000</parameter>
-        <parameter name="CONNECTION_TIMEOUT">60000</parameter>
-    </transportSender>
-    <transportSender name="https"
-                     class="org.apache.axis2.transport.http.CommonsHTTPTransportSender">
-        <parameter name="PROTOCOL">HTTP/1.1</parameter>
-        <parameter name="Transfer-Encoding">chunked</parameter>
-        <parameter name="SO_TIMEOUT">60000</parameter>
-        <parameter name="CONNECTION_TIMEOUT">60000</parameter>
-    </transportSender>
+    {% for name,transport_sender in axis2.transport_sender.items() %}
+        <transportSender name="{{transport_sender.name}}" class="{{transport_sender.class}}">
+            {% for parameter,value in transport_sender.parameters.items() %}
+                <Parameter name="{{parameter}}">{{value}}</Parameter>
+            {% endfor %}
+        </transportSender>
+    {% endfor %}
     <!--<transportSender name="java"-->
     <!--class="org.apache.axis2.transport.java.JavaTransportSender"/>-->
 


### PR DESCRIPTION
## Purpose
Resolves [product-is #12886](https://github.com/wso2/product-is/issues/12886)

## Goals
Templated the axis2_client.xml.j2 file to configure transport senders.

## Approach
Parameters of the existing `local`, `http` and `https` transport senders can be modified by adding a configuration in the following format to the `deployment.toml` file.
```
[axis2.transport_sender.http.parameters]
parameter_name = parameter_value
```