### PR TITLE
[Public] Fix remove tmp directory on Windows startup script

### DIFF
--- a/distribution/kernel/carbon-home/bin/wso2server.bat
+++ b/distribution/kernel/carbon-home/bin/wso2server.bat
@@ -153,10 +153,12 @@ cd %CARBON_HOME%
 
 rem ------------------ Remove tmp folder on startup -----------------------------
 set TMP_DIR=%CARBON_HOME%\tmp
-cd "%TMP_DIR%"
-del *.* /s /q > nul
-FOR /d %%G in ("*.*") DO rmdir %%G /s /q
-cd ..
+if exist "%TMP_DIR%" (
+    cd "%TMP_DIR%"
+    del *.* /s /q > nul
+    FOR /d %%G in ("*.*") DO rmdir %%G /s /q
+    cd ..
+)
 
 rem ---------- Add jars to classpath ----------------
 


### PR DESCRIPTION
## Purpose
Fixes https://github.com/wso2/product-is/issues/13017

Check whether the `<IS_HOME>/tmp` directory is there and run the removing command only if the directory exists as in wso2server.sh script