### PR TITLE
FIx issue on updaing the disabled value of user stores in realm for user stores without a disable property.

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/DefaultRealm.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/DefaultRealm.java
@@ -253,10 +253,8 @@ public class DefaultRealm implements UserRealm {
 
             while (tmpRealmConfig != null) {
 
-                if (tmpRealmConfig.getUserStoreProperty(UserCoreConstants.RealmConfig.USER_STORE_DISABLED) != null) {
-                    isDisabled = Boolean.parseBoolean(
-                            tmpRealmConfig.getUserStoreProperty(UserCoreConstants.RealmConfig.USER_STORE_DISABLED));
-                }
+                isDisabled = Boolean.parseBoolean(
+                        tmpRealmConfig.getUserStoreProperty(UserCoreConstants.RealmConfig.USER_STORE_DISABLED));
                 domainName = tmpRealmConfig.getUserStoreProperty(UserCoreConstants.RealmConfig.PROPERTY_DOMAIN_NAME);
                 value = tmpRealmConfig.getUserStoreClass();
                 if (value == null) {


### PR DESCRIPTION
## Purpose
> If a user store exist without the disabled property, it will use the disabled value of a user store which is in the list.
