### PR TITLE
Fix group rename and group delete issues

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
@@ -17897,25 +17897,25 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
     }
 
     /**
-     * Update group name in the hybrid group-role mapper.
+     * Update group name in the UM_HYBRID_GROUP_ROLE table.
      *
      * @param groupName        The current group name.
      * @param newGroupName     The new group name.
      * @throws UserStoreException An unexpected exception has occurred.
      */
-    public void updateHybridGroupName(String groupName, String newGroupName) throws UserStoreException {
+    public void updateGroupName(String groupName, String newGroupName) throws UserStoreException {
 
-        hybridRoleManager.updateHybridGroupName(groupName, newGroupName);
+        hybridRoleManager.updateGroupName(groupName, newGroupName);
     }
 
     /**
-     * Delete group from the hybrid group-role mapper.
+     * Delete group from the UM_HYBRID_GROUP_ROLE table.
      *
      * @param groupName        The group name.
      * @throws UserStoreException An unexpected exception has occurred.
      */
-    public void deleteHybridGroup(String groupName) throws UserStoreException {
+    public void removeGroupByNameFromRoleMapping(String groupName) throws UserStoreException {
 
-        hybridRoleManager.deleteHybridGroup(groupName);
+        hybridRoleManager.removeGroupByNameFromRoleMapping(groupName);
     }
 }

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
@@ -17895,4 +17895,27 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
         }
         return givenLimit;
     }
+
+    /**
+     * Update group name in the hybrid group-role mapper.
+     *
+     * @param groupName        The current group name.
+     * @param newGroupName     The new group name.
+     * @throws UserStoreException An unexpected exception has occurred.
+     */
+    public void updateHybridGroupName(String groupName, String newGroupName) throws UserStoreException {
+
+        hybridRoleManager.updateHybridGroupName(groupName, newGroupName);
+    }
+
+    /**
+     * Delete group from the hybrid group-role mapper.
+     *
+     * @param groupName        The group name.
+     * @throws UserStoreException An unexpected exception has occurred.
+     */
+    public void deleteHybridGroup(String groupName) throws UserStoreException {
+
+        hybridRoleManager.deleteHybridGroup(groupName);
+    }
 }

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
@@ -17914,8 +17914,8 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
      * @param groupName        The group name.
      * @throws UserStoreException An unexpected exception has occurred.
      */
-    public void removeGroupByNameFromRoleMapping(String groupName) throws UserStoreException {
+    public void removeGroupRoleMappingByGroupName(String groupName) throws UserStoreException {
 
-        hybridRoleManager.removeGroupByNameFromRoleMapping(groupName);
+        hybridRoleManager.removeGroupRoleMappingByGroupName(groupName);
     }
 }

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/hybrid/HybridJDBCConstants.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/hybrid/HybridJDBCConstants.java
@@ -162,10 +162,10 @@ public class HybridJDBCConstants {
     public static final String COUNT_INTERNAL_ONLY_ROLES_SQL = "SELECT COUNT(UM_ID) AS RESULT FROM UM_HYBRID_ROLE " +
             "WHERE UM_ROLE_NAME NOT LIKE 'Application%' AND UM_ROLE_NAME LIKE ? AND UM_TENANT_ID = ?";
 
-    public static final String GET_HYBRID_GROUP_ID = "SELECT UM_ID FROM UM_HYBRID_GROUP_ROLE WHERE UM_GROUP_NAME =? " +
+    public static final String GET_GROUP_ID = "SELECT UM_ID FROM UM_HYBRID_GROUP_ROLE WHERE UM_GROUP_NAME =? " +
             "AND UM_TENANT_ID=?";
 
-    public static final String UPDATE_HYBRID_GROUP_NAME_SQL = "UPDATE UM_HYBRID_GROUP_ROLE set UM_GROUP_NAME=? " +
+    public static final String UPDATE_GROUP_NAME_SQL = "UPDATE UM_HYBRID_GROUP_ROLE set UM_GROUP_NAME=? " +
             "WHERE UM_GROUP_NAME = ? AND UM_TENANT_ID=?";
 
     public static final String DELETE_GROUP_SQL = "DELETE FROM UM_HYBRID_GROUP_ROLE WHERE UM_GROUP_NAME = ? " +

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/hybrid/HybridJDBCConstants.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/hybrid/HybridJDBCConstants.java
@@ -161,4 +161,13 @@ public class HybridJDBCConstants {
 
     public static final String COUNT_INTERNAL_ONLY_ROLES_SQL = "SELECT COUNT(UM_ID) AS RESULT FROM UM_HYBRID_ROLE " +
             "WHERE UM_ROLE_NAME NOT LIKE 'Application%' AND UM_ROLE_NAME LIKE ? AND UM_TENANT_ID = ?";
+
+    public static final String GET_HYBRID_GROUP_ID = "SELECT UM_ID FROM UM_HYBRID_GROUP_ROLE WHERE UM_GROUP_NAME =? " +
+            "AND UM_TENANT_ID=?";
+
+    public static final String UPDATE_HYBRID_GROUP_NAME_SQL = "UPDATE UM_HYBRID_GROUP_ROLE set UM_GROUP_NAME=? " +
+            "WHERE UM_GROUP_NAME = ? AND UM_TENANT_ID=?";
+
+    public static final String DELETE_GROUP_SQL = "DELETE FROM UM_HYBRID_GROUP_ROLE WHERE UM_GROUP_NAME = ? " +
+            "AND UM_TENANT_ID=?";
 }

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/hybrid/HybridJDBCConstants.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/hybrid/HybridJDBCConstants.java
@@ -162,12 +162,12 @@ public class HybridJDBCConstants {
     public static final String COUNT_INTERNAL_ONLY_ROLES_SQL = "SELECT COUNT(UM_ID) AS RESULT FROM UM_HYBRID_ROLE " +
             "WHERE UM_ROLE_NAME NOT LIKE 'Application%' AND UM_ROLE_NAME LIKE ? AND UM_TENANT_ID = ?";
 
-    public static final String GET_GROUP_ID = "SELECT UM_ID FROM UM_HYBRID_GROUP_ROLE WHERE UM_GROUP_NAME =? " +
-            "AND UM_TENANT_ID=?";
+    public static final String GET_GROUP_ROLE_MAPPING_ID = "SELECT UM_ID FROM UM_HYBRID_GROUP_ROLE WHERE UM_GROUP_NAME = ? " +
+            "AND UM_TENANT_ID = ?";
 
-    public static final String UPDATE_GROUP_NAME_SQL = "UPDATE UM_HYBRID_GROUP_ROLE set UM_GROUP_NAME=? " +
-            "WHERE UM_GROUP_NAME = ? AND UM_TENANT_ID=?";
+    public static final String UPDATE_GROUP_NAME_SQL = "UPDATE UM_HYBRID_GROUP_ROLE set UM_GROUP_NAME = ? " +
+            "WHERE UM_GROUP_NAME = ? AND UM_TENANT_ID = ?";
 
     public static final String DELETE_GROUP_SQL = "DELETE FROM UM_HYBRID_GROUP_ROLE WHERE UM_GROUP_NAME = ? " +
-            "AND UM_TENANT_ID=?";
+            "AND UM_TENANT_ID = ?";
 }

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/hybrid/HybridRoleManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/hybrid/HybridRoleManager.java
@@ -1194,12 +1194,12 @@ public class HybridRoleManager {
     }
 
     /**
-     * Check whether the group exists in hybrid group-role mapper.
+     * Check whether the group exists in the UM_HYBRID_GROUP_ROLE table.
      *
      * @param groupName        The group name.
      * @throws UserStoreException An unexpected exception has occurred.
      */
-    public boolean isExistingHybridGroup(String groupName) throws UserStoreException {
+    public boolean isExistingGroup(String groupName) throws UserStoreException {
 
         Connection dbConnection = null;
         PreparedStatement prepStmt = null;
@@ -1208,18 +1208,16 @@ public class HybridRoleManager {
 
         try {
             dbConnection = DatabaseUtil.getDBConnection(dataSource);
-            prepStmt = dbConnection.prepareStatement(HybridJDBCConstants.GET_HYBRID_GROUP_ID);
+            prepStmt = dbConnection.prepareStatement(HybridJDBCConstants.GET_GROUP_ID);
             prepStmt.setString(1, groupName);
             prepStmt.setInt(2, tenantId);
             rs = prepStmt.executeQuery();
+
             if (rs.next()) {
                 int value = rs.getInt(1);
                 if (value > -1) {
                     isExisting = true;
                 }
-            }
-            if (log.isDebugEnabled()) {
-                log.debug("Is group: " + groupName + " existing: " + isExisting + " TenantId: " + tenantId);
             }
             return !isExisting;
         } catch (SQLException e) {
@@ -1235,22 +1233,22 @@ public class HybridRoleManager {
     }
 
     /**
-     * Update group name in the hybrid group-role mapper.
+     * Update group name in the UM_HYBRID_GROUP_ROLE table.
      *
      * @param groupName        The current group name.
      * @param newGroupName     The new group name.
      * @throws UserStoreException An unexpected exception has occurred.
      */
-    public void updateHybridGroupName(String groupName, String newGroupName) throws UserStoreException {
+    public void updateGroupName(String groupName, String newGroupName) throws UserStoreException {
 
-        if (this.isExistingHybridGroup(groupName)) {
+        if (this.isExistingGroup(groupName)) {
             return;
         }
 
         Connection dbConnection = null;
         try {
             dbConnection = DatabaseUtil.getDBConnection(dataSource);
-            DatabaseUtil.updateDatabase(dbConnection, HybridJDBCConstants.UPDATE_HYBRID_GROUP_NAME_SQL,
+            DatabaseUtil.updateDatabase(dbConnection, HybridJDBCConstants.UPDATE_GROUP_NAME_SQL,
                     newGroupName, groupName, tenantId);
             dbConnection.commit();
         } catch (SQLException e) {
@@ -1263,14 +1261,14 @@ public class HybridRoleManager {
     }
 
     /**
-     * Delete group from the hybrid group-role mapper.
+     * Delete group from the UM_HYBRID_GROUP_ROLE table.
      *
      * @param groupName        The group name.
      * @throws UserStoreException An unexpected exception has occurred.
      */
-    public void deleteHybridGroup(String groupName) throws UserStoreException {
+    public void removeGroupByNameFromRoleMapping(String groupName) throws UserStoreException {
 
-        if (this.isExistingHybridGroup(groupName)) {
+        if (this.isExistingGroup(groupName)) {
             return;
         }
 


### PR DESCRIPTION
## Purpose
Resolves https://github.com/wso2/product-is/issues/13534 , https://github.com/wso2/product-is/issues/14122

ATM, renaming a group will remove the assigned roles of the group. This is due to not updating the  UM_HYBRID_GROUP_ROLE table when renaming the group name. And also delete group won't remove the group from this table, due to this issue, if the new group name has old group name which has some assigned roles, those roles will be added to the currrent goup. Fixed both issues. 

Related PR: 