### PR TITLE
Fix Permission Resetting for Same Role Name in Multiple User Stores

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
@@ -5861,10 +5861,6 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
                         userStoreNew.getDomainAwareName());
             }
 
-            // This is a special case. We need to pass roles with domains.
-            userRealm.getAuthorizationManager().resetPermissionOnUpdateRole(
-                    userStore.getDomainAwareName(), userStoreNew.getDomainAwareName());
-
             // To make sure to maintain the back-ward compatibility, only audit log listener will be called.
             handlePostUpdateRoleName(roleName, newRoleName, false);
             // Need to update user role cache upon update of role names

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/hybrid/HybridRoleManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/hybrid/HybridRoleManager.java
@@ -939,8 +939,14 @@ public class HybridRoleManager {
                 DatabaseUtil.updateDatabase(dbConnection, sqlStmt, newRoleName, roleName);
             }
             dbConnection.commit();
-            this.userRealm.getAuthorizationManager().resetPermissionOnUpdateRole(roleName,
-                    newRoleName);
+            if (roleName.contains(UserCoreConstants.DOMAIN_SEPARATOR)) {
+                this.userRealm.getAuthorizationManager().resetPermissionOnUpdateRole(roleName,
+                        newRoleName);
+            } else {
+                String domainNamePrefix = UserCoreConstants.INTERNAL_DOMAIN + UserCoreConstants.DOMAIN_SEPARATOR;
+                this.userRealm.getAuthorizationManager().resetPermissionOnUpdateRole(domainNamePrefix
+                        + roleName, domainNamePrefix + newRoleName);
+            }
         } catch (SQLException e) {
             String errorMessage =
                     "Error occurred while updating hybrid role : " + roleName + " to new role : " + newRoleName;


### PR DESCRIPTION
This issue was caused when an INTERNAL role name is updated, the domain free role name is used to update the role permissions of that role name. Since the domain is not available in the domain free name, at the resetPermissionOnUpdateRole method the default domain name: PRIMARY is used to update the UM_ROLE_PERMISSION table. This results in updating the permissions of similar role names of the PRIMARY userstore.
The duplicated usage of resetPermissionOnUpdateRole method in the AbstractUserStoreManager class will update the role permissions of the relevant name in INTERNAL userstore causing both INTERNAL and PRIMARY userstore role permissions of that changed name to be updated when renaming an INTERNAL role name.

This PR appends the domain name: INTERNAL to the role name when updating the role permissions relevant to that role name during the flow of renaming an INTERNAL role. The duplicate usage of resetPermissionOnUpdateRole is also removed.

Resolves: https://github.com/wso2/product-is/issues/13078