### PR TITLE
Update parent/pom.xml to fix artifacts not picking the version correctly due to errors in the pom

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -1231,7 +1231,7 @@
             <dependency>
                 <groupId>xmlunit</groupId>
                 <artifactId>xmlunit</artifactId>
-                <version>${xmlunit}</version>
+                <version>${version.xmlunit}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.axis2</groupId>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -1221,7 +1221,7 @@
             <dependency>
                 <groupId>org.wso2.orbit.org.apache.poi</groupId>
                 <artifactId>poi-ooxml</artifactId>
-                <version>orbit.version.poi.ooxml</version>
+                <version>${orbit.version.poi.ooxml}</version>
             </dependency>
             <dependency>
                 <groupId>junit</groupId>


### PR DESCRIPTION
## Purpose
Fixing following errors related to version elements in parent/pom.xml
- Version of **poi-ooxml** artifact is not picked correctly. Included the defined version property _orbit.version.poi.ooxml_ **within ${}**, as it was previously missing.
- Incorrect version property referenced for **xmlunit** artifact. Referenced the right version property.

## Goals
To ensure custom component dependent on this parent/pom.xml do not fail when trying to pull and resolve those artifacts above.

### Issue https://github.com/wso2/carbon-kernel/issues/3296