### PR TITLE
Modify `catalina-server.xml.j2` to add custom remoteIpValve properties

### DIFF
--- a/distribution/kernel/carbon-home/repository/resources/conf/templates/repository/conf/tomcat/catalina-server.xml.j2
+++ b/distribution/kernel/carbon-home/repository/resources/conf/templates/repository/conf/tomcat/catalina-server.xml.j2
@@ -62,6 +62,20 @@
 
             <Host name="localhost" unpackWARs="true" deployOnStartup="false" autoDeploy="false"
                   appBase="${carbon.home}/repository/deployment/server/webapps/">
+                {% if catalinaValves.remoteIpValve.enable is sameas true %}
+                        <!-- This should be defined before the AuthenticationValve to get the real client IP addresses via request headers. -->
+                        <Valve
+                            className="org.apache.catalina.valves.RemoteIpValve"
+                            internalProxies="{{catalinaValves.remoteIpValve.internalProxies}}"
+                            remoteIpHeader="{{catalinaValves.remoteIpValve.remoteIpHeader}}"
+                            protocolHeader="{{catalinaValves.remoteIpValve.protocolHeader}}"
+                            proxiesHeader="{{catalinaValves.remoteIpValve.proxiesHeader}}"
+                            trustedProxies="{{catalinaValves.remoteIpValve.trustedProxies}}"
+                            {% for property,value in catalinaValves.remoteIpValve.properties.items() %}
+                                {{property}}="{{value}}"
+                            {% endfor %}
+                        />
+                        {% endif %}
                 <Valve className="org.wso2.carbon.tomcat.ext.valves.RequestEncodingValve" encoding="UTF-8"/>
                 <Valve className="org.wso2.carbon.tomcat.ext.valves.RequestCorrelationIdValve"
                        headerToCorrelationIdMapping="{'activityid':'Correlation-ID'}"

--- a/distribution/kernel/carbon-home/repository/resources/conf/templates/repository/conf/tomcat/catalina-server.xml.j2
+++ b/distribution/kernel/carbon-home/repository/resources/conf/templates/repository/conf/tomcat/catalina-server.xml.j2
@@ -75,7 +75,7 @@
                                 {{property}}="{{value}}"
                             {% endfor %}
                         />
-                        {% endif %}
+                {% endif %}
                 <Valve className="org.wso2.carbon.tomcat.ext.valves.RequestEncodingValve" encoding="UTF-8"/>
                 <Valve className="org.wso2.carbon.tomcat.ext.valves.RequestCorrelationIdValve"
                        headerToCorrelationIdMapping="{'activityid':'Correlation-ID'}"


### PR DESCRIPTION
### Purpose

Please refer the $subject

### Notes

Users can add custom properties to `RemoteIpValve` config by adding the following configuration in the `deployment.toml`

```
[ catalinaValves.remoteIpValve.properties]
customProperty1 = "customVal1"
customProperty2 = "customVal2"
```

`catalina-server.xml` preview

```
<Valve
    className="org.apache.catalina.valves.RemoteIpValve"
    internalProxies=""
    remoteIpHeader=""
    protocolHeader=""
    proxiesHeader=""
    trustedProxies=""
    customProperty1="customVal1"
    customProperty2="customVal2"
/>
```
Resolves : [wso2/product-is#13350](https://github.com/wso2/product-is/issues/13350)
