### PR TITLE
Fix null Tenant Id and Tenant Domain in wso2carbon.log

### DIFF
--- a/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/multitenancy/MultitenantMessageReceiver.java
+++ b/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/multitenancy/MultitenantMessageReceiver.java
@@ -122,6 +122,8 @@ public class MultitenantMessageReceiver implements MessageReceiver {
                     PrivilegedCarbonContext privilegedCarbonContext = 
                             PrivilegedCarbonContext.getThreadLocalCarbonContext();
                     privilegedCarbonContext.setTenantDomain(tenantDomain, true);
+                    ThreadContext.put(MultitenantConstants.TENANT_ID, String.valueOf(privilegedCarbonContext.getTenantId()));
+                    ThreadContext.put(MultitenantConstants.TENANT_DOMAIN, tenantDomain);
                     if (tenantResponseMsgCtx == null) {
                         tenantResponseMsgCtx = new MessageContext();
                         tenantResponseMsgCtx.setOperationContext(tenantRequestMsgCtx.getOperationContext());
@@ -190,6 +192,8 @@ public class MultitenantMessageReceiver implements MessageReceiver {
                     AxisEngine.receive(tenantResponseMsgCtx);
                 } finally {
                     PrivilegedCarbonContext.endTenantFlow();
+                    ThreadContext.remove(org.wso2.carbon.base.MultitenantConstants.TENANT_ID);
+                    ThreadContext.remove(org.wso2.carbon.base.MultitenantConstants.TENANT_DOMAIN);
                 }
             }
         }

--- a/core/org.wso2.carbon.pax-logging-log4j2-plugins/src/main/java/org/wso2/carbon/log4j2/plugins/TenantDomainConverter.java
+++ b/core/org.wso2.carbon.pax-logging-log4j2-plugins/src/main/java/org/wso2/carbon/log4j2/plugins/TenantDomainConverter.java
@@ -69,6 +69,8 @@ public class TenantDomainConverter extends LogEventPatternConverter {
             Object value = contextData.getValue(MultitenantConstants.TENANT_DOMAIN);
             if (value != null) {
                 StringBuilders.appendValue(toAppendTo, value);
+            } else {
+                StringBuilders.appendValue(toAppendTo, MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
             }
         }
     }

--- a/core/org.wso2.carbon.pax-logging-log4j2-plugins/src/main/java/org/wso2/carbon/log4j2/plugins/TenantIdConverter.java
+++ b/core/org.wso2.carbon.pax-logging-log4j2-plugins/src/main/java/org/wso2/carbon/log4j2/plugins/TenantIdConverter.java
@@ -66,6 +66,8 @@ public class TenantIdConverter extends LogEventPatternConverter {
             Object value = contextData.getValue(MultitenantConstants.TENANT_ID);
             if (value != null) {
                 StringBuilders.appendValue(toAppendTo, value);
+            } else {
+                StringBuilders.appendValue(toAppendTo, MultitenantConstants.SUPER_TENANT_ID);
             }
         }
     }


### PR DESCRIPTION
### Purpose 

-  https://github.com/wso2/product-apim/issues/12637

### User stories

`TID: [-1234:carbon.super] [] [2022-03-15 12:00:01,061]  INFO {com.sample.handlers.APILogHandler} - null| Source IP: 127.0.0.1 | API Name: admin--PizzaShackAPI:v1.0.0 |GET| Path: /pizzashack/1.0.0/menu | Response Code: 200 | Response Time: 2701 | Backend Latency: 2378`

`TID: [1:test.com] [] [2022-03-15 11:54:03,639]  INFO {com.sample.handlers.APILogHandler} - null| Source IP: 127.0.0.1 | API Name: admin-AT-test.com--PizzaShackAPI:v1.0.0 |GET| Path: /t/test.com/pizzashack/1.0.0/menu | Response Code: 200 | Response Time: 16 | Backend Latency: 15`
