### PR TITLE
Change SearchBase prefixes appended to the` base_dn` for AD userstores

### DIFF
--- a/distribution/kernel/carbon-home/repository/resources/conf/infer.json
+++ b/distribution/kernel/carbon-home/repository/resources/conf/infer.json
@@ -159,8 +159,8 @@
     "active_directory": {
       "user_store.class": "org.wso2.carbon.user.core.ldap.ActiveDirectoryUserStoreManager",
       "user_store.properties.TenantManager": "org.wso2.carbon.user.core.tenant.CommonHybridLDAPTenantManager",
-      "user_store.properties.UserSearchBase": "ou=Users,$ref{user_store.base_dn}",
-      "user_store.properties.GroupSearchBase": "ou=Groups,$ref{user_store.base_dn}",
+      "user_store.properties.UserSearchBase": "cn=Users,$ref{user_store.base_dn}",
+      "user_store.properties.GroupSearchBase": "cn=Groups,$ref{user_store.base_dn}",
       "user_store.properties.AnonymousBind": false,
       "user_store.properties.UserEntryObjectClass": "identityPerson",
       "user_store.properties.UserNameAttribute": "uid",
@@ -198,8 +198,8 @@
     "active_directory_unique_id": {
       "user_store.class": "org.wso2.carbon.user.core.ldap.UniqueIDActiveDirectoryUserStoreManager",
       "user_store.properties.TenantManager": "org.wso2.carbon.user.core.tenant.CommonHybridLDAPTenantManager",
-      "user_store.properties.UserSearchBase": "ou=Users,$ref{user_store.base_dn}",
-      "user_store.properties.GroupSearchBase": "ou=Groups,$ref{user_store.base_dn}",
+      "user_store.properties.UserSearchBase": "cn=Users,$ref{user_store.base_dn}",
+      "user_store.properties.GroupSearchBase": "cn=Groups,$ref{user_store.base_dn}",
       "user_store.properties.AnonymousBind": false,
       "user_store.properties.UserEntryObjectClass": "identityPerson",
       "user_store.properties.UserNameAttribute": "cn",


### PR DESCRIPTION
## Purpose
When configuring Active Directory as the primary userstore, for UserSearchBase and GroupSearchBase the prefix `ou=Users` is added to the base_dn at the infer.json file. But default AD has User object inside containers instead of organizational units. Therefore the prefix should be changed to "CN" instead of "OU".

Resolves: https://github.com/wso2/product-is/issues/13765

## Documentation
Doc PR: https://github.com/wso2/docs-is/pull/3027

