### PR TITLE
Upgrade from log4j1 to log4j 2.17.1

### DIFF
--- a/launcher/src/main/resources/launch.properties
+++ b/launcher/src/main/resources/launch.properties
@@ -23,8 +23,8 @@ carbon.osgi.framework=file\:plugins/org.eclipse.osgi_3.11.0.v20160603-1336.jar
 carbon.initial.osgi.bundles=\
   file\:plugins/org.eclipse.osgi.services_3.5.100.v20160504-1419.jar@1\:true,\
   file\:plugins/org.eclipse.equinox.cm_1.1.200.v20160324-1850.jar@2\:true,\
-  file\:plugins/org.ops4j.pax.logging.pax-logging-api_1.11.12.jar@2\:true,\
-  file\:plugins/org.ops4j.pax.logging.pax-logging-log4j2_1.11.12.jar@2\:true,\
+  file\:plugins/org.ops4j.pax.logging.pax-logging-api_1.11.13.jar@2\:true,\
+  file\:plugins/org.ops4j.pax.logging.pax-logging-log4j2_1.11.13.jar@2\:true,\
   file\:plugins/org.eclipse.equinox.simpleconfigurator_1.1.200.v20160504-1450.jar@3\:true
 
 osgi.install.area=file\:${wso2.runtime}

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -677,8 +677,8 @@
         <org.eclipse.equinox.p2.metadata.version>2.2.0.v20131211-1531</org.eclipse.equinox.p2.metadata.version>
 
         <!--PAX Logging related dependency versions-->
-        <pax.logging.api.version>1.11.12</pax.logging.api.version>
-        <pax.logging.log4j2.version>1.11.12</pax.logging.log4j2.version>
+        <pax.logging.api.version>1.11.13</pax.logging.api.version>
+        <pax.logging.log4j2.version>1.11.13</pax.logging.log4j2.version>
 
         <!--Maven Plugins -->
         <maven.wagon.ssh.version>2.1</maven.wagon.ssh.version>


### PR DESCRIPTION
## Purpose
To upgrade to log4j 2.17.1

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

