### PR TITLE
Optimize getMaxUserNameListLength and getSQLQueryTimeoutLimit methods

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/JDBCUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/JDBCUserStoreManager.java
@@ -4790,7 +4790,7 @@ public class JDBCUserStoreManager extends AbstractUserStoreManager {
         String searchTimeRawValue = realmConfig.getUserStoreProperty(UserCoreConstants.
                 RealmConfig.PROPERTY_MAX_SEARCH_TIME);
 
-        if (StringUtils.isNumeric(searchTimeRawValue)) {
+        if (StringUtils.isNotEmpty(searchTimeRawValue) && StringUtils.isNumeric(searchTimeRawValue)) {
             searchTime = Integer.parseInt(realmConfig.getUserStoreProperty(UserCoreConstants.
                     RealmConfig.PROPERTY_MAX_SEARCH_TIME));
         } else {

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/JDBCUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/JDBCUserStoreManager.java
@@ -4766,15 +4766,18 @@ public class JDBCUserStoreManager extends AbstractUserStoreManager {
     private int getMaxUserNameListLength() {
 
         int maxUserList;
-        try {
-            maxUserList = Integer.parseInt(realmConfig.getUserStoreProperty(UserCoreConstants.RealmConfig
-                    .PROPERTY_MAX_USER_LIST));
-        } catch (Exception e) {
+        String maxUserListRawValue = realmConfig.getUserStoreProperty(UserCoreConstants.
+                RealmConfig.PROPERTY_MAX_USER_LIST);
+
+        if (StringUtils.isNumeric(maxUserListRawValue)) {
+            maxUserList = Integer.parseInt(realmConfig.getUserStoreProperty(UserCoreConstants.
+                    RealmConfig.PROPERTY_MAX_USER_LIST));
+        } else {
             // The user store property might not be configured. Therefore logging as debug.
             if (log.isDebugEnabled()) {
                 log.debug("Unable to get the " + UserCoreConstants.RealmConfig.PROPERTY_MAX_USER_LIST +
                         " from the realm configuration. The default value: " + UserCoreConstants.MAX_USER_ROLE_LIST +
-                        " is used instead.", e);
+                        " is used instead.");
             }
             maxUserList = UserCoreConstants.MAX_USER_ROLE_LIST;
         }
@@ -4784,15 +4787,18 @@ public class JDBCUserStoreManager extends AbstractUserStoreManager {
     private int getSQLQueryTimeoutLimit() {
 
         int searchTime;
-        try {
-            searchTime = Integer.parseInt(realmConfig
-                    .getUserStoreProperty(UserCoreConstants.RealmConfig.PROPERTY_MAX_SEARCH_TIME));
-        } catch (Exception e) {
-            // The user store property might not be configured. Therefore logging as debug.
+        String searchTimeRawValue = realmConfig.getUserStoreProperty(UserCoreConstants.
+                RealmConfig.PROPERTY_MAX_SEARCH_TIME);
+
+        if (StringUtils.isNumeric(searchTimeRawValue)) {
+            searchTime = Integer.parseInt(realmConfig.getUserStoreProperty(UserCoreConstants.
+                    RealmConfig.PROPERTY_MAX_SEARCH_TIME));
+        } else {
+            // The user store property might not be configured. Therefore, logging as debug.
             if (log.isDebugEnabled()) {
                 log.debug("Unable to get the " + UserCoreConstants.RealmConfig.PROPERTY_MAX_SEARCH_TIME +
                         " from the realm configuration. The default value: " + UserCoreConstants.MAX_SEARCH_TIME +
-                        " is used instead.", e);
+                        " is used instead.");
             }
             searchTime = UserCoreConstants.MAX_SEARCH_TIME;
         }

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/JDBCUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/JDBCUserStoreManager.java
@@ -4769,7 +4769,7 @@ public class JDBCUserStoreManager extends AbstractUserStoreManager {
         String maxUserListRawValue = realmConfig.getUserStoreProperty(UserCoreConstants.
                 RealmConfig.PROPERTY_MAX_USER_LIST);
 
-        if (StringUtils.isNumeric(maxUserListRawValue)) {
+        if (StringUtils.isNotEmpty(maxUserListRawValue) && StringUtils.isNumeric(maxUserListRawValue)) {
             maxUserList = Integer.parseInt(realmConfig.getUserStoreProperty(UserCoreConstants.
                     RealmConfig.PROPERTY_MAX_USER_LIST));
         } else {


### PR DESCRIPTION
## Purpose
> The purpose of this pull request is to remove the process of printing the stack trace in debug logs and to optimize the `getMaxUserNameListLength` and `getSQLQueryTimeoutLimit` methods. Resolves https://github.com/wso2/product-is/issues/14848.

## Goals
> Check whether the string is parsable before parsing it to an integer. This will make sure that no exceptions will occur during the parsing process.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
> JDK 1.8, Ubuntu 20.04