### PR TITLE
Disable remote shutdown/restart from SOAP API

### DIFF
--- a/core/org.wso2.carbon.server.admin/src/main/java/org/wso2/carbon/server/admin/service/ServerAdmin.java
+++ b/core/org.wso2.carbon.server.admin/src/main/java/org/wso2/carbon/server/admin/service/ServerAdmin.java
@@ -180,7 +180,7 @@ public class ServerAdmin extends AbstractAdmin implements ServerAdminMBean, ISer
             if (log.isDebugEnabled()) {
                 log.debug("Server restart through API is disabled.");
             }
-            return true;
+            return false;
         }
 //        checkStandaloneMode();
         Thread thread = Thread.currentThread();
@@ -218,7 +218,7 @@ public class ServerAdmin extends AbstractAdmin implements ServerAdminMBean, ISer
             if (log.isDebugEnabled()) {
                 log.debug("Server restart through API is disabled.");
             }
-            return true;
+            return false;
         }
 //        checkStandaloneMode();
         Thread thread = Thread.currentThread();
@@ -255,7 +255,7 @@ public class ServerAdmin extends AbstractAdmin implements ServerAdminMBean, ISer
             if (log.isDebugEnabled()) {
                 log.debug("Server shutdown through API is disabled.");
             }
-            return true;
+            return false;
         }
 //        checkStandaloneMode();
         Thread thread = Thread.currentThread();
@@ -292,7 +292,7 @@ public class ServerAdmin extends AbstractAdmin implements ServerAdminMBean, ISer
             if (log.isDebugEnabled()) {
                 log.debug("Server shutdown through API is disabled.");
             }
-            return true;
+            return false;
         }
 //        checkStandaloneMode();
         Thread thread = Thread.currentThread();

--- a/core/org.wso2.carbon.server.admin/src/main/java/org/wso2/carbon/server/admin/service/ServerAdmin.java
+++ b/core/org.wso2.carbon.server.admin/src/main/java/org/wso2/carbon/server/admin/service/ServerAdmin.java
@@ -174,6 +174,14 @@ public class ServerAdmin extends AbstractAdmin implements ServerAdminMBean, ISer
     }
 
     public boolean restart() throws Exception {
+
+        if (Boolean.parseBoolean(
+                ServerConfiguration.getInstance().getFirstProperty(ServerConstants.DISABLE_REMOTE_RESTART))) {
+            if (log.isDebugEnabled()) {
+                log.debug("Server restart through API is disabled.");
+            }
+            return true;
+        }
 //        checkStandaloneMode();
         Thread thread = Thread.currentThread();
         ClassLoader originalClassloader = thread.getContextClassLoader();
@@ -204,6 +212,14 @@ public class ServerAdmin extends AbstractAdmin implements ServerAdminMBean, ISer
     }
 
     public boolean restartGracefully() throws Exception {
+
+        if (Boolean.parseBoolean(
+                ServerConfiguration.getInstance().getFirstProperty(ServerConstants.DISABLE_REMOTE_RESTART))) {
+            if (log.isDebugEnabled()) {
+                log.debug("Server restart through API is disabled.");
+            }
+            return true;
+        }
 //        checkStandaloneMode();
         Thread thread = Thread.currentThread();
         ClassLoader originalClassloader = thread.getContextClassLoader();
@@ -233,6 +249,14 @@ public class ServerAdmin extends AbstractAdmin implements ServerAdminMBean, ISer
     }
 
     public boolean shutdown() throws AxisFault {
+
+        if (Boolean.parseBoolean(
+                ServerConfiguration.getInstance().getFirstProperty(ServerConstants.DISABLE_REMOTE_SHUTDOWN))) {
+            if (log.isDebugEnabled()) {
+                log.debug("Server shutdown through API is disabled.");
+            }
+            return true;
+        }
 //        checkStandaloneMode();
         Thread thread = Thread.currentThread();
         ClassLoader originalClassloader = thread.getContextClassLoader();
@@ -262,6 +286,14 @@ public class ServerAdmin extends AbstractAdmin implements ServerAdminMBean, ISer
     }
 
     public boolean shutdownGracefully() throws AxisFault {
+
+        if (Boolean.parseBoolean(
+                ServerConfiguration.getInstance().getFirstProperty(ServerConstants.DISABLE_REMOTE_SHUTDOWN))) {
+            if (log.isDebugEnabled()) {
+                log.debug("Server shutdown through API is disabled.");
+            }
+            return true;
+        }
 //        checkStandaloneMode();
         Thread thread = Thread.currentThread();
         ClassLoader originalClassloader = thread.getContextClassLoader();

--- a/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/ServerConstants.java
+++ b/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/ServerConstants.java
@@ -61,6 +61,12 @@ public final class ServerConstants {
 
     public static final String PASSWORD_EXPIRATION = "passwordExpires";
     public static final String SERVICE_TYPE = "serviceType";
+	
+    /**
+     * System property to disable/ enable server shutdown or restart remotely using APIs.
+     */
+    public static final String DISABLE_REMOTE_RESTART = "disableShutdownRestartFromAPI.disableRestart";
+    public static final String DISABLE_REMOTE_SHUTDOWN = "disableShutdownRestartFromAPI.disableShutdown";
 
     /**
      * This is the key of the System property which indicates whether the server is running

--- a/distribution/kernel/carbon-home/repository/conf/carbon.xml
+++ b/distribution/kernel/carbon-home/repository/conf/carbon.xml
@@ -708,4 +708,11 @@
         <disableRestart>false</disableRestart>
     </disableShutdownRestartFromUI>
 
+    <!-- Configure disable/enable server shutdown and restart from API -->
+
+    <disableShutdownRestartFromAPI>
+        <disableShutdown>true</disableShutdown>
+        <disableRestart>true</disableRestart>
+    </disableShutdownRestartFromAPI>
+
 </Server>

--- a/distribution/kernel/carbon-home/repository/resources/conf/default.json
+++ b/distribution/kernel/carbon-home/repository/resources/conf/default.json
@@ -8,6 +8,8 @@
   "server.file_upload.file_size_limit": "100",
   "server.default_items_per_page": "15",
   "server.max_items_per_page": "100",
+  "server.disable_shutdown_from_api": true,
+  "server.disable_restart_from_api": true,
   "user_store.type": "database",
   "super_admin.admin_role": "admin",
   "everyone.rolename": "everyone",

--- a/distribution/kernel/carbon-home/repository/resources/conf/templates/repository/conf/carbon.xml.j2
+++ b/distribution/kernel/carbon-home/repository/resources/conf/templates/repository/conf/carbon.xml.j2
@@ -763,4 +763,11 @@
         <disableRestart>{{server.disable_restart_from_ui | default('false')}}</disableRestart>
      </disableShutdownRestartFromUI>
 
+    <!-- Configure disable/enable server shutdown and restart from API -->
+
+     <disableShutdownRestartFromAPI>
+        <disableShutdown>{{server.disable_shutdown_from_api}}</disableShutdown>
+        <disableRestart>{{server.disable_restart_from_api}}</disableRestart>
+     </disableShutdownRestartFromAPI>
+
 </Server>


### PR DESCRIPTION
## Purpose
Fix https://github.com/wso2/product-is/issues/12587

By default, the config is set to disable server shutdown and restart. Update the migration docs about the default behavior change.
The following config needs to be added to the deployment.toml to enable the remote shutdown and restart via soap api.

```
[server]
disable_shutdown_from_api = false
disable_restart_from_api = false
```


**UPDATE:**
changed the config by https://github.com/wso2/carbon-kernel/pull/3233
```
[server]
enable_shutdown_from_api = true
enable_restart_from_api = true
```