### PR TITLE
Add `async` to the WSO2_CARBON_DB URL

### DIFF
--- a/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/util/PasswordUpdater.java
+++ b/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/util/PasswordUpdater.java
@@ -188,7 +188,7 @@ public class PasswordUpdater {
     private void printUsage() {
         System.out.println("Usage: chpasswd --db-url DB_URL [OPTIONS]\n");
         System.out.println(USAGE_MSG_INDENT_SPACES + DB_URL + " : The JDBC database URL. " +
-                           "e.g. jdbc:h2:/home/carbon/database/WSO2CARBON_DB\n");
+                           "e.g. jdbc:h2:async:/home/carbon/database/WSO2CARBON_DB\n");
         System.out.println("Options");
         System.out.println(USAGE_MSG_INDENT_SPACES + DB_DRIVER + "    : The database driver class. " +
                            "e.g. org.h2.Driver");

--- a/core/org.wso2.carbon.ndatasource.rdbms/src/test/resources/master-datasources.xml
+++ b/core/org.wso2.carbon.ndatasource.rdbms/src/test/resources/master-datasources.xml
@@ -17,7 +17,7 @@
 -->
 
 <configuration>
-    <url>jdbc:h2:./repository/database/WSO2CARBON_DB;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000</url>
+    <url>jdbc:h2:async:./repository/database/WSO2CARBON_DB;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000</url>
     <username>wso2carbon</username>
     <password>wso2carbon</password>
     <driverClassName>org.h2.Driver</driverClassName>

--- a/core/org.wso2.carbon.registry.core/src/test/resources/user-test/user-mgt-clear.xml
+++ b/core/org.wso2.carbon.registry.core/src/test/resources/user-test/user-mgt-clear.xml
@@ -24,7 +24,7 @@
                      <Password>admin</Password>
                 </AdminUser>
             <EveryOneRoleName>everyone</EveryOneRoleName> <!-- By default users in this role sees the registry root -->
-            <Property name="url">jdbc:h2:./repository/database/WSO2CARBON_DB</Property>
+            <Property name="url">jdbc:h2:async:./repository/database/WSO2CARBON_DB</Property>
             <Property name="userName">wso2carbon</Property>
             <Property name="password">wso2carbon</Property>
             <Property name="driverName">org.h2.Driver</Property>

--- a/core/org.wso2.carbon.registry.core/src/test/resources/user-test/user-mgt-multi-tenant.xml
+++ b/core/org.wso2.carbon.registry.core/src/test/resources/user-test/user-mgt-multi-tenant.xml
@@ -25,7 +25,7 @@
             </AdminUser>
             <EveryOneRoleName>everyone</EveryOneRoleName>
             <!-- By default users in this role sees the registry root -->
-            <Property name="url">jdbc:h2:./repository/database/WSO2CARBON_DB;DB_CLOSE_ON_EXIT=FALSE</Property>
+            <Property name="url">jdbc:h2:async:./repository/database/WSO2CARBON_DB;DB_CLOSE_ON_EXIT=FALSE</Property>
             <Property name="userName">wso2carbon</Property>
             <Property name="password">wso2carbon</Property>
             <Property name="driverName">org.h2.Driver</Property>

--- a/core/org.wso2.carbon.user.core/src/test/resources/user-mgt-multi-tenant.xml
+++ b/core/org.wso2.carbon.user.core/src/test/resources/user-mgt-multi-tenant.xml
@@ -25,7 +25,7 @@
             </AdminUser>
             <EveryOneRoleName>everyone</EveryOneRoleName>
             <!-- By default users in this role sees the registry root -->
-            <Property name="url">jdbc:h2:./repository/database/WSO2CARBON_DB;DB_CLOSE_ON_EXIT=FALSE</Property>
+            <Property name="url">jdbc:h2:async:./repository/database/WSO2CARBON_DB;DB_CLOSE_ON_EXIT=FALSE</Property>
             <Property name="userName">wso2carbon</Property>
             <Property name="password">wso2carbon</Property>
             <Property name="driverName">org.h2.Driver</Property>

--- a/distribution/kernel/carbon-home/bin/README.txt
+++ b/distribution/kernel/carbon-home/bin/README.txt
@@ -12,7 +12,7 @@ this directory.
 	Open a console/shell and run the script from "$CARBON_HOME/bin" directory.
 
 	Usage:
-	# chpasswd.bat/sh --db-url jdbc:h2:/$CARBON_HOME/repository/database/WSO2CARBON_DB
+	# chpasswd.bat/sh --db-url jdbc:h2:async:/$CARBON_HOME/repository/database/WSO2CARBON_DB
 
 	If the administrator wants to use other databases, he should configure the datasource in the "master-datasources.xml", which is in 
 	"$CARBON_HOME/repository/conf/datasources" directory. This datasource is looked up in "registry.xml" and "user-mgt.xml" as a JNDI resource.

--- a/distribution/kernel/carbon-home/repository/conf/datasources/master-datasources.xml
+++ b/distribution/kernel/carbon-home/repository/conf/datasources/master-datasources.xml
@@ -14,7 +14,7 @@
             </jndiConfig>
             <definition type="RDBMS">
                 <configuration>
-                    <url>jdbc:h2:./repository/database/WSO2CARBON_DB;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000</url>
+                    <url>jdbc:h2:async:./repository/database/WSO2CARBON_DB;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000</url>
                     <username>wso2carbon</username>
                     <password>wso2carbon</password>
                     <driverClassName>org.h2.Driver</driverClassName>

--- a/distribution/kernel/carbon-home/repository/resources/conf/infer.json
+++ b/distribution/kernel/carbon-home/repository/resources/conf/infer.json
@@ -272,7 +272,7 @@
     },
     "h2": {
       "database.$1.driver": "org.h2.Driver",
-      "database.$1.url": "jdbc:h2:./repository/database/WSO2CARBON_DB;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000",
+      "database.$1.url": "jdbc:h2:async:./repository/database/WSO2CARBON_DB;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000",
       "database.$1.validationQuery": "SELECT 1"
     }
   },

--- a/distribution/kernel/carbon-home/repository/resources/conf/templates/repository/conf/datasources/master-datasources.xml.j2
+++ b/distribution/kernel/carbon-home/repository/resources/conf/templates/repository/conf/datasources/master-datasources.xml.j2
@@ -14,7 +14,7 @@
             </jndiConfig>
             <definition type="RDBMS">
                 <configuration>
-                    <url>jdbc:h2:./repository/database/WSO2CARBON_DB;DB_CLOSE_ON_EXIT=FALSE</url>
+                    <url>jdbc:h2:async:./repository/database/WSO2CARBON_DB;DB_CLOSE_ON_EXIT=FALSE</url>
                     <username>wso2carbon</username>
                     <password>wso2carbon</password>
                     <driverClassName>org.h2.Driver</driverClassName>


### PR DESCRIPTION
Public Issue:
- https://github.com/wso2/product-is/issues/13138

The embedded local H2 in prod env have broken at a multi-threaded application.
This is already reported H2-issue. As per it `In a multi-threaded application, it is sufficient that one client thread tries to access the database in the interrupted state to completely crash the database.`

According to this H2 issue, adding `async` to the URL is the solution.