### PR TITLE
Handle Deformed Request URLs with Invalid Characters

### DIFF
--- a/core/org.wso2.carbon.tomcat.ext/src/main/java/org/wso2/carbon/tomcat/ext/transport/CarbonResponseWrapper.java
+++ b/core/org.wso2.carbon.tomcat.ext/src/main/java/org/wso2/carbon/tomcat/ext/transport/CarbonResponseWrapper.java
@@ -26,7 +26,6 @@ import org.wso2.carbon.core.ServletCookie;
 
 import java.io.IOException;
 import java.io.PrintWriter;
-import java.lang.IllegalArgumentException;
 import java.nio.charset.Charset;
 import java.util.Collection;
 import java.util.List;
@@ -97,17 +96,17 @@ public class CarbonResponseWrapper extends Response {
             return this.getContext().getCookieProcessor().generateHeader(cookie, null);
         }
 
-            String cookieString = super.generateCookieString(cookie);
-            if (cookie instanceof ServletCookie) {
-                if (((ServletCookie) cookie).getSameSite() == null) {
-                    cookieString = cookieString + "; SameSite=" + SameSiteCookie.STRICT.getName();
-                } else {
-                    cookieString = cookieString + "; SameSite=" + ((ServletCookie) cookie).getSameSite().getName();
-                }
-            } else {
+        String cookieString = super.generateCookieString(cookie);
+        if (cookie instanceof ServletCookie) {
+            if (((ServletCookie) cookie).getSameSite() == null) {
                 cookieString = cookieString + "; SameSite=" + SameSiteCookie.STRICT.getName();
+            } else {
+                cookieString = cookieString + "; SameSite=" + ((ServletCookie) cookie).getSameSite().getName();
             }
-            return cookieString;
+        } else {
+            cookieString = cookieString + "; SameSite=" + SameSiteCookie.STRICT.getName();
+        }
+        return cookieString;
     }
 
     private boolean isLegacyUserAgent() {

--- a/core/org.wso2.carbon.tomcat.ext/src/main/java/org/wso2/carbon/tomcat/ext/transport/CarbonResponseWrapper.java
+++ b/core/org.wso2.carbon.tomcat.ext/src/main/java/org/wso2/carbon/tomcat/ext/transport/CarbonResponseWrapper.java
@@ -97,7 +97,6 @@ public class CarbonResponseWrapper extends Response {
             return this.getContext().getCookieProcessor().generateHeader(cookie, null);
         }
 
-        try {
             String cookieString = super.generateCookieString(cookie);
             if (cookie instanceof ServletCookie) {
                 if (((ServletCookie) cookie).getSameSite() == null) {
@@ -109,12 +108,6 @@ public class CarbonResponseWrapper extends Response {
                 cookieString = cookieString + "; SameSite=" + SameSiteCookie.STRICT.getName();
             }
             return cookieString;
-        } catch (IllegalArgumentException e) {
-            if (log.isDebugEnabled()) {
-                log.debug("Cookie String was not created because invalid character is present.");
-            }
-            return null;
-        }
     }
 
     private boolean isLegacyUserAgent() {
@@ -365,9 +358,7 @@ public class CarbonResponseWrapper extends Response {
         if (!this.included && !this.isCommitted()) {
             this.getCookies().add(cookie);
             String header = this.generateCookieString(cookie);
-            if (header != null) {
-                this.addHeader("Set-Cookie", header, this.getContext().getCookieProcessor().getCharset());
-            }
+            this.addHeader("Set-Cookie", header, this.getContext().getCookieProcessor().getCharset());
         }
     }
 

--- a/core/org.wso2.carbon.ui/src/main/java/org/wso2/carbon/ui/CarbonUILoginUtil.java
+++ b/core/org.wso2.carbon.ui/src/main/java/org/wso2/carbon/ui/CarbonUILoginUtil.java
@@ -120,7 +120,14 @@ public final class CarbonUILoginUtil {
                 cookie.setPath("/");
                 cookie.setSecure(true);
                 cookie.setHttpOnly(true);
-                response.addCookie(cookie);
+
+                try {
+                    response.addCookie(cookie);
+                } catch (IllegalArgumentException e) {
+                    if (log.isDebugEnabled()) {
+                        log.debug("Cookie was not created because invalid character is present.");
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
## Purpose
To solve the issue of server error thrown when a deformed request with invalid characters such as ; in the request URL is sent.
A cookie with request URL is created before redirecting the user and cookie validation results in the error.
This should be handled properly with logging on appropriate log level.

This PR solves this issue by catching the exact exception when creating the cookie and not adding the cookie to the header and logging on debug level.

Example Request:
`https://localhost:9445/carbon/admin;`