### PR TITLE
Upgrade hazelcast from 3.12.x to 4.2.x

### DIFF
--- a/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/clustering/hazelcast/GroupManagementCommandListener.java
+++ b/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/clustering/hazelcast/GroupManagementCommandListener.java
@@ -1,7 +1,7 @@
 package org.wso2.carbon.core.clustering.hazelcast;
 
-import com.hazelcast.core.Message;
-import com.hazelcast.core.MessageListener;
+import com.hazelcast.topic.Message;
+import com.hazelcast.topic.MessageListener;
 import org.apache.axis2.clustering.ClusteringFault;
 import org.apache.axis2.clustering.management.GroupManagementCommand;
 import org.apache.axis2.context.ConfigurationContext;

--- a/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/clustering/hazelcast/HazelcastCarbonClusterImpl.java
+++ b/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/clustering/hazelcast/HazelcastCarbonClusterImpl.java
@@ -18,8 +18,8 @@
 package org.wso2.carbon.core.clustering.hazelcast;
 
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.core.ITopic;
-import com.hazelcast.core.Member;
+import com.hazelcast.topic.ITopic;
+import com.hazelcast.cluster.Member;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.core.clustering.api.CarbonCluster;

--- a/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/clustering/hazelcast/HazelcastClusterMessageAsyncListener.java
+++ b/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/clustering/hazelcast/HazelcastClusterMessageAsyncListener.java
@@ -17,8 +17,8 @@
  */
 package org.wso2.carbon.core.clustering.hazelcast;
 
-import com.hazelcast.core.Message;
-import com.hazelcast.core.MessageListener;
+import com.hazelcast.topic.Message;
+import com.hazelcast.topic.MessageListener;
 import org.apache.axis2.clustering.ClusteringFault;
 import org.apache.axis2.clustering.ClusteringMessage;
 import org.apache.axis2.context.ConfigurationContext;

--- a/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/clustering/hazelcast/HazelcastClusterMessageListener.java
+++ b/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/clustering/hazelcast/HazelcastClusterMessageListener.java
@@ -17,8 +17,8 @@
 */
 package org.wso2.carbon.core.clustering.hazelcast;
 
-import com.hazelcast.core.Message;
-import com.hazelcast.core.MessageListener;
+import com.hazelcast.topic.Message;
+import com.hazelcast.topic.MessageListener;
 import org.apache.axis2.clustering.ClusteringFault;
 import org.apache.axis2.clustering.ClusteringMessage;
 import org.apache.axis2.context.ConfigurationContext;

--- a/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/clustering/hazelcast/HazelcastClusteringAgent.java
+++ b/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/clustering/hazelcast/HazelcastClusteringAgent.java
@@ -69,6 +69,8 @@ import org.wso2.carbon.core.clustering.api.CoordinatedActivity;
 import org.wso2.carbon.core.clustering.hazelcast.aws.AWSBasedMembershipScheme;
 import org.wso2.carbon.core.clustering.hazelcast.aws.AWSECSBasedMembershipScheme;
 import org.wso2.carbon.core.clustering.hazelcast.general.GeneralMembershipScheme;
+import org.wso2.carbon.core.clustering.hazelcast.kubernetes.KubernetesConstants;
+import org.wso2.carbon.core.clustering.hazelcast.kubernetes.KubernetesMembershipScheme;
 import org.wso2.carbon.core.clustering.hazelcast.multicast.MulticastBasedMembershipScheme;
 import org.wso2.carbon.core.clustering.hazelcast.util.MemberUtils;
 import org.wso2.carbon.core.clustering.hazelcast.wka.WKABasedMembershipScheme;
@@ -599,7 +601,14 @@ public class HazelcastClusteringAgent extends ParameterAdapter implements Cluste
                     primaryHazelcastInstance,
                     sentMsgsBuffer);
             membershipScheme.init();
-        } else {
+        } else if (scheme.equals(HazelcastConstants.KUBERNETES_MEMBERSHIP_SCHEME)) {
+            membershipScheme = new KubernetesMembershipScheme(parameters, primaryDomain,
+                    primaryHazelcastConfig,
+                    primaryHazelcastInstance,
+                    sentMsgsBuffer);
+            membershipScheme.init();
+        }
+        else {
             Parameter classNameParameter = parameters.get(MEMBERSHIP_SCHEME_CLASS_NAME);
             if(classNameParameter != null) {
                 initiateCustomMembershipScheme(classNameParameter, primaryHazelcastConfig);
@@ -656,14 +665,16 @@ public class HazelcastClusteringAgent extends ParameterAdapter implements Cluste
         if (!mbrScheme.equals(ClusteringConstants.MembershipScheme.MULTICAST_BASED) &&
             !mbrScheme.equals(ClusteringConstants.MembershipScheme.WKA_BASED) &&
             !mbrScheme.equals(HazelcastConstants.AWS_MEMBERSHIP_SCHEME) &&
-                !mbrScheme.equals(HazelcastConstants.AWS_ECS_MEMBERSHIP_SCHEME)) {
+                !mbrScheme.equals(HazelcastConstants.AWS_ECS_MEMBERSHIP_SCHEME) &&
+                !mbrScheme.equals(HazelcastConstants.KUBERNETES_MEMBERSHIP_SCHEME)) {
 
             Parameter classNameParameter = parameters.get(MEMBERSHIP_SCHEME_CLASS_NAME);
             if(classNameParameter == null) {
                 String msg = "Invalid membership scheme '" + mbrScheme + "'. Supported schemes are " +
                         ClusteringConstants.MembershipScheme.MULTICAST_BASED + ", " +
                         ClusteringConstants.MembershipScheme.WKA_BASED + " & " +
-                        HazelcastConstants.AWS_MEMBERSHIP_SCHEME;
+                        HazelcastConstants.AWS_MEMBERSHIP_SCHEME + " & " +
+                        HazelcastConstants.KUBERNETES_MEMBERSHIP_SCHEME;
                 log.error(msg);
                 throw new ClusteringFault(msg);
             }

--- a/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/clustering/hazelcast/HazelcastClusteringAgent.java
+++ b/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/clustering/hazelcast/HazelcastClusteringAgent.java
@@ -18,7 +18,6 @@
 package org.wso2.carbon.core.clustering.hazelcast;
 
 import com.hazelcast.config.Config;
-import com.hazelcast.config.GroupConfig;
 import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.config.MapConfig;
 import com.hazelcast.config.MemberAttributeConfig;
@@ -29,14 +28,13 @@ import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastException;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.HazelcastInstanceNotActiveException;
-import com.hazelcast.core.ILock;
-import com.hazelcast.core.ITopic;
-import com.hazelcast.core.Member;
-import com.hazelcast.core.MemberAttributeEvent;
-import com.hazelcast.core.MembershipEvent;
-import com.hazelcast.core.MembershipListener;
-import com.hazelcast.core.Message;
-import com.hazelcast.core.MessageListener;
+import com.hazelcast.cp.lock.FencedLock;
+import com.hazelcast.topic.ITopic;
+import com.hazelcast.cluster.Member;
+import com.hazelcast.cluster.MembershipEvent;
+import com.hazelcast.cluster.MembershipListener;
+import com.hazelcast.topic.Message;
+import com.hazelcast.topic.MessageListener;
 import com.hazelcast.nio.serialization.ByteArraySerializer;
 import com.hazelcast.nio.serialization.StreamSerializer;
 import org.apache.axiom.om.OMAttribute;
@@ -178,7 +176,7 @@ public class HazelcastClusteringAgent extends ParameterAdapter implements Cluste
         Parameter localParameter = getParameter(LOCAL_MEMBER_IDENTIFIER);
         if (localParameter != null) {
             MemberAttributeConfig memberAttributeConfig = new MemberAttributeConfig();
-            memberAttributeConfig.setStringAttribute(localParameter.getName(), localParameter.getValue().toString());
+            memberAttributeConfig.setAttribute(localParameter.getName(), localParameter.getValue().toString());
             primaryHazelcastConfig.setMemberAttributeConfig(memberAttributeConfig);
         }
 
@@ -227,11 +225,11 @@ public class HazelcastClusteringAgent extends ParameterAdapter implements Cluste
         }
 
         localMember = primaryHazelcastInstance.getCluster().getLocalMember();
-        localMember.getInetSocketAddress().getPort();
+        localMember.getSocketAddress().getPort();
         final org.apache.axis2.clustering.Member carbonLocalMember =
                 MemberUtils.getLocalMember(primaryDomain,
-                                           localMember.getInetSocketAddress().getAddress().getHostAddress(),
-                                           localMember.getInetSocketAddress().getPort());
+                                           localMember.getSocketAddress().getAddress().getHostAddress(),
+                                           localMember.getSocketAddress().getPort());
         log.info("Local member: [" + localMember.getUuid() + "] - " + carbonLocalMember);
 
         //Create a Queue for receiving messages from others
@@ -253,7 +251,7 @@ public class HazelcastClusteringAgent extends ParameterAdapter implements Cluste
         if(carbonLocalMember.getProperties().get("subDomain") == null){
             carbonLocalMember.getProperties().put("subDomain", "__$default");  // Set the default subDomain
         }
-        MemberUtils.getMembersMap(primaryHazelcastInstance, primaryDomain).put(localMember.getUuid(),
+        MemberUtils.getMembersMap(primaryHazelcastInstance, primaryDomain).put(localMember.getUuid().toString(),
                                                                                carbonLocalMember);
 
         // To receive membership events required for the leader election algorithm.
@@ -269,7 +267,7 @@ public class HazelcastClusteringAgent extends ParameterAdapter implements Cluste
         // node which acquires the lock checks whether it is the oldest member in the cluster. If it is the oldest
         // member then it elects itself as the coordinator node and then release the lock. If it is not the oldest
         // member them simply release the lock. This distributed lock is used to avoid any race conditions.
-        ILock lock = primaryHazelcastInstance.getLock(HazelcastConstants.CLUSTER_COORDINATOR_LOCK);
+        FencedLock lock = primaryHazelcastInstance.getCPSubsystem().getLock(HazelcastConstants.CLUSTER_COORDINATOR_LOCK);
 
         try {
             log.debug("Trying to get the CLUSTER_COORDINATOR_LOCK lock.");
@@ -308,7 +306,7 @@ public class HazelcastClusteringAgent extends ParameterAdapter implements Cluste
 
         if (hazelcastInstance != null && hazelcastInstance.getCluster() != null &&
                 hazelcastInstance.getCluster().getLocalMember() != null) {
-            return hazelcastInstance.getCluster().getLocalMember().getUuid();
+            return hazelcastInstance.getCluster().getLocalMember().getUuid().toString();
         } else {
             return clusterNodeId != null ? clusterNodeId : UUID.randomUUID().toString();
         }
@@ -360,7 +358,7 @@ public class HazelcastClusteringAgent extends ParameterAdapter implements Cluste
 
         Parameter managementCenterURL = getParameter(HazelcastConstants.MGT_CENTER_URL);
         if (managementCenterURL != null) {
-            primaryHazelcastConfig.getManagementCenterConfig().setEnabled(true).setUrl((String) managementCenterURL.getValue());
+            primaryHazelcastConfig.getManagementCenterConfig().addTrustedInterface((String) managementCenterURL.getValue());
         }
 
         Parameter licenseKey = getParameter(HazelcastConstants.LICENSE_KEY);
@@ -369,12 +367,8 @@ public class HazelcastClusteringAgent extends ParameterAdapter implements Cluste
         }
 
         primaryHazelcastConfig.setInstanceName(primaryDomain + ".instance");
-        GroupConfig groupConfig = primaryHazelcastConfig.getGroupConfig();
-        groupConfig.setName(primaryDomain);
+        primaryHazelcastConfig.setClusterName(primaryDomain);
         Parameter memberPassword = getParameter(HazelcastConstants.GROUP_PASSWORD);
-        if (memberPassword != null) {
-            groupConfig.setPassword((String) memberPassword.getValue());
-        }
 
         NetworkConfig nwConfig = primaryHazelcastConfig.getNetworkConfig();
         Parameter localMemberHostParam = getParameter(HazelcastConstants.LOCAL_MEMBER_HOST);
@@ -403,7 +397,7 @@ public class HazelcastClusteringAgent extends ParameterAdapter implements Cluste
         configureMembershipScheme(nwConfig, primaryHazelcastConfig);
 
         MapConfig mapConfig = new MapConfig("carbon-map-config");
-        mapConfig.setEvictionPolicy(MapConfig.DEFAULT_EVICTION_POLICY);
+        mapConfig.getEvictionConfig().setEvictionPolicy(MapConfig.DEFAULT_EVICTION_POLICY);
         if (licenseKey != null) {
             mapConfig.setInMemoryFormat(InMemoryFormat.BINARY);
         }
@@ -960,10 +954,6 @@ public class HazelcastClusteringAgent extends ParameterAdapter implements Cluste
                     log.debug("Member Removed Event: This member is elected as the Coordinator node");
                 }
             }
-        }
-
-        @Override
-        public void memberAttributeChanged(MemberAttributeEvent memberAttributeEvent) {
         }
     }
 }

--- a/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/clustering/hazelcast/HazelcastConstants.java
+++ b/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/clustering/hazelcast/HazelcastConstants.java
@@ -42,6 +42,7 @@ public final class HazelcastConstants {
 
     public static final String CONFIG_XML_NAME = "hazelcast.xml";
     public static final String AWS_ECS_MEMBERSHIP_SCHEME = "aws-ecs";
+    public static final String KUBERNETES_MEMBERSHIP_SCHEME = "kubernetes";
 
     private HazelcastConstants() {
     }

--- a/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/clustering/hazelcast/HazelcastControlCommandListener.java
+++ b/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/clustering/hazelcast/HazelcastControlCommandListener.java
@@ -17,8 +17,8 @@
 */
 package org.wso2.carbon.core.clustering.hazelcast;
 
-import com.hazelcast.core.Message;
-import com.hazelcast.core.MessageListener;
+import com.hazelcast.topic.Message;
+import com.hazelcast.topic.MessageListener;
 import org.apache.axis2.clustering.ClusteringFault;
 import org.apache.axis2.clustering.control.ControlCommand;
 import org.apache.axis2.context.ConfigurationContext;

--- a/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/clustering/hazelcast/HazelcastDistributedMapProvider.java
+++ b/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/clustering/hazelcast/HazelcastDistributedMapProvider.java
@@ -75,6 +75,7 @@ public class HazelcastDistributedMapProvider implements DistributedMapProvider {
                     listenerId = map.addEntryListener(new EntryListener<K, V>() {
                         @Override
                         public void entryExpired(EntryEvent<K, V> entryEvent) {
+
                         }
 
                         @Override

--- a/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/clustering/hazelcast/HazelcastGroupManagementAgent.java
+++ b/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/clustering/hazelcast/HazelcastGroupManagementAgent.java
@@ -19,7 +19,6 @@ package org.wso2.carbon.core.clustering.hazelcast;
 
 import com.hazelcast.config.AwsConfig;
 import com.hazelcast.config.Config;
-import com.hazelcast.config.GroupConfig;
 import com.hazelcast.config.MulticastConfig;
 import com.hazelcast.config.NetworkConfig;
 import com.hazelcast.config.TcpIpConfig;
@@ -27,14 +26,11 @@ import com.hazelcast.core.EntryEvent;
 import com.hazelcast.core.EntryListener;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.core.IMap;
-import com.hazelcast.core.ITopic;
-import com.hazelcast.core.MapEvent;
-import com.hazelcast.core.MembershipEvent;
-import com.hazelcast.core.MemberAttributeEvent;
-import com.hazelcast.core.MembershipListener;
-import com.hazelcast.core.Message;
-import com.hazelcast.core.MessageListener;
+import com.hazelcast.map.IMap;
+import com.hazelcast.topic.ITopic;
+import com.hazelcast.map.MapEvent;
+import com.hazelcast.cluster.MembershipEvent;
+import com.hazelcast.cluster.MembershipListener;
 import org.apache.axis2.clustering.ClusteringFault;
 import org.apache.axis2.clustering.ClusteringMessage;
 import org.apache.axis2.clustering.Member;
@@ -43,6 +39,7 @@ import org.apache.axis2.clustering.management.GroupManagementCommand;
 import org.apache.axis2.context.ConfigurationContext;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.core.clustering.hazelcast.aws.AWSConstants;
 import org.wso2.carbon.core.clustering.hazelcast.util.MemberUtils;
 
 import java.io.IOException;
@@ -102,14 +99,14 @@ public class HazelcastGroupManagementAgent implements GroupManagementAgent {
             groupMulticastConfig.setMulticastTimeoutSeconds(primaryMulticastConfig.getMulticastTimeoutSeconds());
             groupMulticastConfig.setMulticastTimeToLive(primaryMulticastConfig.getMulticastTimeToLive());
         } else if (groupNwConfig.getJoin().getAwsConfig().isEnabled()) {
-            groupAwsConfig.setAccessKey(primaryAwsConfig.getAccessKey());
-            groupAwsConfig.setSecretKey(primaryAwsConfig.getSecretKey());
-            groupAwsConfig.setTagKey(primaryAwsConfig.getTagKey());
-            groupAwsConfig.setTagValue(primaryAwsConfig.getTagValue());
-            groupAwsConfig.setRegion(primaryAwsConfig.getRegion());
-            groupAwsConfig.setHostHeader(primaryAwsConfig.getHostHeader());
+            groupAwsConfig.setProperty(AWSConstants.ACCESS_KEY, primaryAwsConfig.getProperty(AWSConstants.ACCESS_KEY));
+            groupAwsConfig.setProperty(AWSConstants.SECRET_KEY, primaryAwsConfig.getProperty(AWSConstants.SECRET_KEY));
+            groupAwsConfig.setProperty(AWSConstants.TAG_KEY, primaryAwsConfig.getProperty(AWSConstants.TAG_KEY));
+            groupAwsConfig.setProperty(AWSConstants.TAG_VALUE, primaryAwsConfig.getProperty(AWSConstants.TAG_VALUE));
+            groupAwsConfig.setProperty(AWSConstants.REGION, primaryAwsConfig.getProperty(AWSConstants.REGION));
+            groupAwsConfig.setProperty(AWSConstants.HOST_HEADER, primaryAwsConfig.getProperty(AWSConstants.HOST_HEADER));
 //            groupAwsConfig.setSecurityGroupName(primaryAwsConfig.getSecurityGroupName()); //TODO: Find a way to set security group
-            groupAwsConfig.setConnectionTimeoutSeconds(primaryAwsConfig.getConnectionTimeoutSeconds());
+            groupAwsConfig.setProperty(AWSConstants.CONNECTION_TIMEOUT, primaryAwsConfig.getProperty(AWSConstants.CONNECTION_TIMEOUT));
         } else if (groupNwConfig.getJoin().getTcpIpConfig().isEnabled()) {
             tcpIpConfig.setConnectionTimeoutSeconds(primaryNwConfig.getJoin().getTcpIpConfig().getConnectionTimeoutSeconds());
             for (Member wkaMember : wkaMembers) {
@@ -117,15 +114,14 @@ public class HazelcastGroupManagementAgent implements GroupManagementAgent {
             }
         }
 
-        GroupConfig groupConfig = config.getGroupConfig();
-        groupConfig.setName(domain);
+        config.setClusterName(domain);
         config.setProperties(primaryHazelcastConfig.getProperties());
         HazelcastInstance hazelcastInstance = Hazelcast.getHazelcastInstanceByName(domain);
         if (hazelcastInstance == null) {
             hazelcastInstance = Hazelcast.newHazelcastInstance(config);
         }
         hazelcastInstance.getCluster().addMembershipListener(new GroupMembershipListener());
-        localMemberUUID = hazelcastInstance.getCluster().getLocalMember().getUuid();
+        localMemberUUID = hazelcastInstance.getCluster().getLocalMember().getUuid().toString();
         Member localMember =
                 MemberUtils.getLocalMember(domain, groupNwConfig.getPublicAddress(),
                                            groupMgtPort);
@@ -191,19 +187,16 @@ public class HazelcastGroupManagementAgent implements GroupManagementAgent {
 
         @Override
         public void memberAdded(MembershipEvent membershipEvent) {
-            com.hazelcast.core.Member member = membershipEvent.getMember();
-            log.info("Member joined [" + member.getUuid() + "]: " + member.getInetSocketAddress().toString());
+            com.hazelcast.cluster.Member member = membershipEvent.getMember();
+            log.info("Member joined [" + member.getUuid() + "]: " + member.getSocketAddress().toString());
         }
 
         @Override
         public void memberRemoved(MembershipEvent membershipEvent) {
-            com.hazelcast.core.Member member = membershipEvent.getMember();
-            log.info("Member left [" + member.getUuid() + "]: " + member.getInetSocketAddress().toString());
+            com.hazelcast.cluster.Member member = membershipEvent.getMember();
+            log.info("Member left [" + member.getUuid() + "]: " + member.getSocketAddress().toString());
             Member removed = members.remove(membershipEvent.getMember().getUuid());
             connectedMembers.remove(removed);
-        }
-
-        public void memberAttributeChanged(MemberAttributeEvent memberAttributeEvent) {
         }
     }
 
@@ -248,6 +241,11 @@ public class HazelcastGroupManagementAgent implements GroupManagementAgent {
 
         @Override
         public void mapCleared(MapEvent mapEvent) {
+            // Nothing to do
+        }
+
+        @Override
+        public void entryExpired(EntryEvent<String, Member> entryEvent) {
             // Nothing to do
         }
     }

--- a/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/clustering/hazelcast/HazelcastIdempotentClusterMessageListener.java
+++ b/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/clustering/hazelcast/HazelcastIdempotentClusterMessageListener.java
@@ -17,8 +17,8 @@
  */
 package org.wso2.carbon.core.clustering.hazelcast;
 
-import com.hazelcast.core.Message;
-import com.hazelcast.core.MessageListener;
+import com.hazelcast.topic.Message;
+import com.hazelcast.topic.MessageListener;
 import org.apache.axis2.clustering.ClusteringFault;
 import org.apache.axis2.clustering.ClusteringMessage;
 import org.apache.axis2.context.ConfigurationContext;

--- a/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/clustering/hazelcast/HazelcastMembershipScheme.java
+++ b/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/clustering/hazelcast/HazelcastMembershipScheme.java
@@ -18,7 +18,7 @@
 package org.wso2.carbon.core.clustering.hazelcast;
 
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.core.Member;
+import com.hazelcast.cluster.Member;
 import org.apache.axis2.clustering.MembershipScheme;
 
 /**

--- a/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/clustering/hazelcast/HazelcastUtil.java
+++ b/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/clustering/hazelcast/HazelcastUtil.java
@@ -17,7 +17,7 @@
 */
 package org.wso2.carbon.core.clustering.hazelcast;
 
-import com.hazelcast.core.Member;
+import com.hazelcast.cluster.Member;
 import org.apache.axis2.clustering.ClusteringMessage;
 import org.wso2.carbon.core.clustering.api.CarbonCluster;
 import org.wso2.carbon.core.clustering.api.ClusterMember;
@@ -30,7 +30,7 @@ import java.util.List;
  */
 public class HazelcastUtil {
     public static ClusterMember toClusterMember(Member hazelcastMember) {
-        return new ClusterMember(hazelcastMember.getUuid(), hazelcastMember.getInetSocketAddress());
+        return new ClusterMember(hazelcastMember.getUuid().toString(), hazelcastMember.getSocketAddress());
     }
 
     /**

--- a/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/clustering/hazelcast/aws/AWSBasedMembershipScheme.java
+++ b/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/clustering/hazelcast/aws/AWSBasedMembershipScheme.java
@@ -21,10 +21,9 @@ import com.hazelcast.config.AwsConfig;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.NetworkConfig;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.core.Member;
-import com.hazelcast.core.MembershipEvent;
-import com.hazelcast.core.MemberAttributeEvent;
-import com.hazelcast.core.MembershipListener;
+import com.hazelcast.cluster.Member;
+import com.hazelcast.cluster.MembershipEvent;
+import com.hazelcast.cluster.MembershipListener;
 import org.apache.axiom.om.OMElement;
 import org.apache.axis2.clustering.ClusteringFault;
 import org.apache.axis2.clustering.ClusteringMessage;
@@ -119,42 +118,42 @@ public class AWSBasedMembershipScheme implements HazelcastMembershipScheme {
             if (secretResolver != null) {
                 String resolvedValue = MiscellaneousUtil.resolve(accessKey.getParameterElement(), secretResolver);
                 if (!StringUtils.isEmpty(resolvedValue)) {
-                    awsConfig.setAccessKey(resolvedValue);
+                    awsConfig.setProperty(AWSConstants.ACCESS_KEY, resolvedValue);
                 }
             } else {
-                awsConfig.setAccessKey(((String) accessKey.getValue()).trim());
+                awsConfig.setProperty(AWSConstants.ACCESS_KEY, ((String) accessKey.getValue()).trim());
             }
         }
         if (secretKey != null) {
             if (secretResolver != null) {
                 String resolvedValue = MiscellaneousUtil.resolve(secretKey.getParameterElement(), secretResolver);
                 if (!StringUtils.isEmpty(resolvedValue)) {
-                    awsConfig.setSecretKey(resolvedValue);
+                    awsConfig.setProperty(AWSConstants.SECRET_KEY, resolvedValue);
                 }
             } else {
-                awsConfig.setSecretKey(((String) secretKey.getValue()).trim());
+                awsConfig.setProperty(AWSConstants.SECRET_KEY, ((String) secretKey.getValue()).trim());
             }
         }
         if (iamRole != null) {
-            awsConfig.setIamRole(((String) iamRole.getValue()).trim());
+            awsConfig.setProperty(AWSConstants.IAM_ROLE, ((String) iamRole.getValue()).trim());
         }
         if (securityGroup != null) {
-            awsConfig.setSecurityGroupName(((String) securityGroup.getValue()).trim());
+            awsConfig.setProperty(AWSConstants.SECURITY_GROUP, ((String) securityGroup.getValue()).trim());
         }
         if (connTimeout != null) {
-            awsConfig.setConnectionTimeoutSeconds(Integer.parseInt(((String) connTimeout.getValue()).trim()));
+            awsConfig.setProperty(AWSConstants.CONNECTION_TIMEOUT, ((String) connTimeout.getValue()).trim());
         }
         if (hostHeader != null) {
-            awsConfig.setHostHeader(((String) hostHeader.getValue()).trim());
+            awsConfig.setProperty(AWSConstants.HOST_HEADER, ((String) hostHeader.getValue()).trim());
         }
         if (region != null) {
-            awsConfig.setRegion(((String) region.getValue()).trim());
+            awsConfig.setProperty(AWSConstants.REGION, ((String) region.getValue()).trim());
         }
         if (tagKey != null) {
-            awsConfig.setTagKey(((String) tagKey.getValue()).trim());
+            awsConfig.setProperty(AWSConstants.TAG_KEY, ((String) tagKey.getValue()).trim());
         }
         if (tagValue != null) {
-            awsConfig.setTagValue(((String) tagValue.getValue()).trim());
+            awsConfig.setProperty(AWSConstants.TAG_VALUE, ((String) tagValue.getValue()).trim());
         }
 
     }
@@ -222,7 +221,7 @@ public class AWSBasedMembershipScheme implements HazelcastMembershipScheme {
 
             // send all cluster messages
             carbonCluster.memberAdded(member);
-            log.info("Member joined [" + member.getUuid() + "]: " + member.getInetSocketAddress().toString());
+            log.info("Member joined [" + member.getUuid() + "]: " + member.getSocketAddress().toString());
             // Wait for sometime for the member to completely join before replaying messages
             try {
                 Thread.sleep(5000);
@@ -235,10 +234,7 @@ public class AWSBasedMembershipScheme implements HazelcastMembershipScheme {
         public void memberRemoved(MembershipEvent membershipEvent) {
             Member member = membershipEvent.getMember();
             carbonCluster.memberRemoved(member);
-            log.info("Member left [" + member.getUuid() + "]: " + member.getInetSocketAddress().toString());
-        }
-
-        public void memberAttributeChanged(MemberAttributeEvent memberAttributeEvent) {
+            log.info("Member left [" + member.getUuid() + "]: " + member.getSocketAddress().toString());
         }
 
     }

--- a/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/clustering/hazelcast/aws/AWSConstants.java
+++ b/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/clustering/hazelcast/aws/AWSConstants.java
@@ -22,14 +22,14 @@ package org.wso2.carbon.core.clustering.hazelcast.aws;
  */
 public class AWSConstants {
 
-    public static final String ACCESS_KEY = "accessKey";
-    public static final String SECRET_KEY = "secretKey";
-    public static final String SECURITY_GROUP = "securityGroup" ;
-    public static final String CONNECTION_TIMEOUT ="connTimeout" ;
-    public static final String HOST_HEADER = "hostHeader";
+    public static final String ACCESS_KEY = "access-key";
+    public static final String SECRET_KEY = "secret-key";
+    public static final String SECURITY_GROUP = "security-group-name" ;
+    public static final String CONNECTION_TIMEOUT ="connection-timeout-seconds" ;
+    public static final String HOST_HEADER = "host-header";
     public static final String REGION = "region";
-    public static final String TAG_KEY = "tagKey";
-    public static final String TAG_VALUE = "tagValue";
-    public static final String IAM_ROLE = "iamRole";
+    public static final String TAG_KEY = "tag-key";
+    public static final String TAG_VALUE = "tag-value";
+    public static final String IAM_ROLE = "iam-role";
     public static final String NETWORK_INTERFACE = "networkInterface";
 }

--- a/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/clustering/hazelcast/general/GeneralMembershipScheme.java
+++ b/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/clustering/hazelcast/general/GeneralMembershipScheme.java
@@ -1,5 +1,8 @@
 package org.wso2.carbon.core.clustering.hazelcast.general;
 
+import com.hazelcast.cluster.Member;
+import com.hazelcast.cluster.MembershipEvent;
+import com.hazelcast.cluster.MembershipListener;
 import com.hazelcast.core.*;
 import org.apache.axis2.clustering.ClusteringFault;
 import org.apache.axis2.clustering.ClusteringMessage;
@@ -69,7 +72,7 @@ public class GeneralMembershipScheme implements HazelcastMembershipScheme {
 
             // send all cluster messages
             carbonCluster.memberAdded(member);
-            log.info("Member joined [" + member.getUuid() + "]: " + member.getInetSocketAddress().toString());
+            log.info("Member joined [" + member.getUuid() + "]: " + member.getSocketAddress().toString());
             // Wait for sometime for the member to completely join before replaying messages
             try {
                 Thread.sleep(5000);
@@ -82,12 +85,8 @@ public class GeneralMembershipScheme implements HazelcastMembershipScheme {
         public void memberRemoved(MembershipEvent membershipEvent) {
             Member member = membershipEvent.getMember();
             carbonCluster.memberRemoved(member);
-            log.info("Member left [" + member.getUuid() + "]: " + member.getInetSocketAddress().toString());
+            log.info("Member left [" + member.getUuid() + "]: " + member.getSocketAddress().toString());
             members.remove(member.getUuid());
-        }
-
-        @Override
-        public void memberAttributeChanged(MemberAttributeEvent memberAttributeEvent) {
         }
 
     }

--- a/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/clustering/hazelcast/kubernetes/KubernetesConstants.java
+++ b/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/clustering/hazelcast/kubernetes/KubernetesConstants.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.com).
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.core.clustering.hazelcast.kubernetes;
+
+/**
+ * Constants used by the Kubernetes membership schema implementation.
+ */
+public class KubernetesConstants {
+
+    public static final String NAMESPACE_PROPERTY = "KUBERNETES_NAMESPACE";
+    public static final String NAMESPACE = "namespace";
+
+    public static final String SERVICE_NAME_PROPERTY = "KUBERNETES_SERVICES";
+    public static final String SERVICE_NAME = "service-name";
+
+    public static final String SERVICE_PORT = "service-port";
+}

--- a/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/clustering/hazelcast/kubernetes/KubernetesMembershipScheme.java
+++ b/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/clustering/hazelcast/kubernetes/KubernetesMembershipScheme.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.com).
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.core.clustering.hazelcast.kubernetes;
+
+import com.hazelcast.cluster.Member;
+import com.hazelcast.cluster.MembershipEvent;
+import com.hazelcast.cluster.MembershipListener;
+import com.hazelcast.config.Config;
+import com.hazelcast.config.NetworkConfig;
+import com.hazelcast.config.TcpIpConfig;
+import com.hazelcast.core.HazelcastInstance;
+import org.apache.axis2.clustering.ClusteringMessage;
+import org.apache.axis2.description.Parameter;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.core.clustering.hazelcast.HazelcastCarbonClusterImpl;
+import org.wso2.carbon.core.clustering.hazelcast.HazelcastConstants;
+import org.wso2.carbon.core.clustering.hazelcast.HazelcastMembershipScheme;
+import org.wso2.carbon.core.clustering.hazelcast.HazelcastUtil;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Registering the configurations required for Hazelcast auto discovery plugin in kubernetes and define membership schemes.
+ */
+public class KubernetesMembershipScheme implements HazelcastMembershipScheme {
+
+    private static final Log log = LogFactory.getLog(KubernetesMembershipScheme.class);
+
+    private final Map<String, Parameter> parameters;
+    private final NetworkConfig nwConfig;
+    private final List<ClusteringMessage> messageBuffer;
+    private HazelcastInstance primaryHazelcastInstance;
+    private HazelcastCarbonClusterImpl carbonCluster;
+
+    public KubernetesMembershipScheme(Map<String, Parameter> parameters, String primaryDomain, Config config,
+                                      HazelcastInstance primaryHazelcastInstance, List<ClusteringMessage> messageBuffer) {
+
+        this.parameters = parameters;
+        this.primaryHazelcastInstance = primaryHazelcastInstance;
+        this.messageBuffer = messageBuffer;
+        this.nwConfig = config.getNetworkConfig();
+    }
+
+    @Override
+    public void setPrimaryHazelcastInstance(HazelcastInstance primaryHazelcastInstance) {
+
+        this.primaryHazelcastInstance = primaryHazelcastInstance;
+    }
+
+    @Override
+    public void setLocalMember(Member localMember) {
+
+    }
+
+    @Override
+    public void setCarbonCluster(HazelcastCarbonClusterImpl hazelcastCarbonCluster) {
+
+        this.carbonCluster = hazelcastCarbonCluster;
+    }
+
+    @Override
+    public void init() {
+
+        String localMemberPort = "4000";
+        Parameter namespace = getParameter(KubernetesConstants.NAMESPACE_PROPERTY);
+        Parameter serviceName = getParameter(KubernetesConstants.SERVICE_NAME_PROPERTY);
+
+        log.info("Initializing kubernetes membership scheme...");
+        nwConfig.getJoin().getMulticastConfig().setEnabled(false);
+        nwConfig.getJoin().getAwsConfig().setEnabled(false);
+        nwConfig.getJoin().getKubernetesConfig().setEnabled(true);
+
+        Parameter localMemberPortParam = getParameter(HazelcastConstants.LOCAL_MEMBER_PORT);
+        if (localMemberPortParam != null) {
+            localMemberPort = ((String) localMemberPortParam.getValue()).trim();
+            nwConfig.getJoin().getKubernetesConfig().setProperty(KubernetesConstants.SERVICE_PORT, localMemberPort);
+        } else {
+            nwConfig.getJoin().getKubernetesConfig().setProperty(KubernetesConstants.SERVICE_PORT, localMemberPort);
+        }
+
+        if (namespace != null) {
+            nwConfig.getJoin().getKubernetesConfig().setProperty(KubernetesConstants.NAMESPACE, ((String) namespace.getValue()).trim());
+        }
+        if (serviceName != null) {
+            nwConfig.getJoin().getKubernetesConfig().setProperty(KubernetesConstants.SERVICE_NAME, ((String) serviceName.getValue()).trim());
+        }
+    }
+
+    @Override
+    public void joinGroup() {
+
+        primaryHazelcastInstance.getCluster().addMembershipListener(new KubernetesMembershipSchemeListener());
+    }
+
+    private Parameter getParameter(String name) {
+
+        return parameters.get(name);
+    }
+
+    /**
+     * Kubernetes membership scheme listener
+     */
+    private class KubernetesMembershipSchemeListener implements MembershipListener {
+
+        @Override
+        public void memberAdded(MembershipEvent membershipEvent) {
+
+            Member member = membershipEvent.getMember();
+            TcpIpConfig tcpIpConfig = nwConfig.getJoin().getTcpIpConfig();
+            List<String> memberList = tcpIpConfig.getMembers();
+            if (!memberList.contains(member.getSocketAddress().getAddress().getHostAddress())) {
+                tcpIpConfig.addMember(String.valueOf(member.getSocketAddress().getAddress().getHostAddress()));
+            }
+
+            // Send all cluster messages.
+            carbonCluster.memberAdded(member);
+            log.info(String.format("Member joined: [UUID] %s, [Address] %s", member.getUuid(),
+                    member.getSocketAddress().toString()));
+            // Wait for sometime for the member to completely join before replaying messages.
+            try {
+                Thread.sleep(5000);
+            } catch (InterruptedException ignored) {
+            }
+            HazelcastUtil.sendMessagesToMember(messageBuffer, member, carbonCluster);
+            if (log.isDebugEnabled()) {
+                log.debug(String.format("Current member list: %s", tcpIpConfig.getMembers()));
+            }
+        }
+
+        @Override
+        public void memberRemoved(MembershipEvent membershipEvent) {
+
+            Member member = membershipEvent.getMember();
+            carbonCluster.memberRemoved(member);
+            TcpIpConfig tcpIpConfig = nwConfig.getJoin().getTcpIpConfig();
+            String memberIp = member.getSocketAddress().getAddress().getHostAddress();
+
+            tcpIpConfig.getMembers().remove(memberIp);
+            log.info(String.format("Member left: [UUID] %s, [Address] %s", member.getUuid(),
+                    member.getSocketAddress().toString()));
+            if (log.isDebugEnabled()) {
+                log.debug(String.format("Current member list: %s", tcpIpConfig.getMembers()));
+            }
+        }
+    }
+}

--- a/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/clustering/hazelcast/multicast/MulticastBasedMembershipScheme.java
+++ b/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/clustering/hazelcast/multicast/MulticastBasedMembershipScheme.java
@@ -19,10 +19,9 @@ package org.wso2.carbon.core.clustering.hazelcast.multicast;
 
 import com.hazelcast.config.MulticastConfig;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.core.Member;
-import com.hazelcast.core.MembershipEvent;
-import com.hazelcast.core.MemberAttributeEvent;
-import com.hazelcast.core.MembershipListener;
+import com.hazelcast.cluster.Member;
+import com.hazelcast.cluster.MembershipEvent;
+import com.hazelcast.cluster.MembershipListener;
 import org.apache.axis2.clustering.ClusteringFault;
 import org.apache.axis2.clustering.ClusteringMessage;
 import org.apache.axis2.description.Parameter;
@@ -123,7 +122,7 @@ public class MulticastBasedMembershipScheme implements HazelcastMembershipScheme
 
             // send all cluster messages
             carbonCluster.memberAdded(member);
-            log.info("Member joined [" + member.getUuid() + "]: " + member.getInetSocketAddress().toString());
+            log.info("Member joined [" + member.getUuid() + "]: " + member.getSocketAddress().toString());
             // Wait for sometime for the member to completely join before replaying messages
             try {
                 Thread.sleep(5000);
@@ -136,13 +135,8 @@ public class MulticastBasedMembershipScheme implements HazelcastMembershipScheme
         public void memberRemoved(MembershipEvent membershipEvent) {
             Member member = membershipEvent.getMember();
             carbonCluster.memberRemoved(member);
-            log.info("Member left [" + member.getUuid() + "]: " + member.getInetSocketAddress().toString());
+            log.info("Member left [" + member.getUuid() + "]: " + member.getSocketAddress().toString());
             members.remove(member.getUuid());
         }
-
-        @Override
-        public void memberAttributeChanged(MemberAttributeEvent memberAttributeEvent) {
-        }
-
     }
 }

--- a/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/clustering/hazelcast/util/MemberUtils.java
+++ b/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/clustering/hazelcast/util/MemberUtils.java
@@ -19,7 +19,7 @@ package org.wso2.carbon.core.clustering.hazelcast.util;
 
 import com.hazelcast.config.TcpIpConfig;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.core.IMap;
+import com.hazelcast.map.IMap;
 import org.apache.axiom.om.OMAttribute;
 import org.apache.axiom.om.OMElement;
 import org.apache.axis2.clustering.ClusteringConstants;

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -499,7 +499,7 @@
 
         <version.eclipse.ecj>4.4.2</version.eclipse.ecj>
 
-        <orbit.version.hazelcast>4.2.4.wso2v1</orbit.version.hazelcast>
+        <orbit.version.hazelcast>4.2.5.wso2v1</orbit.version.hazelcast>
         <version.apacheds.shared.ldap>0.9.18</version.apacheds.shared.ldap>
 
         <!-- hibernate -->

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -499,7 +499,7 @@
 
         <version.eclipse.ecj>4.4.2</version.eclipse.ecj>
 
-        <orbit.version.hazelcast>3.12.2.wso2v2</orbit.version.hazelcast>
+        <orbit.version.hazelcast>4.2.4.wso2v1</orbit.version.hazelcast>
         <version.apacheds.shared.ldap>0.9.18</version.apacheds.shared.ldap>
 
         <!-- hibernate -->


### PR DESCRIPTION
## Purpose
$subject

### Related Issues
- https://github.com/wso2/product-is/issues/13647

Hazelcast auto discovery plugin for Kubernetes is used for member discovery. More details on the configurations can be found here. https://github.com/hazelcast/hazelcast-kubernetes

The Hazelcast upgrade from 3.12.x to 4.2.x included following API changes.

- [x] ILock API is deprecated after introduction of CP subsystem to Hazelcast. 

![Screenshot 2022-05-11 at 11 23 26](https://user-images.githubusercontent.com/35717390/167779895-a7103549-9a15-4a60-be80-8b21d54a177e.png)

   - Migrate "com.hazelcast.core.ILock" to "com.hazelcast.cp.lock.FencedLock"
   - Create lock object via cpSubsystem. ( FencedLock lock = hazelcastInstance.getCPSubsystem().getLock("lock") )
   
- [x] AWS programmatic configuration has been merged with a more universal configuration infrastructure common to all cloud providers.

![Screenshot 2022-05-11 at 11 51 52](https://user-images.githubusercontent.com/35717390/167782177-c907543a-ccce-41d8-a861-49088eab3c39.png)

- [x] The Member class has been moved from "com.hazelcast.core.Member" to "com.hazelcast.cluster.Member". 
        -  "getInetSocketAddress" method is refactored to "getSocketAddress"
        -  "getUuid" method return UUID object instead of String object 
        
- [x] Member attribute setter methods have changed to "setAttribute" method

![Screenshot 2022-05-11 at 12 43 03](https://user-images.githubusercontent.com/35717390/167790696-a968719c-143e-4351-8efd-0702bebd9fdb.png)![Screenshot 2022-05-11 at 12 38 48](https://user-images.githubusercontent.com/35717390/167790250-914252f1-e3b8-4858-a3d5-e00957b19be5.png)

- [x] The GroupConfig class has been removed. Both the client and member configurations have the GroupConfig (or <group> in XML) replaced by a simple cluster name configuration.

![Screenshot 2022-05-11 at 12 49 19](https://user-images.githubusercontent.com/35717390/167791788-f64040c9-27be-45af-afd2-5cd8eb6b9e5c.png)

- [x] MembershipListener interface has exclude "memberAttributeChanged" method.

<img width="1367" alt="Screenshot 2022-05-11 at 13 02 05" src="https://user-images.githubusercontent.com/35717390/167794168-414551af-50d0-4228-b8b4-e693bacb88e1.png">


- [x] IMAP class moved to com.hazelcast.map from com.hazelcast.core

![Screenshot 2022-05-11 at 11 14 26](https://user-images.githubusercontent.com/35717390/167777322-93bc87d9-a405-4701-878a-cae0deda208c.png)

- [x] Configure Hazelcast auto discovery plugin for Kubernetes

![Screenshot 2022-05-11 at 11 54 03](https://user-images.githubusercontent.com/35717390/167782467-55815d74-4e13-4913-9cf7-f35ee4b090d1.png)

