### PR TITLE
Clear the credentialObj Object in Finally Block

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
@@ -8086,14 +8086,20 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
             return false;
         }
 
-        Secret credentialObj;
+        Secret credentialObj = null;
+        boolean isValidCredentials;
         try {
             credentialObj = Secret.getSecret(credential);
+            isValidCredentials = credentialObj.getChars().length >= 1;
         } catch (UnsupportedSecretTypeException e) {
             throw new UserStoreException("Unsupported credential type", e);
+        } finally {
+            if (credentialObj != null) {
+                credentialObj.clear();
+            }
         }
 
-        return credentialObj.getChars().length >= 1;
+        return isValidCredentials;
     }
 
     /**


### PR DESCRIPTION
## Purpose
In this PR, logic is added to clear the credentialObj object in a finally block.

## Goals
The credentialObj object which contain password should be cleared after use.

## Approach
Invoked the clear method of Secret class to clear the credentialObj object in a finally block.