### PR TITLE
[4.6.x] Upgrade jstl to 1.2.1.wso2v3

### DIFF
--- a/core/org.wso2.carbon.ui/pom.xml
+++ b/core/org.wso2.carbon.ui/pom.xml
@@ -129,7 +129,7 @@
             <artifactId>org.wso2.carbon.core.commons.stub</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.servlet.jsp.jstl.wso2</groupId>
+            <groupId>org.wso2.orbit.javax.servlet.jsp.jstl</groupId>
             <artifactId>jstl</artifactId>
             <exclusions>
                 <exclusion>

--- a/features/org.wso2.carbon.core.ui.feature/pom.xml
+++ b/features/org.wso2.carbon.core.ui.feature/pom.xml
@@ -63,7 +63,7 @@
                                 <bundleDef>org.wso2.carbon:org.wso2.carbon.feature.mgt.stub:${carbon.kernel.version}</bundleDef>
                                 <bundleDef>org.wso2.carbon:org.wso2.carbon.roles.mgt.ui:${carbon.kernel.version}</bundleDef>
                                 <bundleDef>org.wso2.carbon:org.wso2.carbon.roles.mgt.stub:${carbon.kernel.version}</bundleDef>
-                                <bundleDef>javax.servlet.jsp.jstl.wso2:jstl:${orbit.version.jstl}</bundleDef>
+                                <bundleDef>org.wso2.orbit.javax.servlet.jsp.jstl:jstl:${orbit.version.jstl}</bundleDef>
                                 <bundleDef>org.wso2.orbit.org.owasp.encoder:encoder:${orbit.version.encoder}</bundleDef>
                                 <bundleDef>org.wso2.orbit.org.owasp:csrfguard:${orbit.version.csrfguard}</bundleDef>
                             </bundles>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -392,7 +392,7 @@
 
         <!-- JSTL -->
         <version.jstl>1.2.1</version.jstl>
-        <orbit.version.jstl>1.2.1.wso2v2</orbit.version.jstl>
+        <orbit.version.jstl>1.2.1.wso2v3</orbit.version.jstl>
         <exp.pkg.version.javax.servlet.jsp.jstl>1.2.1</exp.pkg.version.javax.servlet.jsp.jstl>
         <imp.pkg.version.javax.servlet.jsp.jstl>[1.2.1, 1.3.0)</imp.pkg.version.javax.servlet.jsp.jstl>
 
@@ -1367,7 +1367,7 @@
                 <version>${carbon.kernel.version}</version>
             </dependency>
             <dependency>
-                <groupId>javax.servlet.jsp.jstl.wso2</groupId>
+                <groupId>org.wso2.orbit.javax.servlet.jsp.jstl</groupId>
                 <artifactId>jstl</artifactId>
                 <version>${orbit.version.jstl}</version>
             </dependency>


### PR DESCRIPTION
## Purpose
This PR upgrades the jstl version to `1.2.1.wso2v3`.

Related PR: https://github.com/wso2/orbit/pull/686