### PR TITLE
Fixed SQL for identity claim filtering in a DB2 type database.

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCUserStoreManager.java
@@ -3508,7 +3508,7 @@ public class UniqueIDJDBCUserStoreManager extends JDBCUserStoreManager {
             if (DB2.equals(dbType)) {
                 sqlStatement = new StringBuilder(
                         "SELECT UM_USER_ID, UM_USER_NAME FROM (SELECT ROW_NUMBER() OVER (ORDER BY "
-                                + "UM_USER_NAME) AS rn, p* FROM (SELECT DISTINCT U.UM_USER_ID, " +
+                                + "UM_USER_NAME) AS rn, p.* FROM (SELECT DISTINCT U.UM_USER_ID, " +
                                 "U.UM_USER_NAME FROM UM_USER U INNER JOIN UM_USER_ATTRIBUTE UA ON " +
                                 "U.UM_ID = UA.UM_USER_ID");
             } else if (MSSQL.equals(dbType)) {

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCUserStoreManager.java
@@ -3507,8 +3507,8 @@ public class UniqueIDJDBCUserStoreManager extends JDBCUserStoreManager {
         } else if (isUsernameFiltering && isClaimFiltering || isClaimFiltering) {
             if (DB2.equals(dbType)) {
                 sqlStatement = new StringBuilder(
-                        "SELECT UM_USER_ID, UM_USER_NAME FROM (SELECT ROW_NUMBER() OVER (ORDER BY "
-                                + "UM_USER_NAME) AS rn, p.* FROM (SELECT DISTINCT U.UM_USER_ID, " +
+                        "SELECT UM_USER_ID, UM_USER_NAME FROM (SELECT ROW_NUMBER() OVER (ORDER BY " +
+                                "UM_USER_NAME) AS rn, UM_USER_ID, UM_USER_NAME FROM (SELECT DISTINCT U.UM_USER_ID, " +
                                 "U.UM_USER_NAME FROM UM_USER U INNER JOIN UM_USER_ATTRIBUTE UA ON " +
                                 "U.UM_ID = UA.UM_USER_ID");
             } else if (MSSQL.equals(dbType)) {

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCUserStoreManager.java
@@ -3508,7 +3508,7 @@ public class UniqueIDJDBCUserStoreManager extends JDBCUserStoreManager {
             if (DB2.equals(dbType)) {
                 sqlStatement = new StringBuilder(
                         "SELECT UM_USER_ID, UM_USER_NAME FROM (SELECT ROW_NUMBER() OVER (ORDER BY "
-                                + "UM_USER_NAME) AS rn, UM_USER_ID, UM_USER_NAME FROM (SELECT DISTINCT U.UM_USER_ID, " +
+                                + "UM_USER_NAME) AS rn, p* FROM (SELECT DISTINCT U.UM_USER_ID, " +
                                 "U.UM_USER_NAME FROM UM_USER U INNER JOIN UM_USER_ATTRIBUTE UA ON " +
                                 "U.UM_ID = UA.UM_USER_ID");
             } else if (MSSQL.equals(dbType)) {
@@ -3621,7 +3621,7 @@ public class UniqueIDJDBCUserStoreManager extends JDBCUserStoreManager {
             if (DB2.equals(dbType)) {
                 if (isClaimFiltering && !isGroupFiltering && totalMultiClaimFilters > 1) {
                     // Handle multi attribute filtering without group filtering.
-                    sqlBuilder.setTail(") AS Q) AS S) AS R) AS p WHERE P.rn BETWEEN ? AND ?", limit, offset);
+                    sqlBuilder.setTail(") AS Q) AS S) AS R) AS p WHERE p.rn BETWEEN ? AND ?", limit, offset);
                 } else {
                     sqlBuilder.setTail(") AS p) WHERE rn BETWEEN ? AND ?", limit, offset);
                 }


### PR DESCRIPTION
## Purpose
The SQL generated for DB2 identity claim filtering (single claim, multi claim and a combination of identity claim and user claim) was incorrect. Necessary changes to the SQL has been made. 

Related Issue: https://github.com/wso2/product-is/issues/13880

## Goals
Properly filter users from a DB2 type database using identity claims.

## Approach
First the changes mentioned in: https://github.com/wso2-extensions/identity-governance/pull/592 have to be merged or else we run into another issue where the request returns an empty list. After this change is made the request will reach the incorrect SQL and throw an error. With this PR, the SQL has been adjusted.

## Related PRs
https://github.com/wso2-extensions/identity-governance/pull/592 should be merged to make this change functional.

## Test environment
 - Open JDK 11
 - WSO2IS 5.12.0
 - Ubuntu Linux
 - DB2 11.5.7.0
