### PR TITLE
Fixed the multi attribute filtering with identity and user claims issue with JDBC userstores.

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
@@ -15575,7 +15575,7 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
 
             for (String username : identityClaimFilteredUserNames) {
                 User user = getUser(getUserIDFromUserName(username), username);
-                user.setUserStoreDomain(UserCoreUtil.extractDomainFromName(user.getUsername()));
+                user.setUserStoreDomain(UserCoreUtil.extractDomainFromName(username));
                 identityClaimFilteredUsers.add(user);
             }
 


### PR DESCRIPTION


## Purpose
Fixes issue [Multi-attribute filtering with identity claims and default claims not functioning for JDBC user stores ](https://github.com/wso2/product-is/issues/13673) product-is#13673, where we are unable to perform filtering with both identity claims (in a h2 database) and user claims with JDBC user stores.

## Goals
To be able to filter with both identity claims and user claims when identity claims are stored in a h2 database and user claims in a JDBC user store.

## Approach
The flow of the code in an instance where the identity claims are stored in an h2 database and user claims are stored in a secondary database:
1. Get a list of all usernames of users who meet the identity claim filters, from the embedded h2 database.
2. Create separate user objects based off the usernames retrieved, and add them to a list.
3. Search for users that match the user claim filters from the secondary user store.
4. Intersect the data from identity store and secondary user store to get the results.

The issue was with Step 2. Create user objects.

The getUser method would: Remove the domain name from the username and add it as a seperate attribute inside the user object.
Then when calling the extractDomainFromName(user.getUsername()) method in the next line, the username would be just the name without the domain as it has already been detached by the getUser method. Therefore as the extractDomainFromName method doesn't detect a domain, it sets the domain to PRIMARY. When intersecting records and checking if the usernames match, because the domains are different, they will not match, thus returning 0 results. 

It was functional with LDAP because the method would default and set the domain to PRIMARY as it didn't have a secondary domain with the username.

The solution:
1. Entirely remove the line: user.setUserStoreDomain(UserCoreUtil.extractDomainFromName(user.getUsername()));
2. Instead of passing user.getUsername, we can pass in the username from the for loop, which contains the domain as well.

I opted to go for option 2, as there may be situations where extractDomainFromUserName is needed, as it checks the RealmConfig.

Change which caused the issue: https://github.com/wso2/carbon-kernel/commit/6d1fbf7027b9e8ee3ef78496b107a7d142f41d84

## Test environment
Product Version: wso2is-5.12.0-beta2-SNAPSHOT
OS: Ubuntu Linux
Database: h2 database, MySQL.
Userstore: LDAP, JDBC