### PR TITLE
Fix Identity claim filtering

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserOperationEventListener.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserOperationEventListener.java
@@ -407,6 +407,21 @@ public class AbstractUserOperationEventListener implements UniqueIDUserOperation
         return true;
     }
 
+    /**
+     * Pre listener for the get paginated conditional user list method.
+     *
+     * @param condition             Condition.
+     * @param returnUsernameList    List of user names that this listener will return.
+     * @param userStoreManager      UserStoreManager.
+     * @param domain                User store domain.
+     * @throws UserStoreException   UserStoreException
+     */
+    public boolean doPreGetUserList(Condition condition, List<String> returnUsernameList,
+                                    UserStoreManager userStoreManager, String domain) throws UserStoreException {
+
+        return true;
+    }
+
     @Override
     public boolean doPostGetUserListWithID(String claimUri, String claimValue, final List<User> returnValues,
             UserStoreManager userStoreManager) throws UserStoreException {

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
@@ -104,6 +104,7 @@ import java.util.stream.Stream;
 
 import javax.sql.DataSource;
 
+import static org.wso2.carbon.user.core.UserCoreConstants.ClaimTypeURIs.IDENTITY_CLAIM_URI;
 import static org.wso2.carbon.user.core.UserCoreConstants.DOMAIN_SEPARATOR;
 import static org.wso2.carbon.user.core.UserCoreConstants.INTERNAL_DOMAIN;
 import static org.wso2.carbon.user.core.UserCoreConstants.INTERNAL_SYSTEM_ROLE_PREFIX;
@@ -3170,6 +3171,11 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
                     .collect(Collectors.toList()) + " for domain: " + extractedDomain);
         }
 
+        for (org.wso2.carbon.user.core.common.User  user:filteredUserList) {
+            if (StringUtils.isBlank(user.getUserStoreDomain())) {
+                user.setUserStoreDomain(UserCoreUtil.extractDomainFromName(user.getUsername()));
+            }
+        }
         return filteredUserList;
     }
 
@@ -15509,38 +15515,134 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
         }
 
         handlePreGetUserListWithID(condition, domain, profileName, limit, offset, sortBy, sortOrder);
-
         if (log.isDebugEnabled()) {
             log.debug("Pre listener get conditional  user list for domain: " + domain);
         }
 
+        UserStoreManager secondaryUserStoreManager = getSecondaryUserStoreManager(domain);
+        List<User> identityClaimFilteredUsers = new ArrayList<>();
+        List<String> identityClaimFilteredUserNames = new ArrayList<>();
         List<User> filteredUsers = new ArrayList<>();
-        UserStoreManager userManager = this;
-        /*
-         * This method("getUserListWithID") can be called for secondary userstore managers.
-         * At that time the "domain" is the name of the "this" usertore manager.
-         */
-        if (StringUtils.isNotEmpty(domain) && !StringUtils.equalsIgnoreCase(getMyDomainName(), domain)) {
-            userManager = getSecondaryUserStoreManager(domain);
-        }
-        if (userManager != null) {
-            if (userManager instanceof AbstractUserStoreManager) {
-                if (isUniqueUserIdEnabled(userManager)) {
-                    UniqueIDPaginatedSearchResult users = ((AbstractUserStoreManager) userManager)
-                            .doGetUserListWithID(condition, profileName, limit, offset, sortBy, sortOrder);
-                    addUsersToUserIdCache(users.getUsers());
-                    addUsersToUserNameCache(users.getUsers());
-                    filteredUsers = users.getUsers();
-                } else {
-                    PaginatedSearchResult users = ((AbstractUserStoreManager) userManager)
-                            .doGetUserList(condition, profileName, limit, offset, sortBy, sortOrder);
-                    filteredUsers = userUniqueIDManger.listUsers(users.getUsers(), this);
-                }
+        boolean hasNonIdentityClaimFilterConditions = false;
+        boolean isIdentityClaimsInIdentityStore = false;
+        boolean isIdentityClaimFilterExistInPostCondition;
+        List<ExpressionCondition> expressionConditions = new ArrayList<>();
+
+        /* Duplicating condition object to ensure that nullifying the conditions in the flow does not affect the
+        validation in the next iteration of flow when the domain name is not in query params.*/
+        Condition duplicateCondition = getDuplicateCondition(condition);
+        getExpressionConditions(duplicateCondition, expressionConditions);
+
+        // Check whether the request has IdentityClaims in filters.
+        boolean identityClaimsExistsInInitialCondition = hasIdentityClaimInitially(expressionConditions);
+
+        if (identityClaimsExistsInInitialCondition) {
+            if (expressionConditions.size() != countIdentityClaims(expressionConditions)) {
+                hasNonIdentityClaimFilterConditions = true;
             }
-        } else if (StringUtils.isNotEmpty(domain)) {
-            String message = ErrorMessages.ERROR_CODE_INVALID_DOMAIN_NAME.getMessage();
-            String errorCode = ErrorMessages.ERROR_CODE_INVALID_DOMAIN_NAME.getCode();
-            throw new UserStoreClientException(errorCode + " - " + String.format(message, domain), errorCode);
+
+            // Call the listeners to get the filtered users from relevant identity store.
+            if (secondaryUserStoreManager != null) {
+                handlePreGetUserListWithIdentityClaims(duplicateCondition, domain, profileName, limit, offset, sortBy,
+                        sortOrder, secondaryUserStoreManager, identityClaimFilteredUserNames,
+                        hasNonIdentityClaimFilterConditions);
+            }
+
+            // Check whether the request has IdentityClaims in filters after trying to filter at Identity Data Store.
+            expressionConditions = new ArrayList<>();
+            getExpressionConditions(duplicateCondition, expressionConditions);
+            isIdentityClaimFilterExistInPostCondition = containsIdentityClaims(expressionConditions);
+
+            // Means the identity claims are identity store based. (Else it is user store based)
+            if (!isIdentityClaimFilterExistInPostCondition) {
+                isIdentityClaimsInIdentityStore = true;
+            } else {
+                updateCondition(duplicateCondition, domain);
+            }
+
+            /* If identity claims are in JDBCIdentityDataStore, and filtering in JDBCIdentityDataStore returned an empty
+         list, we can skip filtering in user store.*/
+            if (isIdentityClaimsInIdentityStore && identityClaimFilteredUserNames.isEmpty()) {
+                return filteredUsers;
+            }
+
+            for (String username : identityClaimFilteredUserNames) {
+                User user = new User();
+                user.setUsername(username);
+                user.setUserID(getUserIDFromUserName(username));
+                user.setUserStoreDomain(UserCoreUtil.extractDomainFromName(user.getUsername()));
+                identityClaimFilteredUsers.add(user);
+            }
+
+            // After filtering based on identity claims, if there are no other filters can return the list.
+            if (expressionConditions.isEmpty()) {
+                return identityClaimFilteredUsers;
+            }
+        }
+
+        if (identityClaimsExistsInInitialCondition && isIdentityClaimsInIdentityStore) {
+            // The identity claims are not user store based.
+            List<User> tempFilteredUsers;
+            List<User> aggregateUserList = new ArrayList<>();
+            int offsetCounter = 0;
+            int paginationLimit;
+
+            if (offset <= 0) {
+                paginationLimit = limit;
+            } else {
+                paginationLimit = (offset - 1) + limit;
+            }
+
+            Set<User> prevIterationFilteredUsers = new HashSet<>();
+            while (aggregateUserList.size() < paginationLimit) {
+                tempFilteredUsers = getFilteredUsers(duplicateCondition, profileName, limit, offsetCounter, sortBy,
+                        sortOrder, secondaryUserStoreManager);
+
+                if (tempFilteredUsers.isEmpty()) {
+                    // Means no users has been filtered in this particular iteration and hence can exit the flow.
+                    break;
+                }
+
+                // Prevent same set of users being returned and break the loop if so.
+                if (isExactSameFilteredUsers(tempFilteredUsers, prevIterationFilteredUsers)) {
+                    break;
+                }
+
+                prevIterationFilteredUsers.clear();
+                prevIterationFilteredUsers.addAll(tempFilteredUsers);
+
+                // For next iteration consider the offset from last fetched size of users.
+                offsetCounter += limit;
+
+                // Taking the interception of the user list.
+                tempFilteredUsers.retainAll(identityClaimFilteredUsers);
+                aggregateUserList.addAll(tempFilteredUsers);
+            }
+
+            // Removing duplicates.
+            aggregateUserList = aggregateUserList.stream().distinct().collect(Collectors.toList());
+
+            // Pagination
+            if (offset <= 0) {
+                offset = 0;
+            } else {
+                offset = offset - 1;
+            }
+
+            if (aggregateUserList.isEmpty()) {
+                filteredUsers = aggregateUserList;
+            } else if (offset > aggregateUserList.size()) {
+                filteredUsers = new ArrayList<>();
+            } else if (aggregateUserList.size() < paginationLimit) {
+                filteredUsers = aggregateUserList.subList(offset, aggregateUserList.size());
+            } else {
+                filteredUsers = aggregateUserList.subList(offset, paginationLimit);
+            }
+        } else {
+            /* When the filters has only the non-identity claims or if Identity claims are persisted in User store
+            based Identity Data store.*/
+            filteredUsers = getFilteredUsers(duplicateCondition, profileName, limit, offset, sortBy, sortOrder,
+                    secondaryUserStoreManager);
         }
 
         handlePostGetUserListWithID(condition, domain, profileName, limit, offset, sortBy, sortOrder, filteredUsers,
@@ -15550,6 +15652,264 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
             log.debug("post listener get conditional  user list for domain: " + domain);
         }
         return filteredUsers;
+    }
+
+    private boolean isExactSameFilteredUsers(List<User> tempFilteredUsers, Set<User> prevIterationFilteredUsers) {
+
+        if (prevIterationFilteredUsers.size() == tempFilteredUsers.size()) {
+            for (User user : tempFilteredUsers) {
+                if (!prevIterationFilteredUsers.contains(user)) {
+                    return false;
+                }
+            }
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    private List<User> getFilteredUsers(Condition condition, String profileName, int limit, int offset, String sortBy,
+                                        String sortOrder, UserStoreManager secManager) throws UserStoreException {
+
+        List<User> filteredUsers = new ArrayList<>();
+        if (secManager != null) {
+            if (secManager instanceof AbstractUserStoreManager) {
+                if (isUniqueUserIdEnabled(secManager)) {
+                    UniqueIDPaginatedSearchResult users = ((AbstractUserStoreManager) secManager)
+                            .doGetUserListWithID(condition, profileName, limit, offset, sortBy, sortOrder);
+                    addUsersToUserIdCache(users.getUsers());
+                    addUsersToUserNameCache(users.getUsers());
+                    filteredUsers = users.getUsers();
+                } else {
+                    PaginatedSearchResult users = ((AbstractUserStoreManager) secManager)
+                            .doGetUserList(condition, profileName, limit, offset, sortBy, sortOrder);
+                    filteredUsers = userUniqueIDManger.listUsers(users.getUsers(), this);
+                }
+            }
+        }
+        return filteredUsers;
+    }
+
+    /**
+     * Get duplicate condition object.
+     *
+     * @param condition Condition.
+     * @throws UserStoreException User store exception.
+     */
+    private Condition getDuplicateCondition(Condition condition) {
+
+        Condition duplicateCondition;
+        if (condition instanceof ExpressionCondition) {
+            duplicateCondition = new ExpressionCondition(condition.getOperation(),
+                    ((ExpressionCondition) condition).getAttributeName(),
+                    ((ExpressionCondition) condition).getAttributeValue());
+        } else if (condition instanceof OperationalCondition) {
+            duplicateCondition = new OperationalCondition(condition.getOperation(),
+                    ((OperationalCondition) condition).getLeftCondition(),
+                    ((OperationalCondition) condition).getRightCondition());
+        } else {
+            /* Have not duplicated the remaining condition objects.
+             If it is essential to duplicate, handle it with an if-else.*/
+            duplicateCondition = condition;
+            if (log.isDebugEnabled()) {
+                log.debug(" Condition object is not duplicated. This might end up in failures when domain names are " +
+                        "not provided in the request as the flows nullify the conditions in due process.");
+            }
+        }
+        return duplicateCondition;
+    }
+
+    /**
+     * Pre listener for getting user list with identity claim filters.
+     *
+     * @param condition                  Condition.
+     * @param domain                     Domain name.
+     * @param limit                      Limit for the result.
+     * @param offset                     Off set for the result.
+     * @param secManager                 Secondary user store manager.
+     * @param hasNonIdentityClaimFilters Count of non-identity claim filters.
+     * @throws UserStoreException User store exception.
+     */
+    private void handlePreGetUserListWithIdentityClaims(Condition condition, String domain, String profileName,
+                                                        int limit, int offset, String sortBy, String sortOrder,
+                                                        UserStoreManager secManager,
+                                                        List<String> identityClaimFilteredUserNames,
+                                                        boolean hasNonIdentityClaimFilters) throws UserStoreException {
+
+        try {
+            for (UserOperationEventListener listener : UMListenerServiceComponent
+                    .getUserOperationEventListeners()) {
+                if (listener instanceof AbstractUserOperationEventListener) {
+                    AbstractUserOperationEventListener newListener =
+                            (AbstractUserOperationEventListener) listener;
+
+                    if (!hasNonIdentityClaimFilters) {
+                        // In this case, can filter with Identity claim filters and paginate at DB level.
+                        if (!newListener.doPreGetPaginatedUserList(condition, identityClaimFilteredUserNames,
+                                domain, secManager, limit, offset)) {
+                            handleGetUserListFailure(
+                                    ErrorMessages.ERROR_CODE_ERROR_WHILE_GETTING_PAGINATED_USER_LIST.getCode(),
+                                    String.format(ErrorMessages.ERROR_CODE_ERROR_WHILE_GETTING_PAGINATED_USER_LIST
+                                                    .getMessage(),
+                                            UserCoreErrorConstants.PRE_LISTENER_TASKS_FAILED_MESSAGE),
+                                    condition, domain, profileName, limit, offset, sortBy, sortOrder);
+                            break;
+                        }
+                    } else {
+                        // In this case, can filter with Identity claim filters and fetch whole filtered list.
+                        if (!newListener.doPreGetUserList(condition, identityClaimFilteredUserNames,
+                                secManager, domain)) {
+                            handleGetUserListFailure(
+                                    ErrorMessages.ERROR_CODE_ERROR_DURING_PRE_GET__CONDITIONAL_USER_LIST.getCode(),
+                                    String.format(ErrorMessages.ERROR_CODE_ERROR_DURING_PRE_GET__CONDITIONAL_USER_LIST
+                                                    .getMessage(),
+                                            UserCoreErrorConstants.PRE_LISTENER_TASKS_FAILED_MESSAGE),
+                                    condition, domain, profileName, limit, offset, sortBy, sortOrder);
+                            break;
+                        }
+                    }
+                }
+            }
+        } catch (UserStoreException ex) {
+            throw new UserStoreException("Error occurred while retrieving users for Identity Claim Filters " +
+                    "with pagination parameters.", ex);
+        }
+    }
+
+    /**
+     * If the condition contains expressions with identity claims, the claims are in the form of local claim dialect
+     * URIs. Hence, they are converted to the mapped attribute.
+     *
+     * @param condition Condition.
+     * @param domain    Domain name.
+     * @throws UserStoreException
+     */
+    private void updateCondition(Condition condition, String domain) throws UserStoreException {
+
+        if (condition instanceof ExpressionCondition) {
+            ExpressionCondition expressionCondition = (ExpressionCondition) condition;
+            if (expressionCondition.getAttributeName().
+                    contains(IDENTITY_CLAIM_URI)) {
+                String claimUri = expressionCondition.getAttributeName();
+                try {
+                    ClaimMapping mapping = (ClaimMapping) claimManager.getClaimMapping(claimUri);
+                    String attribute = mapping.getMappedAttribute(domain);
+                    expressionCondition.setAttributeName(attribute);
+                } catch (org.wso2.carbon.user.api.UserStoreException e) {
+                    throw new UserStoreException(e);
+                }
+            }
+        } else if (condition instanceof OperationalCondition) {
+            Condition leftCondition = ((OperationalCondition) condition).getLeftCondition();
+            updateCondition(leftCondition, domain);
+            Condition rightCondition = ((OperationalCondition) condition).getRightCondition();
+            updateCondition(rightCondition, domain);
+        }
+    }
+
+    /**
+     * Extract filter expressions form the condition as a list.
+     *
+     * @param condition            condition.
+     * @param expressionConditions list of expression conditions.
+     */
+    private void getExpressionConditions(Condition condition, List<ExpressionCondition> expressionConditions) {
+
+        if (condition instanceof ExpressionCondition) {
+            ExpressionCondition expressionCondition = (ExpressionCondition) condition;
+            if (isConditionExist(expressionCondition)) {
+                expressionConditions.add(expressionCondition);
+            }
+        } else if (condition instanceof OperationalCondition) {
+            Condition leftCondition = ((OperationalCondition) condition).getLeftCondition();
+            getExpressionConditions(leftCondition, expressionConditions);
+            Condition rightCondition = ((OperationalCondition) condition).getRightCondition();
+            getExpressionConditions(rightCondition, expressionConditions);
+        }
+    }
+
+    private boolean isConditionExist(ExpressionCondition expressionCondition) {
+
+        if (StringUtils.isNotEmpty(expressionCondition.getAttributeName()) ||
+                StringUtils.isNotEmpty(expressionCondition.getAttributeValue()) ||
+                StringUtils.isNotEmpty(expressionCondition.getOperation())) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Check if the conditions have identity claim as filters.
+     *
+     * @param expressionConditions List of expression conditions.
+     * @throws UserStoreException
+     */
+    private boolean hasIdentityClaimInitially(List<ExpressionCondition> expressionConditions)
+            throws UserStoreException {
+
+        boolean hasIdentityClaims = false;
+        try {
+            org.wso2.carbon.user.api.ClaimMapping[] claimMapping = claimManager.getAllClaimMappings();
+
+            for (ExpressionCondition expressionCondition : expressionConditions) {
+                List<org.wso2.carbon.user.api.ClaimMapping> mappedClaim =
+                        Arrays.stream(claimMapping).filter(mapping -> mapping.getMappedAttribute() ==
+                                expressionCondition.getAttributeName()).collect(Collectors.toList());
+
+                //Obtaining relevant URI for the mapped attribute.
+                if (mappedClaim.size() == 1) {
+                    String tempClaimURI = mappedClaim.get(0).getClaim().getClaimUri();
+                    //Check if the claimURI are of type 'identity claims'.
+                    if (tempClaimURI.contains(IDENTITY_CLAIM_URI)) {
+                        hasIdentityClaims = true;
+                        expressionCondition.setAttributeName(tempClaimURI);
+                        if (log.isDebugEnabled()) {
+                            log.debug("Obtained the ClaimURI " + tempClaimURI + " from the map for the attribute : "
+                                    + expressionCondition.getAttributeName());
+                        }
+                    }
+                }
+            }
+        } catch (org.wso2.carbon.user.api.UserStoreException e) {
+            throw new UserStoreException("Error occurred while checking the existence of identity claim filters " +
+                    "from the expression nodes.", e);
+        }
+        return hasIdentityClaims;
+    }
+
+    /**
+     * Check if the expression list contains identity claims.
+     *
+     * @param expressionConditions list of expression conditions.
+     * @return true if contains identity claims, false otherwise.
+     */
+    private boolean containsIdentityClaims(List<ExpressionCondition> expressionConditions) {
+
+        for (ExpressionCondition expressionCondition : expressionConditions) {
+            if (expressionCondition.getAttributeName() != null &&
+                    expressionCondition.getAttributeName().contains(IDENTITY_CLAIM_URI)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Count the no. of identity claims.
+     *
+     * @param expressionConditions List of expression conditions.
+     * @return true if contains identity claims, false otherwise.
+     */
+    private int countIdentityClaims(List<ExpressionCondition> expressionConditions) {
+
+        int identityClaimsCount = 0;
+        for (ExpressionCondition expressionCondition : expressionConditions) {
+            if (expressionCondition.getAttributeName() != null &&
+                    expressionCondition.getAttributeName().contains(IDENTITY_CLAIM_URI)) {
+                identityClaimsCount += 1;
+            }
+        }
+        return identityClaimsCount;
     }
 
     private List<User> doGetUserListWithID(String claim, String claimValue, String profileName, int limit, int offset,

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/JDBCUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/JDBCUserStoreManager.java
@@ -4615,13 +4615,13 @@ public class JDBCUserStoreManager extends AbstractUserStoreManager {
         sqlBuilder.updateSqlWithOROperation("UA.UM_ATTR_NAME = ?", attributeName);
 
         if (ExpressionOperation.EQ.toString().equals(operation)) {
-            sqlBuilder.updateSqlWithOROperation("UA.UM_ATTR_VALUE = ?", attributeValue);
+            sqlBuilder.where("UA.UM_ATTR_VALUE = ?", attributeValue);
         } else if (ExpressionOperation.EW.toString().equals(operation)) {
-            sqlBuilder.updateSqlWithOROperation("UA.UM_ATTR_VALUE LIKE ?", "%" + attributeValue);
+            sqlBuilder.where("UA.UM_ATTR_VALUE LIKE ?", "%" + attributeValue);
         } else if (ExpressionOperation.CO.toString().equals(operation)) {
-            sqlBuilder.updateSqlWithOROperation("UA.UM_ATTR_VALUE LIKE ?", "%" + attributeValue + "%");
+            sqlBuilder.where("UA.UM_ATTR_VALUE LIKE ?", "%" + attributeValue + "%");
         } else if (ExpressionOperation.SW.toString().equals(operation)) {
-            sqlBuilder.updateSqlWithOROperation("UA.UM_ATTR_VALUE LIKE ?", attributeValue + "%");
+            sqlBuilder.where("UA.UM_ATTR_VALUE LIKE ?", attributeValue + "%");
         }
     }
 
@@ -4645,7 +4645,12 @@ public class JDBCUserStoreManager extends AbstractUserStoreManager {
     private void getExpressionConditions(Condition condition, List<ExpressionCondition> expressionConditions) {
 
         if (condition instanceof ExpressionCondition) {
-            expressionConditions.add((ExpressionCondition) condition);
+            ExpressionCondition expressionCondition = (ExpressionCondition) condition;
+            if (StringUtils.isNotEmpty(expressionCondition.getAttributeName()) ||
+                    StringUtils.isNotEmpty(expressionCondition.getAttributeValue()) ||
+                    StringUtils.isNotEmpty(expressionCondition.getOperation())) {
+                expressionConditions.add(expressionCondition);
+            }
         } else if (condition instanceof OperationalCondition) {
             Condition leftCondition = ((OperationalCondition) condition).getLeftCondition();
             getExpressionConditions(leftCondition, expressionConditions);

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCUserStoreManager.java
@@ -3723,13 +3723,13 @@ public class UniqueIDJDBCUserStoreManager extends JDBCUserStoreManager {
         sqlBuilder.updateSqlWithOROperation("UA.UM_ATTR_NAME = ?", attributeName);
 
         if (ExpressionOperation.EQ.toString().equals(operation)) {
-            sqlBuilder.updateSqlWithOROperation("UA.UM_ATTR_VALUE = ?", attributeValue);
+            sqlBuilder.where("UA.UM_ATTR_VALUE = ?", attributeValue);
         } else if (ExpressionOperation.EW.toString().equals(operation)) {
-            sqlBuilder.updateSqlWithOROperation("UA.UM_ATTR_VALUE LIKE ?", "%" + attributeValue);
+            sqlBuilder.where("UA.UM_ATTR_VALUE LIKE ?", "%" + attributeValue);
         } else if (ExpressionOperation.CO.toString().equals(operation)) {
-            sqlBuilder.updateSqlWithOROperation("UA.UM_ATTR_VALUE LIKE ?", "%" + attributeValue + "%");
+            sqlBuilder.where("UA.UM_ATTR_VALUE LIKE ?", "%" + attributeValue + "%");
         } else if (ExpressionOperation.SW.toString().equals(operation)) {
-            sqlBuilder.updateSqlWithOROperation("UA.UM_ATTR_VALUE LIKE ?", attributeValue + "%");
+            sqlBuilder.where("UA.UM_ATTR_VALUE LIKE ?", attributeValue + "%");
         }
     }
 
@@ -3753,7 +3753,12 @@ public class UniqueIDJDBCUserStoreManager extends JDBCUserStoreManager {
     private void getExpressionConditions(Condition condition, List<ExpressionCondition> expressionConditions) {
 
         if (condition instanceof ExpressionCondition) {
-            expressionConditions.add((ExpressionCondition) condition);
+            ExpressionCondition expressionCondition = (ExpressionCondition) condition;
+            if (StringUtils.isNotEmpty(expressionCondition.getAttributeName()) ||
+                    StringUtils.isNotEmpty(expressionCondition.getAttributeValue()) ||
+                    StringUtils.isNotEmpty(expressionCondition.getOperation())) {
+                expressionConditions.add(expressionCondition);
+            }
         } else if (condition instanceof OperationalCondition) {
             Condition leftCondition = ((OperationalCondition) condition).getLeftCondition();
             getExpressionConditions(leftCondition, expressionConditions);

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/ReadOnlyLDAPUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/ReadOnlyLDAPUserStoreManager.java
@@ -3059,9 +3059,13 @@ public class ReadOnlyLDAPUserStoreManager extends AbstractUserStoreManager {
 
         if (condition instanceof ExpressionCondition) {
             ExpressionCondition expressionCondition = (ExpressionCondition) condition;
-            expressionCondition.setAttributeValue(
-                    escapeSpecialCharactersForFilterWithStarAsRegex(expressionCondition.getAttributeValue()));
-            expressionConditions.add(expressionCondition);
+            if (StringUtils.isNotEmpty(expressionCondition.getAttributeName()) ||
+                    StringUtils.isNotEmpty(expressionCondition.getAttributeValue()) ||
+                    StringUtils.isNotEmpty(expressionCondition.getOperation())) {
+                expressionCondition.setAttributeValue(
+                        escapeSpecialCharactersForFilterWithStarAsRegex(expressionCondition.getAttributeValue()));
+                expressionConditions.add(expressionCondition);
+            }
         } else if (condition instanceof OperationalCondition) {
             Condition leftCondition = ((OperationalCondition) condition).getLeftCondition();
             getExpressionConditionsAsList(leftCondition, expressionConditions);

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/listener/UserOperationEventListener.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/listener/UserOperationEventListener.java
@@ -867,4 +867,21 @@ public interface UserOperationEventListener {
         return true;
     }
 
+    /**
+     * Pre listener for getting paginated user list for certain claim and value.
+     *
+     * @param condition        Conditions with filters.
+     * @param domain           User store domain name.
+     * @param userStoreManager User store manager.
+     * @param limit            Pagination parameter for the size of the page.
+     * @param offset           Pagination parameter that indexes the start of the page.
+     * @throws UserStoreException UserStoreException
+     */
+    default boolean doPreGetPaginatedUserList(Condition condition, List<String> userNames, String domain,
+                                              UserStoreManager userStoreManager, int limit, int offset)
+            throws UserStoreException {
+
+        return true;
+    }
+
 }


### PR DESCRIPTION
**This PR fixes:**
1. https://github.com/wso2/product-is/issues/11766	

Support PR - https://github.com/wso2-support/carbon-kernel/pull/1577		

**Description of the Issue**
--
Filtering with Identity claims does not work on the SCIM2 Users endpoint 
1. **without count**  query param : `totalResults` is correct but results are not displayed
2. **with count** query param : `totalResults` also not correct.

**Cause**
--
1. `userStoreDomainName` was not set and hence unable to get through **scimEnabled** check
2. With count param - the flow is through new API leading to point where there is **no support to handle filters with Identity claims** when the configured datastore is JDBC. 

**Fix**
--
1. Added the `userStoreDomainName` for user.
2. Branch the flow for filters with Identity Claims. 
3. Supports filtering with identity claims and mixed set of claims (identity/non identity)
4. Supports pagination for filtering with only identity claim filtering and filtering with mixed claim filters


**Related PR:** 
-- 
1. https://github.com/wso2-extensions/identity-inbound-provisioning-scim2/pull/406
2. https://github.com/wso2-extensions/identity-governance/pull/567
