### PR TITLE
Fix ConAppKey Violation

### DIFF
--- a/core/org.wso2.carbon.ndatasource.rdbms/src/main/java/org/wso2/carbon/ndatasource/rdbms/CorrelationLogInterceptor.java
+++ b/core/org.wso2.carbon.ndatasource.rdbms/src/main/java/org/wso2/carbon/ndatasource/rdbms/CorrelationLogInterceptor.java
@@ -25,6 +25,7 @@ import org.wso2.carbon.utils.xml.StringUtils;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.sql.CallableStatement;
 import java.sql.DatabaseMetaData;
@@ -156,7 +157,15 @@ public class CorrelationLogInterceptor extends AbstractQueryReport {
                 Object result = null;
 
                 if (this.delegate != null) {
-                    result = method.invoke(this.delegate, args);
+                    try {
+                        result = method.invoke(this.delegate, args);
+                    } catch (InvocationTargetException e) {
+                        // Since the exception is checked and not declared by the proxied interface, it will first be
+                        // wrapped in an UndeclaredThrowableException. The Method.invoke wraps all exceptions in an
+                        // InvocationTargetException. By re-throwing the InvocationTargetHandler’s cause, the client
+                        // code will be able to see the real cause of the exception.
+                        throw e.getCause();
+                    }
                 }
 
                 //If the query is an execute type of query the time taken is calculated and logged

--- a/core/org.wso2.carbon.ndatasource.rdbms/src/main/java/org/wso2/carbon/ndatasource/rdbms/CorrelationLogInterceptor.java
+++ b/core/org.wso2.carbon.ndatasource.rdbms/src/main/java/org/wso2/carbon/ndatasource/rdbms/CorrelationLogInterceptor.java
@@ -164,7 +164,11 @@ public class CorrelationLogInterceptor extends AbstractQueryReport {
                         // wrapped in an UndeclaredThrowableException. The Method.invoke wraps all exceptions in an
                         // InvocationTargetException. By re-throwing the InvocationTargetHandler’s cause, the client
                         // code will be able to see the real cause of the exception.
-                        throw e.getCause();
+                        if (e.getCause() != null) {
+                            throw e.getCause();
+                        } else {
+                            throw e;
+                        }
                     }
                 }
 


### PR DESCRIPTION
## Purpose
This PR handles throwing UndeclaredThrowableException when there are concurrent requests to update the access token. In CorrelationLogInterceptor, since the exception is checked and not declared by the proxied interface, it will first be wrapped in an UndeclaredThrowableException. The used Method.invoke wraps all exceptions in an InvocationTargetException. By re-throwing the InvocationTargetHandler’s cause, the client code will be able to see the real cause of the exception.