### PR TITLE
Fixed issue where Oracle database results were not ordered when filtering with multiple identity claims

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCUserStoreManager.java
@@ -3629,6 +3629,9 @@ public class UniqueIDJDBCUserStoreManager extends JDBCUserStoreManager {
             } else if (ORACLE.equals(dbType)) {
                 if (isClaimFiltering && !isGroupFiltering && totalMultiClaimFilters > 1) {
                     StringBuilder brackets = new StringBuilder(")");
+                    // x = 2 --> Any Oracle query will begin with 2 opening brackets
+                    // x <= (totalMultiClaimFilters * 2) - 2 --> 2 is deducted as there are 2 closing brackets in the
+                    // setTail section below.
                     for (int x = 2; x <= (totalMultiClaimFilters * 2) - 2; x++) {
                         brackets = brackets.append(" )");
                     }

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCUserStoreManager.java
@@ -3628,12 +3628,13 @@ public class UniqueIDJDBCUserStoreManager extends JDBCUserStoreManager {
                 }
             } else if (ORACLE.equals(dbType)) {
                 if (isClaimFiltering && !isGroupFiltering && totalMultiClaimFilters > 1) {
-                    String brackets = ")";
+                    StringBuilder brackets = new StringBuilder(")");
                     for (int x = 2; x <= (totalMultiClaimFilters * 2) - 2; x++) {
-                        brackets = brackets + " )";
+                        brackets = brackets.append(" )");
                     }
                     // Handle multi attribute filtering without group filtering.
-                    sqlBuilder.setTail(brackets + "ORDER BY UM_USER_NAME ) where rownum <= ?) WHERE  rnum > ?", limit, offset);
+                    sqlBuilder.setTail(brackets.toString()
+                            .concat("ORDER BY UM_USER_NAME ) where rownum <= ?) WHERE  rnum > ?"), limit, offset);
                 } else {
                     sqlBuilder.setTail(" ORDER BY UM_USER_NAME) where rownum <= ?) WHERE  rnum > ?", limit, offset);
                 }

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCUserStoreManager.java
@@ -3629,7 +3629,7 @@ public class UniqueIDJDBCUserStoreManager extends JDBCUserStoreManager {
             } else if (ORACLE.equals(dbType)) {
                 if (isClaimFiltering && !isGroupFiltering && totalMultiClaimFilters > 1) {
                     String brackets = ")";
-                    for (int x = 2; x <= (totalMultiClaimFilters*2) - 2; x++) {
+                    for (int x = 2; x <= (totalMultiClaimFilters * 2) - 2; x++) {
                         brackets = brackets + " )";
                     }
                     // Handle multi attribute filtering without group filtering.

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCUserStoreManager.java
@@ -3629,11 +3629,14 @@ public class UniqueIDJDBCUserStoreManager extends JDBCUserStoreManager {
             } else if (ORACLE.equals(dbType)) {
                 if (isClaimFiltering && !isGroupFiltering && totalMultiClaimFilters > 1) {
                     StringBuilder brackets = new StringBuilder(")");
-                    // x = 2 --> Any Oracle query will begin with 2 opening brackets
-                    // x <= (totalMultiClaimFilters * 2) - 2 --> totalMultiClaims are multiplied by 2 as 2 new opening
-                    // brackets are created for every new claim.
-                    // 2 is deducted as there are 2 closing brackets in the setTail section below.
-                    for (int x = 2; x <= (totalMultiClaimFilters * 2) - 2; x++) {
+                    /*
+                     * x is used to count the number of brackets
+                     * (totalMultiClaimFilters * 2) --> totalMultiClaims are multiplied by 2 as 2 new opening
+                     * brackets are created for every new claim, which needs to be closed at the right position.
+                     * (totalMultiClaimFilters * 2) - 4 is deducted as there are 2 opening brackets in the SQL query
+                     *  and 2 closing brackets in the setTail section below.
+                     */
+                    for (int x = 0; x <= (totalMultiClaimFilters * 2) - 4; x++) {
                         brackets = brackets.append(" )");
                     }
                     // Handle multi attribute filtering without group filtering.

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCUserStoreManager.java
@@ -3627,7 +3627,16 @@ public class UniqueIDJDBCUserStoreManager extends JDBCUserStoreManager {
                     sqlBuilder.setTail(") AS R) AS P WHERE P.RowNum BETWEEN ? AND ?", limit, offset);
                 }
             } else if (ORACLE.equals(dbType)) {
-                sqlBuilder.setTail(" ORDER BY UM_USER_NAME) where rownum <= ?) WHERE  rnum > ?", limit, offset);
+                if (isClaimFiltering && !isGroupFiltering && totalMultiClaimFilters > 1) {
+                    String brackets = ")";
+                    for (int x = 2; x <= (totalMultiClaimFilters*2) - 2; x++) {
+                        brackets = brackets + " )";
+                    }
+                    // Handle multi attribute filtering without group filtering.
+                    sqlBuilder.setTail(brackets + "ORDER BY UM_USER_NAME ) where rownum <= ?) WHERE  rnum > ?", limit, offset);
+                } else {
+                    sqlBuilder.setTail(" ORDER BY UM_USER_NAME) where rownum <= ?) WHERE  rnum > ?", limit, offset);
+                }
             } else {
                 sqlBuilder.setTail(" ORDER BY UM_USER_NAME ASC LIMIT ? OFFSET ?", limit, offset);
             }

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCUserStoreManager.java
@@ -3630,8 +3630,9 @@ public class UniqueIDJDBCUserStoreManager extends JDBCUserStoreManager {
                 if (isClaimFiltering && !isGroupFiltering && totalMultiClaimFilters > 1) {
                     StringBuilder brackets = new StringBuilder(")");
                     // x = 2 --> Any Oracle query will begin with 2 opening brackets
-                    // x <= (totalMultiClaimFilters * 2) - 2 --> 2 is deducted as there are 2 closing brackets in the
-                    // setTail section below.
+                    // x <= (totalMultiClaimFilters * 2) - 2 --> totalMultiClaims are multiplied by 2 as 2 new opening
+                    // brackets are created for every new claim.
+                    // 2 is deducted as there are 2 closing brackets in the setTail section below.
                     for (int x = 2; x <= (totalMultiClaimFilters * 2) - 2; x++) {
                         brackets = brackets.append(" )");
                     }


### PR DESCRIPTION
## Purpose
To fix the issue where, when filtering users by 2+ identity claims (such as accountLock, accountDisabled, accountState) from an Oracle database, the results received were not in order of UM_USER_NAME.
Resolves issue: https://github.com/wso2/product-is/issues/13883

## Approach
The issue was with the closing of brackets when generating the SQL statement. The fix identifies the number of Identity claims that the request filters by and adds closing brackets appropriately, such that the order by is done at the correct level.

## Related PRs
https://github.com/wso2-extensions/identity-governance/pull/592 should be merged to make this change functional.


## Test environment

- Open JDK 11
- WSO2IS 5.12.0
- Ubuntu Linux
- Oracle 19.3.0-ee
