### PR TITLE
Fix multi-attribute filtering issue with Identity and normal claims

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
@@ -15563,9 +15563,7 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
             }
 
             for (String username : identityClaimFilteredUserNames) {
-                User user = new User();
-                user.setUsername(username);
-                user.setUserID(getUserIDFromUserName(username));
+                User user = getUser(getUserIDFromUserName(username), username);
                 user.setUserStoreDomain(UserCoreUtil.extractDomainFromName(user.getUsername()));
                 identityClaimFilteredUsers.add(user);
             }


### PR DESCRIPTION
Resolves https://github.com/wso2/product-is/issues/13122

**Purpose:**
The intersection of 2 user objects from `identityClaimFilteredUsers` and `tempFilteredUsers` being compared returns false even though there is a match because some attributes are null(eg: tenantDomain, preferedUserName) due to not being populated in a similar manner.

**Approach:**
Handle the 2 user objects in the same way by populating all the required attributes of both user objects.