### PR TITLE
Skip username regex validation for jit provisioning

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
@@ -4937,7 +4937,8 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
             // #################### </Pre-Listeners> #####################################################
 
             // Validate the username against provided regular expressions.
-            if (!checkUserNameValid(userStore.getDomainFreeName())) {
+            if (!checkUserNameValid(userStore.getDomainFreeName()) &&
+                    !UserCoreUtil.getSkipUsernamePatternValidationThreadLocal()) {
                 String regEx = realmConfig
                         .getUserStoreProperty(UserCoreConstants.RealmConfig.PROPERTY_USER_NAME_JAVA_REG_EX);
                 // Inorder to support both UsernameJavaRegEx and UserNameJavaRegEx.
@@ -5079,6 +5080,7 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
             // #################### </Post-Listeners> #####################################################
         } finally {
             UserCoreUtil.removeSkipPasswordPatternValidationThreadLocal();
+            UserCoreUtil.removeSkipUsernamePatternValidationThreadLocal();
             credentialObj.clear();
         }
 

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/util/UserCoreUtil.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/util/UserCoreUtil.java
@@ -84,6 +84,12 @@ public final class UserCoreUtil {
     private static ThreadLocal<Boolean> skipPasswordPatternValidationThreadLocal = new ThreadLocal<>();
 
     /**
+     * This thread local is used to keep track whether username policy validation is skipped
+     * during the user addition flow.
+     */
+    private static ThreadLocal<Boolean> skipUsernamePatternValidationThreadLocal = new ThreadLocal<>();
+
+    /**
      * @param arr1
      * @param arr2
      * @return
@@ -503,6 +509,25 @@ public final class UserCoreUtil {
     public static void removeSkipPasswordPatternValidationThreadLocal() {
 
         skipPasswordPatternValidationThreadLocal.remove();
+    }
+
+    public static void setSkipUsernamePatternValidationThreadLocal(Boolean askPasswordEnabled) {
+
+        skipUsernamePatternValidationThreadLocal.set(askPasswordEnabled);
+    }
+
+    public static boolean getSkipUsernamePatternValidationThreadLocal() {
+
+        if (skipUsernamePatternValidationThreadLocal.get() != null) {
+            return skipUsernamePatternValidationThreadLocal.get().booleanValue();
+        } else {
+            return false;
+        }
+    }
+
+    public static void removeSkipUsernamePatternValidationThreadLocal() {
+
+        skipUsernamePatternValidationThreadLocal.remove();
     }
 
     /**


### PR DESCRIPTION
## Purpose
> Unique identifier is returned as subject identifier for a federated user during JIT provisioning. Therefore this PR skip the username regex validation during JIT provisioning flow.
