### PR TITLE
Add SAMLSignKeyStore configuration to carbon.xml.j2

### DIFF
--- a/distribution/kernel/carbon-home/repository/resources/conf/templates/repository/conf/carbon.xml.j2
+++ b/distribution/kernel/carbon-home/repository/resources/conf/templates/repository/conf/carbon.xml.j2
@@ -514,7 +514,7 @@
         </InternalKeyStore>
 
         <!--
-            KeyStore which will be used for SAML response/request signing if configured.
+            KeyStore which will be used for SAML request/response signing if configured.
             This is only supported for the super tenant ATM.
         -->
         <SAMLSignKeyStore>

--- a/distribution/kernel/carbon-home/repository/resources/conf/templates/repository/conf/carbon.xml.j2
+++ b/distribution/kernel/carbon-home/repository/resources/conf/templates/repository/conf/carbon.xml.j2
@@ -513,6 +513,22 @@
             <KeyPassword>{{keystore.internal.key_password}}</KeyPassword>
         </InternalKeyStore>
 
+        <!--
+            KeyStore which will be used for SAML response/request signing if configured.
+            This is only supported for the super tenant ATM.
+        -->
+        <SAMLSignKeyStore>
+            <Location>${carbon.home}/repository/resources/security/{{keystore.saml.file_name}}</Location>
+            <!-- Keystore type (JKS/PKCS12 etc.)-->
+            <Type>{{keystore.saml.type}}</Type>
+            <!-- Keystore password-->
+            <Password>{{keystore.saml.password}}</Password>
+            <!-- Private Key alias-->
+            <KeyAlias>{{keystore.saml.alias}}</KeyAlias>
+            <!-- Private Key password-->
+            <KeyPassword>{{keystore.saml.key_password}}</KeyPassword>
+        </SAMLSignKeyStore>
+
         <UserStorePasswordEncryption>{{keystore.userstore_password_encryption}}</UserStorePasswordEncryption>
 
         <!--


### PR DESCRIPTION
## Purpose
This PR is to template the SAMLSignKeyStore Configuration which is not templated. [1] 

[1] -  https://github.com/wso2-extensions/identity-inbound-auth-saml/blob/342cb8d5fc1ea2f1fff5f309379902db6e2f23eb/components/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/builders/SignKeyDataHolder.java#L117

## Related Issues
- https://github.com/wso2/product-is/issues/12108