### PR TITLE
Publish diagnostic logs in a JSON serializable manner

### DIFF
--- a/core/org.wso2.carbon.utils/pom.xml
+++ b/core/org.wso2.carbon.utils/pom.xml
@@ -226,6 +226,10 @@
             <scope>test</scope>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+        </dependency>
     </dependencies>
 
     <properties>

--- a/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/CarbonConstants.java
+++ b/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/CarbonConstants.java
@@ -34,14 +34,6 @@ public final class CarbonConstants {
     public static final Log AUDIT_LOG = LogFactory.getLog("AUDIT_LOG");
     public static final String AUDIT_MESSAGE = "Initiator : %s | Action : %s | Target : %s | Data : { %s } | Result : %s ";
     public static final String DISABLE_LEGACY_AUDIT_LOGS = "disableLegacyAuditLogs";
-    public static final String AUDIT_LOG_MESSAGE_TEMPLATE =
-            "{ id : %s, recordedAt : %s, clientComponent : %s, requestId : %s, " +
-                    "initiatorId : %s, initiatorName : %s, initiatorType : %s, eventType : %s, targetId : %s, " +
-                    "targetName : %s, targetType : %s, dataChange : %s }";
-    public static final String DIAGNOSTIC_LOG_TEMPLATE =
-            "{ id : %s, recordedAt : %s, requestId : %s, flowId : %s, " +
-                    "componentId : %s, actionId : %s, input : %s, configurations : %s, resultStatus : %s, " +
-                    "resultMessage : %s }";
     public enum DiagnosticLogMode {
         FULL,
         NONE

--- a/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/CarbonConstants.java
+++ b/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/CarbonConstants.java
@@ -36,12 +36,12 @@ public final class CarbonConstants {
     public static final String DISABLE_LEGACY_AUDIT_LOGS = "disableLegacyAuditLogs";
     public static final String AUDIT_LOG_MESSAGE_TEMPLATE =
             "{ id : %s, recordedAt : %s, clientComponent : %s, requestId : %s, " +
-                    "initiator.id : %s, initiator.name : %s, initiator.type : %s, event.type : %s, target.id : %s, " +
-                    "target.name : %s, target.type : %s, data.change : %s }";
+                    "initiatorId : %s, initiatorName : %s, initiatorType : %s, eventType : %s, targetId : %s, " +
+                    "targetName : %s, targetType : %s, dataChange : %s }";
     public static final String DIAGNOSTIC_LOG_TEMPLATE =
             "{ id : %s, recordedAt : %s, requestId : %s, flowId : %s, " +
-                    "component.id : %s, action.id : %s, input : %s, configurations : %s, result.status : %s, " +
-                    "result.message : %s }";
+                    "componentId : %s, actionId : %s, input : %s, configurations : %s, resultStatus : %s, " +
+                    "resultMessage : %s }";
     public enum DiagnosticLogMode {
         FULL,
         NONE

--- a/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/CarbonUtils.java
+++ b/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/CarbonUtils.java
@@ -107,6 +107,7 @@ public class CarbonUtils {
             org.apache.xerces.impl.Constants.SECURITY_MANAGER_PROPERTY;
     private static boolean isServerConfigInitialized;
     private static Log audit = CarbonConstants.AUDIT_LOG;
+    private static Gson gson = new Gson();
 
     public static boolean isAdminConsoleEnabled() {
         boolean enableAdminConsole = false;
@@ -1373,7 +1374,7 @@ public class CarbonUtils {
         Object auditLogObject = auditLogData.get(CarbonConstants.LogEventConstants.AUDIT_LOG);
         if (auditLogObject instanceof AuditLog) {
             AuditLog auditLog = (AuditLog) auditLogObject;
-            audit.warn(new Gson().toJson(auditLog));
+            audit.warn(gson.toJson(auditLog));
         }
     }
 
@@ -1461,7 +1462,7 @@ public class CarbonUtils {
         Object diagnosticLogObj = diagnosticLogData.get(CarbonConstants.LogEventConstants.DIAGNOSTIC_LOG);
         if (diagnosticLogObj instanceof DiagnosticLog) {
             DiagnosticLog log = (DiagnosticLog) diagnosticLogObj;
-            diagnosticLog.info(new Gson().toJson(log));
+            diagnosticLog.info(gson.toJson(log));
         }
     }
 

--- a/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/CarbonUtils.java
+++ b/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/CarbonUtils.java
@@ -16,6 +16,8 @@
 
 package org.wso2.carbon.utils;
 
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import org.apache.axiom.util.base64.Base64Utils;
 import org.apache.axis2.AxisFault;
 import org.apache.axis2.Constants;
@@ -1465,12 +1467,10 @@ public class CarbonUtils {
 
         Object diagnosticLogObj = diagnosticLogData.get(CarbonConstants.LogEventConstants.DIAGNOSTIC_LOG);
         if (diagnosticLogObj instanceof DiagnosticLog) {
-            DiagnosticLog log = (DiagnosticLog) diagnosticLogObj;
-            String logStr = String.format(CarbonConstants.DIAGNOSTIC_LOG_TEMPLATE, log.getLogId(),
-                    log.getRecordedAt(), log.getRequestId(), log.getFlowId(), log.getComponentId(), log.getActionId(),
-                    getMapDataAsString(log.getInput()), getMapDataAsString(log.getConfigurations()),
-                    log.getResultStatus(), log.getResultMessage());
-            diagnosticLog.info(logStr);
+            DiagnosticLog diagnosticLog = (DiagnosticLog) diagnosticLogObj;
+            GsonBuilder builder = new GsonBuilder();
+            builder.serializeNulls();
+            CarbonUtils.diagnosticLog.info(builder.create().toJson(diagnosticLog));
         }
     }
 

--- a/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/CarbonUtils.java
+++ b/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/CarbonUtils.java
@@ -1373,12 +1373,7 @@ public class CarbonUtils {
         Object auditLogObject = auditLogData.get(CarbonConstants.LogEventConstants.AUDIT_LOG);
         if (auditLogObject instanceof AuditLog) {
             AuditLog auditLog = (AuditLog) auditLogObject;
-            String auditLogString = String.format(CarbonConstants.AUDIT_LOG_MESSAGE_TEMPLATE, auditLog.getLogId(),
-                    auditLog.getRecordedAt(), auditLog.getClientComponent(), auditLog.getCorrelationId(),
-                    auditLog.getInitiatorId(), auditLog.getInitiatorName(), auditLog.getInitiatorType(),
-                    auditLog.getEventType(), auditLog.getTargetId(), auditLog.getTargetName(), auditLog.getTargetType(),
-                    auditLog.getDataChange());
-            audit.warn(auditLogString);
+            audit.warn(new Gson().toJson(auditLog));
         }
     }
 

--- a/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/CarbonUtils.java
+++ b/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/CarbonUtils.java
@@ -17,7 +17,6 @@
 package org.wso2.carbon.utils;
 
 import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
 import org.apache.axiom.util.base64.Base64Utils;
 import org.apache.axis2.AxisFault;
 import org.apache.axis2.Constants;
@@ -76,7 +75,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-
 import javax.servlet.ServletContext;
 import javax.servlet.http.HttpSession;
 import javax.xml.XMLConstants;
@@ -1467,10 +1465,8 @@ public class CarbonUtils {
 
         Object diagnosticLogObj = diagnosticLogData.get(CarbonConstants.LogEventConstants.DIAGNOSTIC_LOG);
         if (diagnosticLogObj instanceof DiagnosticLog) {
-            DiagnosticLog diagnosticLog = (DiagnosticLog) diagnosticLogObj;
-            GsonBuilder builder = new GsonBuilder();
-            builder.serializeNulls();
-            CarbonUtils.diagnosticLog.info(builder.create().toJson(diagnosticLog));
+            DiagnosticLog log = (DiagnosticLog) diagnosticLogObj;
+            diagnosticLog.info(new Gson().toJson(log));
         }
     }
 


### PR DESCRIPTION
## Purpose
make use of a JSON parser to publish the logs in a JSON serializable manner. So when fetching the log results, we can easily parse the JSON log string to an object.

