### PR TITLE
Sanitize attributes in SCIM claims

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/claim/inmemory/ClaimConfig.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/claim/inmemory/ClaimConfig.java
@@ -42,6 +42,8 @@ public class ClaimConfig {
      */
     private Map<ClaimKey, Map<String, String>> propertyHolder;
 
+    private Map<String, String> claimUriRegex;
+
     public ClaimConfig() {
 
     }
@@ -159,5 +161,15 @@ public class ClaimConfig {
      */
     public void setPropertyHolderMap(Map<ClaimKey, Map<String, String>> propertyHolder) {
         this.propertyHolder = propertyHolder;
+    }
+
+    public String getClaimUriRegex(String claimDialectUri) {
+
+        return claimUriRegex.get(claimDialectUri);
+    }
+
+    public void setClaimUriRegex(Map<String, String> claimUriRegex) {
+
+        this.claimUriRegex = claimUriRegex;
     }
 }

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/claim/inmemory/FileBasedClaimBuilder.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/claim/inmemory/FileBasedClaimBuilder.java
@@ -103,7 +103,9 @@ public class FileBasedClaimBuilder {
                 OMElement dialect = (OMElement) dialectIterator.next();
                 dialectUri = dialect.getAttributeValue(new QName(ATTR_DIALECT_URI));
                 claimUriRegex = dialect.getAttributeValue(new QName(ATTR_CLAIM_URI_REGEX));
-                if (claimUriRegex != null) claimDialectRegex.put(dialectUri, claimUriRegex);
+                if (claimUriRegex != null) {
+                    claimDialectRegex.put(dialectUri, claimUriRegex);
+                }
                 Iterator claimsIterator = dialect.getChildrenWithName(new QName(LOCAL_NAME_CLAIM));
 
                 //Go through Claims

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/claim/inmemory/FileBasedClaimBuilder.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/claim/inmemory/FileBasedClaimBuilder.java
@@ -50,6 +50,7 @@ public class FileBasedClaimBuilder {
     public static final String LOCAL_NAME_DESCRIPTION = "Description";
     public static final String LOCAL_NAME_ATTR_ID = "AttributeID";
     public static final String ATTR_DIALECT_URI = "dialectURI";
+    public static final String ATTR_CLAIM_URI_REGEX = "claimURIRegex";
     private static final String CLAIM_CONFIG = "claim-config.xml";
 
     private static Log log = LogFactory.getLog(FileBasedClaimBuilder.class);
@@ -80,8 +81,10 @@ public class FileBasedClaimBuilder {
         OMElement dom;
         Map<ClaimKey, ClaimMapping> claims = new HashMap<>();
         Map<ClaimKey, Map<String, String>> propertyHolder = new HashMap<>();
+        Map<String, String> claimDialectRegex = new HashMap<>();
 
         String dialectUri;
+        String claimUriRegex;
 
         Claim claim;
         ClaimMapping claimMapping;
@@ -99,6 +102,8 @@ public class FileBasedClaimBuilder {
             while (dialectIterator.hasNext()) {
                 OMElement dialect = (OMElement) dialectIterator.next();
                 dialectUri = dialect.getAttributeValue(new QName(ATTR_DIALECT_URI));
+                claimUriRegex = dialect.getAttributeValue(new QName(ATTR_CLAIM_URI_REGEX));
+                if (claimUriRegex != null) claimDialectRegex.put(dialectUri, claimUriRegex);
                 Iterator claimsIterator = dialect.getChildrenWithName(new QName(LOCAL_NAME_CLAIM));
 
                 //Go through Claims
@@ -145,6 +150,7 @@ public class FileBasedClaimBuilder {
         claimConfig = new ClaimConfig();
         claimConfig.setClaimMap(claims);
         claimConfig.setPropertyHolderMap(propertyHolder);
+        claimConfig.setClaimUriRegex(claimDialectRegex);
         return claimConfig;
     }
 


### PR DESCRIPTION
## Purpose
> Sanitize the storing attributes via Attribute mgt API: checking whether the claim contains any invalid characters disallowed by SCIM
