### PR TITLE
Resolve adminUUID only if the tenant is not created from org-mgt path

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/tenant/JDBCTenantManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/tenant/JDBCTenantManager.java
@@ -802,8 +802,12 @@ public class JDBCTenantManager implements TenantManager {
                 tenant.setRealmConfig(realmConfig);
                 setSecondaryUserStoreConfig(realmConfig, id);
                 tenant.setAdminName(realmConfig.getAdminUserName());
-                tenant.setAdminUserId(getUserId(realmConfig.getAdminUserName(), id));
-
+                // Handle the admin UUID resolution properly with https://github.com/wso2/product-is/issues/14001.
+                if (StringUtils.isNotBlank(tenant.getAssociatedOrganizationUUID())) {
+                    tenant.setAdminUserId(realmConfig.getAdminUserName());
+                } else {
+                    tenant.setAdminUserId(getUserId(realmConfig.getAdminUserName(), id));
+                }
                 if (log.isDebugEnabled()) {
                     log.debug("Obtained tenant from database for the given UUID: " + uniqueId
                             + ", hence adding tenant to cache where tenantDomain: {" + domain + "}");


### PR DESCRIPTION
## Purpose
Part of fix https://github.com/wso2/product-is/issues/13959

With https://github.com/wso2/product-is/issues/13959, we save only org creator's UUID. 
`getUserId(tenantawareUsername, tenantID)` method can't be used for admin UUID resolution. 
As a temporary fix, if the tenant is created from org-mgt flow (if tenant.getAssociatedOrganizationUUID() is not blank) take the saved UUID as admin name will be set as userID

Properly handle it in https://github.com/wso2/product-is/issues/14001