### PR TITLE
[4.6.x] Fix server startup error with jinjava upgrade

### DIFF
--- a/distribution/kernel/src/assembly/bin.xml
+++ b/distribution/kernel/src/assembly/bin.xml
@@ -147,6 +147,7 @@
                 <include>com.fasterxml.jackson.core:jackson-core:jar</include>
                 <include>com.fasterxml.jackson.core:jackson-databind:jar</include>
                 <include>com.fasterxml.jackson.core:jackson-annotations:jar</include>
+                <include>com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:jar</include>
                 <include>com.google.re2j:re2j:jar</include>
                 <include>commons-codec:commons-codec:jar</include>
                 <include>ant-contrib:ant-contrib:jar</include>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -1808,6 +1808,11 @@
                 <version>${version.jackson}</version>
             </dependency>
             <dependency>
+                <groupId>com.fasterxml.jackson.dataformat</groupId>
+                <artifactId>jackson-dataformat-yaml</artifactId>
+                <version>${version.jackson}</version>
+            </dependency>
+            <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
                 <version>${version.guava}</version>


### PR DESCRIPTION
## Purpose
From jinjava `2.5.7` onwards, `com.fasterxml.jackson.dataformat:jackson-dataformat-yaml` is used for the yaml parser. This PR adds the missing dependency to the kernel.