### PR TITLE
Fixed issue of getting 0 results from MySQL db when filtering with 2+ identity claims. 

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCUserStoreManager.java
@@ -3600,7 +3600,7 @@ public class UniqueIDJDBCUserStoreManager extends JDBCUserStoreManager {
             } else if (groupFilterCount > 0) {
                 sqlBuilder.updateSql(" HAVING COUNT(DISTINCT R.UM_ROLE_NAME) = " + groupFilterCount);
             } else if (claimFilterCount > 0) {
-                sqlBuilder.updateSql(" HAVING COUNT(DISTINCT UA.UM_ATTR_VALUE) = " + claimFilterCount);
+                sqlBuilder.updateSql(" HAVING COUNT(DISTINCT UA.UM_ATTR_NAME) = " + claimFilterCount);
             }
         }
 


### PR DESCRIPTION
## Purpose
Fixes the issue where a MySQL database which stores identity claims returns 0 results when filtering with 2 or more identity claims (eg: filter: urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.accountLocked eq true and urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.accountDisabled eq true)
Resolves issue: https://github.com/wso2/product-is/issues/13720

## Goals
To get valid results from a MySQL database when filtering with 2 or more identity claims. 

## Fix
From the database we need to count the UM_ATTR_NAME instead of the UM_ATTR_VALUE.