### PR TITLE
[4.7.x] Using tomcat dbcp2 instead of commons dbcp

### DIFF
--- a/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/util/PasswordUpdater.java
+++ b/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/util/PasswordUpdater.java
@@ -16,7 +16,7 @@
 
 package org.wso2.carbon.core.util;
 
-import org.apache.commons.dbcp.BasicDataSource;
+import org.apache.tomcat.dbcp.dbcp2.BasicDataSource;
 import org.wso2.carbon.user.api.RealmConfiguration;
 import org.wso2.carbon.user.core.UserStoreException;
 import org.wso2.carbon.user.core.UserStoreManager;

--- a/core/org.wso2.carbon.registry.core/src/main/java/org/wso2/carbon/registry/core/jdbc/realm/InMemoryRealmService.java
+++ b/core/org.wso2.carbon.registry.core/src/main/java/org/wso2/carbon/registry/core/jdbc/realm/InMemoryRealmService.java
@@ -18,7 +18,7 @@
  */
 package org.wso2.carbon.registry.core.jdbc.realm;
 
-import org.apache.commons.dbcp.BasicDataSource;
+import org.apache.tomcat.dbcp.dbcp2.BasicDataSource;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.base.MultitenantConstants;

--- a/core/org.wso2.carbon.registry.core/src/main/java/org/wso2/carbon/registry/core/jdbc/utils/RegistryDataSource.java
+++ b/core/org.wso2.carbon.registry.core/src/main/java/org/wso2/carbon/registry/core/jdbc/utils/RegistryDataSource.java
@@ -16,7 +16,7 @@
 
 package org.wso2.carbon.registry.core.jdbc.utils;
 
-import org.apache.commons.dbcp.BasicDataSource;
+import org.apache.tomcat.dbcp.dbcp2.BasicDataSource;
 import org.wso2.carbon.registry.core.config.DataBaseConfiguration;
 import org.wso2.carbon.registry.core.dataaccess.DataAccessManager;
 
@@ -57,15 +57,15 @@ public class RegistryDataSource implements DataSource {
         basicDataSource.setPassword(config.getResolvedPassword());
 
         if (config.getMaxActive() != null) {
-            basicDataSource.setMaxActive(Integer.parseInt(config.getMaxActive()));
+            basicDataSource.setMaxTotal(Integer.parseInt(config.getMaxActive() + config.getMaxIdle()));
         } else {
-            basicDataSource.setMaxActive(DEFAULT_MAX_ACTIVE);
+            basicDataSource.setMaxTotal(DEFAULT_MAX_ACTIVE);
         }
 
         if (config.getMaxWait() != null) {
-            basicDataSource.setMaxWait(Integer.parseInt(config.getMaxWait()));
+            basicDataSource.setMaxWaitMillis(Integer.parseInt(config.getMaxWait()));
         } else {
-            basicDataSource.setMaxWait(DEFAULT_MAX_WAIT);
+            basicDataSource.setMaxWaitMillis(DEFAULT_MAX_WAIT);
         }
 
         if (config.getMaxIdle() != null) {

--- a/core/org.wso2.carbon.registry.core/src/main/java/org/wso2/carbon/registry/core/utils/RegistryUtils.java
+++ b/core/org.wso2.carbon.registry.core/src/main/java/org/wso2/carbon/registry/core/utils/RegistryUtils.java
@@ -218,8 +218,8 @@ public final class RegistryUtils {
             org.apache.tomcat.jdbc.pool.DataSource ds = (org.apache.tomcat.jdbc.pool.DataSource) datasource;
             connectionId = ds.getPoolProperties().getUsername() + "@" + ds.getPoolProperties().getUrl();
         }
-        if (datasource instanceof org.apache.commons.dbcp.BasicDataSource) {
-            org.apache.commons.dbcp.BasicDataSource ds = (org.apache.commons.dbcp.BasicDataSource) datasource;
+        if (datasource instanceof org.apache.tomcat.dbcp.dbcp2.BasicDataSource) {
+            org.apache.tomcat.dbcp.dbcp2.BasicDataSource ds = (org.apache.tomcat.dbcp.dbcp2.BasicDataSource) datasource;
             connectionId = ds.getUsername() + "@" + ds.getUrl();
         }
         if(log.isDebugEnabled()) {

--- a/core/org.wso2.carbon.registry.core/src/test/java/org/wso2/carbon/registry/core/test/multitenant/MultiTenantTest.java
+++ b/core/org.wso2.carbon.registry.core/src/test/java/org/wso2/carbon/registry/core/test/multitenant/MultiTenantTest.java
@@ -18,7 +18,7 @@
  */
 package org.wso2.carbon.registry.core.test.multitenant;
 
-import org.apache.commons.dbcp.BasicDataSource;
+import org.apache.tomcat.dbcp.dbcp2.BasicDataSource;
 import org.junit.BeforeClass;
 import org.wso2.carbon.context.internal.OSGiDataHolder;
 import org.wso2.carbon.registry.core.ActionConstants;

--- a/core/org.wso2.carbon.registry.core/src/test/java/org/wso2/carbon/registry/core/test/performance/BasicPerformanceTest.java
+++ b/core/org.wso2.carbon.registry.core/src/test/java/org/wso2/carbon/registry/core/test/performance/BasicPerformanceTest.java
@@ -15,7 +15,7 @@
  */
 package org.wso2.carbon.registry.core.test.performance;
 
-import org.apache.commons.dbcp.BasicDataSource;
+import org.apache.tomcat.dbcp.dbcp2.BasicDataSource;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.registry.core.test.utils.BaseTestCase;
@@ -45,7 +45,7 @@ public class BasicPerformanceTest extends BaseTestCase {
 
 //        ds.setMaxWait(1000*60*2);
 
-        ds.setMaxActive(150);
+        ds.setMaxTotal(150);
         ds.setMaxIdle(1000*60*2);
         ds.setMinIdle(5);
         //ds.setDriverClassName("net.sf.log4jdbc.DriverSpy");

--- a/core/org.wso2.carbon.user.core/pom.xml
+++ b/core/org.wso2.carbon.user.core/pom.xml
@@ -63,10 +63,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>commons-dbcp.wso2</groupId>
-            <artifactId>commons-dbcp</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.wso2.org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
@@ -74,6 +70,10 @@
             <groupId>org.wso2.orbit.org.apache.tomcat</groupId>
             <artifactId>jdbc-pool</artifactId>
             <version>${jdbc-pool.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.orbit.org.apache.tomcat</groupId>
+            <artifactId>tomcat</artifactId>
         </dependency>
         <dependency>
             <groupId>org.wso2.securevault</groupId>

--- a/core/org.wso2.carbon.user.core/src/test/java/org/wso2/carbon/user/core/authman/AdvancedPermissionTreeTest.java
+++ b/core/org.wso2.carbon.user.core/src/test/java/org/wso2/carbon/user/core/authman/AdvancedPermissionTreeTest.java
@@ -17,7 +17,7 @@
 */
 package org.wso2.carbon.user.core.authman;
 
-import org.apache.commons.dbcp.BasicDataSource;
+import org.apache.tomcat.dbcp.dbcp2.BasicDataSource;
 import org.wso2.carbon.user.api.RealmConfiguration;
 import org.wso2.carbon.user.core.AuthorizationManager;
 import org.wso2.carbon.user.core.BaseTestCase;

--- a/core/org.wso2.carbon.user.core/src/test/java/org/wso2/carbon/user/core/authman/AdvancedPermissionTreeWithIDTest.java
+++ b/core/org.wso2.carbon.user.core/src/test/java/org/wso2/carbon/user/core/authman/AdvancedPermissionTreeWithIDTest.java
@@ -17,7 +17,7 @@
 */
 package org.wso2.carbon.user.core.authman;
 
-import org.apache.commons.dbcp.BasicDataSource;
+import org.apache.tomcat.dbcp.dbcp2.BasicDataSource;
 import org.wso2.carbon.user.api.RealmConfiguration;
 import org.wso2.carbon.user.core.AuthorizationManager;
 import org.wso2.carbon.user.core.BaseTestCase;

--- a/core/org.wso2.carbon.user.core/src/test/java/org/wso2/carbon/user/core/claim/AdvancedClaimManagerTest.java
+++ b/core/org.wso2.carbon.user.core/src/test/java/org/wso2/carbon/user/core/claim/AdvancedClaimManagerTest.java
@@ -17,7 +17,7 @@
 */
 package org.wso2.carbon.user.core.claim;
 
-import org.apache.commons.dbcp.BasicDataSource;
+import org.apache.tomcat.dbcp.dbcp2.BasicDataSource;
 import org.wso2.carbon.user.core.BaseTestCase;
 import org.wso2.carbon.user.core.ClaimTestUtil;
 import org.wso2.carbon.user.core.UserCoreTestConstants;

--- a/core/org.wso2.carbon.user.core/src/test/java/org/wso2/carbon/user/core/claim/ClaimDAOTest.java
+++ b/core/org.wso2.carbon.user.core/src/test/java/org/wso2/carbon/user/core/claim/ClaimDAOTest.java
@@ -18,7 +18,7 @@
 package org.wso2.carbon.user.core.claim;
 
 import junit.framework.TestCase;
-import org.apache.commons.dbcp.BasicDataSource;
+import org.apache.tomcat.dbcp.dbcp2.BasicDataSource;
 import org.wso2.carbon.user.core.BaseTestCase;
 import org.wso2.carbon.user.core.ClaimTestUtil;
 import org.wso2.carbon.user.core.UserCoreTestConstants;

--- a/core/org.wso2.carbon.user.core/src/test/java/org/wso2/carbon/user/core/hybrid/AdvancedHybridRoleManagerTest.java
+++ b/core/org.wso2.carbon.user.core/src/test/java/org/wso2/carbon/user/core/hybrid/AdvancedHybridRoleManagerTest.java
@@ -17,7 +17,7 @@
 */
 package org.wso2.carbon.user.core.hybrid;
 
-import org.apache.commons.dbcp.BasicDataSource;
+import org.apache.tomcat.dbcp.dbcp2.BasicDataSource;
 import org.wso2.carbon.user.core.BaseTestCase;
 import org.wso2.carbon.user.core.UserCoreTestConstants;
 import org.wso2.carbon.user.core.util.DatabaseUtil;

--- a/core/org.wso2.carbon.user.core/src/test/java/org/wso2/carbon/user/core/hybrid/HybridRoleManagerTest.java
+++ b/core/org.wso2.carbon.user.core/src/test/java/org/wso2/carbon/user/core/hybrid/HybridRoleManagerTest.java
@@ -17,7 +17,7 @@
  */
 package org.wso2.carbon.user.core.hybrid;
 
-import org.apache.commons.dbcp.BasicDataSource;
+import org.apache.tomcat.dbcp.dbcp2.BasicDataSource;
 import org.wso2.carbon.user.api.RealmConfiguration;
 import org.wso2.carbon.user.core.BaseTestCase;
 import org.wso2.carbon.user.core.ClaimTestUtil;

--- a/core/org.wso2.carbon.user.core/src/test/java/org/wso2/carbon/user/core/hybrid/HybridRoleManagerWithIDTest.java
+++ b/core/org.wso2.carbon.user.core/src/test/java/org/wso2/carbon/user/core/hybrid/HybridRoleManagerWithIDTest.java
@@ -17,7 +17,7 @@
  */
 package org.wso2.carbon.user.core.hybrid;
 
-import org.apache.commons.dbcp.BasicDataSource;
+import org.apache.tomcat.dbcp.dbcp2.BasicDataSource;
 import org.wso2.carbon.user.api.RealmConfiguration;
 import org.wso2.carbon.user.core.BaseTestCase;
 import org.wso2.carbon.user.core.ClaimTestUtil;

--- a/core/org.wso2.carbon.user.core/src/test/java/org/wso2/carbon/user/core/jdbc/AdvancedJDBCRealmTest.java
+++ b/core/org.wso2.carbon.user.core/src/test/java/org/wso2/carbon/user/core/jdbc/AdvancedJDBCRealmTest.java
@@ -18,7 +18,7 @@
 package org.wso2.carbon.user.core.jdbc;
 
 import junit.framework.TestCase;
-import org.apache.commons.dbcp.BasicDataSource;
+import org.apache.tomcat.dbcp.dbcp2.BasicDataSource;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.junit.Assert;

--- a/core/org.wso2.carbon.user.core/src/test/java/org/wso2/carbon/user/core/jdbc/AdvancedReadOnlyJDBCRealmTest.java
+++ b/core/org.wso2.carbon.user.core/src/test/java/org/wso2/carbon/user/core/jdbc/AdvancedReadOnlyJDBCRealmTest.java
@@ -17,7 +17,7 @@
 */
 package org.wso2.carbon.user.core.jdbc;
 
-import org.apache.commons.dbcp.BasicDataSource;
+import org.apache.tomcat.dbcp.dbcp2.BasicDataSource;
 import org.wso2.carbon.user.api.RealmConfiguration;
 import org.wso2.carbon.user.core.AuthorizationManager;
 import org.wso2.carbon.user.core.BaseTestCase;

--- a/core/org.wso2.carbon.user.core/src/test/java/org/wso2/carbon/user/core/jdbc/AdvancedReadOnlyJDBCRealmWithIDTest.java
+++ b/core/org.wso2.carbon.user.core/src/test/java/org/wso2/carbon/user/core/jdbc/AdvancedReadOnlyJDBCRealmWithIDTest.java
@@ -17,7 +17,7 @@
  */
 package org.wso2.carbon.user.core.jdbc;
 
-import org.apache.commons.dbcp.BasicDataSource;
+import org.apache.tomcat.dbcp.dbcp2.BasicDataSource;
 import org.wso2.carbon.user.api.RealmConfiguration;
 import org.wso2.carbon.user.core.AuthorizationManager;
 import org.wso2.carbon.user.core.BaseTestCase;

--- a/core/org.wso2.carbon.user.core/src/test/java/org/wso2/carbon/user/core/jdbc/JDBCRealmPrimaryUserStoreTest.java
+++ b/core/org.wso2.carbon.user.core/src/test/java/org/wso2/carbon/user/core/jdbc/JDBCRealmPrimaryUserStoreTest.java
@@ -17,7 +17,7 @@
  */
 package org.wso2.carbon.user.core.jdbc;
 
-import org.apache.commons.dbcp.BasicDataSource;
+import org.apache.tomcat.dbcp.dbcp2.BasicDataSource;
 import org.apache.commons.lang.ArrayUtils;
 import org.junit.Assert;
 import org.junit.FixMethodOrder;

--- a/core/org.wso2.carbon.user.core/src/test/java/org/wso2/carbon/user/core/jdbc/JDBCRealmSecondaryUserStoreTest.java
+++ b/core/org.wso2.carbon.user.core/src/test/java/org/wso2/carbon/user/core/jdbc/JDBCRealmSecondaryUserStoreTest.java
@@ -20,7 +20,7 @@ package org.wso2.carbon.user.core.jdbc;
 import org.apache.axiom.om.OMElement;
 import org.apache.axiom.om.impl.builder.StAXOMBuilder;
 import org.apache.axiom.om.xpath.AXIOMXPath;
-import org.apache.commons.dbcp.BasicDataSource;
+import org.apache.tomcat.dbcp.dbcp2.BasicDataSource;
 import org.apache.commons.lang.ArrayUtils;
 import org.junit.Assert;
 import org.junit.FixMethodOrder;

--- a/core/org.wso2.carbon.user.core/src/test/java/org/wso2/carbon/user/core/jdbc/JDBCRealmTest.java
+++ b/core/org.wso2.carbon.user.core/src/test/java/org/wso2/carbon/user/core/jdbc/JDBCRealmTest.java
@@ -18,7 +18,7 @@
 package org.wso2.carbon.user.core.jdbc;
 
 import junit.framework.TestCase;
-import org.apache.commons.dbcp.BasicDataSource;
+import org.apache.tomcat.dbcp.dbcp2.BasicDataSource;
 import org.wso2.carbon.user.api.RealmConfiguration;
 import org.wso2.carbon.user.core.AuthorizationManager;
 import org.wso2.carbon.user.core.BaseTestCase;

--- a/core/org.wso2.carbon.user.core/src/test/java/org/wso2/carbon/user/core/jdbc/JDBCRealmWithUniqueIDTest.java
+++ b/core/org.wso2.carbon.user.core/src/test/java/org/wso2/carbon/user/core/jdbc/JDBCRealmWithUniqueIDTest.java
@@ -18,7 +18,7 @@
 package org.wso2.carbon.user.core.jdbc;
 
 import junit.framework.TestCase;
-import org.apache.commons.dbcp.BasicDataSource;
+import org.apache.tomcat.dbcp.dbcp2.BasicDataSource;
 import org.wso2.carbon.user.api.RealmConfiguration;
 import org.wso2.carbon.user.core.AuthorizationManager;
 import org.wso2.carbon.user.core.BaseTestCase;

--- a/core/org.wso2.carbon.user.core/src/test/java/org/wso2/carbon/user/core/jdbc/PermissionTest.java
+++ b/core/org.wso2.carbon.user.core/src/test/java/org/wso2/carbon/user/core/jdbc/PermissionTest.java
@@ -17,7 +17,7 @@
 */
 package org.wso2.carbon.user.core.jdbc;
 
-import org.apache.commons.dbcp.BasicDataSource;
+import org.apache.tomcat.dbcp.dbcp2.BasicDataSource;
 import org.wso2.carbon.user.api.RealmConfiguration;
 import org.wso2.carbon.user.core.AuthorizationManager;
 import org.wso2.carbon.user.core.BaseTestCase;

--- a/core/org.wso2.carbon.user.core/src/test/java/org/wso2/carbon/user/core/jdbc/PermissionWithIDTest.java
+++ b/core/org.wso2.carbon.user.core/src/test/java/org/wso2/carbon/user/core/jdbc/PermissionWithIDTest.java
@@ -17,7 +17,7 @@
 */
 package org.wso2.carbon.user.core.jdbc;
 
-import org.apache.commons.dbcp.BasicDataSource;
+import org.apache.tomcat.dbcp.dbcp2.BasicDataSource;
 import org.wso2.carbon.user.api.RealmConfiguration;
 import org.wso2.carbon.user.core.AuthorizationManager;
 import org.wso2.carbon.user.core.BaseTestCase;

--- a/core/org.wso2.carbon.user.core/src/test/java/org/wso2/carbon/user/core/jdbc/ReadOnlyJDBCRealmTest.java
+++ b/core/org.wso2.carbon.user.core/src/test/java/org/wso2/carbon/user/core/jdbc/ReadOnlyJDBCRealmTest.java
@@ -18,7 +18,7 @@
 package org.wso2.carbon.user.core.jdbc;
 
 import junit.framework.TestCase;
-import org.apache.commons.dbcp.BasicDataSource;
+import org.apache.tomcat.dbcp.dbcp2.BasicDataSource;
 import org.junit.Assert;
 import org.wso2.carbon.user.api.RealmConfiguration;
 import org.wso2.carbon.user.core.AuthorizationManager;

--- a/core/org.wso2.carbon.user.core/src/test/java/org/wso2/carbon/user/core/jdbc/ReadOnlyJDBCRealmWithIDTest.java
+++ b/core/org.wso2.carbon.user.core/src/test/java/org/wso2/carbon/user/core/jdbc/ReadOnlyJDBCRealmWithIDTest.java
@@ -18,7 +18,7 @@
 package org.wso2.carbon.user.core.jdbc;
 
 import junit.framework.TestCase;
-import org.apache.commons.dbcp.BasicDataSource;
+import org.apache.tomcat.dbcp.dbcp2.BasicDataSource;
 import org.junit.Assert;
 import org.wso2.carbon.user.api.Permission;
 import org.wso2.carbon.user.api.RealmConfiguration;

--- a/core/org.wso2.carbon.user.core/src/test/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCRealmPrimaryUserStoreTest.java
+++ b/core/org.wso2.carbon.user.core/src/test/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCRealmPrimaryUserStoreTest.java
@@ -17,7 +17,7 @@
  */
 package org.wso2.carbon.user.core.jdbc;
 
-import org.apache.commons.dbcp.BasicDataSource;
+import org.apache.tomcat.dbcp.dbcp2.BasicDataSource;
 import org.apache.commons.lang.ArrayUtils;
 import org.junit.Assert;
 import org.junit.FixMethodOrder;

--- a/core/org.wso2.carbon.user.core/src/test/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCRealmSecondaryUserStoreTest.java
+++ b/core/org.wso2.carbon.user.core/src/test/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCRealmSecondaryUserStoreTest.java
@@ -20,7 +20,7 @@ package org.wso2.carbon.user.core.jdbc;
 import org.apache.axiom.om.OMElement;
 import org.apache.axiom.om.impl.builder.StAXOMBuilder;
 import org.apache.axiom.om.xpath.AXIOMXPath;
-import org.apache.commons.dbcp.BasicDataSource;
+import org.apache.tomcat.dbcp.dbcp2.BasicDataSource;
 import org.apache.commons.lang.ArrayUtils;
 import org.junit.Assert;
 import org.junit.FixMethodOrder;

--- a/core/org.wso2.carbon.user.core/src/test/java/org/wso2/carbon/user/core/profile/AdvancedProfileConfigManagerTest.java
+++ b/core/org.wso2.carbon.user.core/src/test/java/org/wso2/carbon/user/core/profile/AdvancedProfileConfigManagerTest.java
@@ -17,7 +17,7 @@
 */
 package org.wso2.carbon.user.core.profile;
 
-import org.apache.commons.dbcp.BasicDataSource;
+import org.apache.tomcat.dbcp.dbcp2.BasicDataSource;
 import org.wso2.carbon.user.core.BaseTestCase;
 import org.wso2.carbon.user.core.ClaimTestUtil;
 import org.wso2.carbon.user.core.UserCoreTestConstants;

--- a/core/org.wso2.carbon.user.core/src/test/java/org/wso2/carbon/user/core/tenant/TestTenantManager.java
+++ b/core/org.wso2.carbon.user.core/src/test/java/org/wso2/carbon/user/core/tenant/TestTenantManager.java
@@ -17,7 +17,7 @@
 */
 package org.wso2.carbon.user.core.tenant;
 
-import org.apache.commons.dbcp.BasicDataSource;
+import org.apache.tomcat.dbcp.dbcp2.BasicDataSource;
 import org.wso2.carbon.context.internal.OSGiDataHolder;
 import org.wso2.carbon.user.api.RealmConfiguration;
 import org.wso2.carbon.user.core.BaseTestCase;

--- a/core/org.wso2.carbon.user.core/src/test/java/org/wso2/carbon/user/core/tenant/TestTenantManagerWithID.java
+++ b/core/org.wso2.carbon.user.core/src/test/java/org/wso2/carbon/user/core/tenant/TestTenantManagerWithID.java
@@ -17,7 +17,7 @@
 */
 package org.wso2.carbon.user.core.tenant;
 
-import org.apache.commons.dbcp.BasicDataSource;
+import org.apache.tomcat.dbcp.dbcp2.BasicDataSource;
 import org.wso2.carbon.context.internal.OSGiDataHolder;
 import org.wso2.carbon.user.api.RealmConfiguration;
 import org.wso2.carbon.user.core.BaseTestCase;

--- a/core/org.wso2.carbon.utils/pom.xml
+++ b/core/org.wso2.carbon.utils/pom.xml
@@ -161,11 +161,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>commons-dbcp.wso2</groupId>
-            <artifactId>commons-dbcp</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>commons-pool.wso2</groupId>
             <artifactId>commons-pool</artifactId>
             <scope>test</scope>

--- a/core/org.wso2.carbon.utils/src/test/java/org/wso2/carbon/utils/dbcreator/DatabaseCreatorTest.java
+++ b/core/org.wso2.carbon.utils/src/test/java/org/wso2/carbon/utils/dbcreator/DatabaseCreatorTest.java
@@ -17,7 +17,7 @@
  */
 package org.wso2.carbon.utils.dbcreator;
 
-import org.apache.commons.dbcp.BasicDataSource;
+import org.apache.tomcat.dbcp.dbcp2.BasicDataSource;
 import org.apache.commons.io.FileUtils;
 import org.junit.Assert;
 import org.testng.annotations.BeforeTest;

--- a/features/org.wso2.carbon.core.common.feature/pom.xml
+++ b/features/org.wso2.carbon.core.common.feature/pom.xml
@@ -76,7 +76,6 @@
                                 <bundleDef>org.apache.axis2.wso2:axis2-json:${orbit.version.axis2}</bundleDef>
                                 <bundleDef>org.codehaus.jettison.wso2:jettison:${orbit.version.jettison}</bundleDef>
                                 <bundleDef>commons-pool.wso2:commons-pool:${orbit.version.commons.pool}</bundleDef>
-                                <bundleDef>commons-dbcp.wso2:commons-dbcp:${orbit.version.commons.dbcp}</bundleDef>
                                 <bundleDef>org.apache.abdera.wso2:abdera:${orbit.version.abdera}</bundleDef>
                                 <bundleDef>org.apache.axis2.wso2:axis2:${orbit.version.axis2}</bundleDef>
                                 <bundleDef>org.wso2.orbit.com.hazelcast:hazelcast:${orbit.version.hazelcast}</bundleDef>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -481,7 +481,6 @@
         <orbit.version.commons.lang>2.6.0.wso2v1</orbit.version.commons.lang>
         <orbit.version.commons.collection>3.2.2.wso2v1</orbit.version.commons.collection>
         <orbit.version.commons.io>2.7.0.wso2v1</orbit.version.commons.io>
-        <orbit.version.commons.dbcp>1.4.0.wso2v1</orbit.version.commons.dbcp>
         <orbit.version.smack>3.0.4.wso2v1</orbit.version.smack>
         <orbit.version.apacheds>1.5.7-wso2v1</orbit.version.apacheds>
         <orbit.version.geronimo-jms_1.1_spec>1.1.1.wso2v1</orbit.version.geronimo-jms_1.1_spec>
@@ -1162,11 +1161,6 @@
                 <groupId>commons-pool.wso2</groupId>
                 <artifactId>commons-pool</artifactId>
                 <version>${orbit.version.commons.pool}</version>
-            </dependency>
-            <dependency>
-                <groupId>commons-dbcp.wso2</groupId>
-                <artifactId>commons-dbcp</artifactId>
-                <version>${orbit.version.commons.dbcp}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.httpcomponents.wso2</groupId>


### PR DESCRIPTION
## Purpose
commons-dbcp is an old release [1], whereas the new releases are being maintained by tomcat [2]. Hence, upgrading to the tomcat dbcp2 because tomcat jar is already getting packed in the products. After this fix, in the future when upgrading the tomcat, dbcp will also get upgraded.

## Goals
Upgrading the commons-dbcp to tomcat-dbcp2

## Approach
- Changed the package names where necessary
- Changed the functions appropriately (Most of the classes where I changed the functions are deprecated. Hence, the risk is low)

## Related PRs
- https://github.com/wso2/carbon-kernel/pull/3321

[1] https://mvnrepository.com/artifact/org.apache.commons/commons-dbcp2
[2] https://mvnrepository.com/artifact/org.apache.tomcat/tomcat-dbcp