### PR TITLE
Capability to resolve embedded and multiple secrets in a OMElement

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -602,7 +602,7 @@
         <orbit.version.qpid>0.12.wso2v1</orbit.version.qpid>
 
         <!--Wso2 Secure Vault -->
-        <securevault.version>1.1.4</securevault.version>
+        <securevault.version>1.1.5</securevault.version>
 
         <jdbc-pool.version>9.0.56.wso2v1</jdbc-pool.version>
 


### PR DESCRIPTION
## Purpose
When using encrypted secrets with cipher tool, current implementation doesn't allow to use embedded secrets and only allows to use a single secret in one string. This PR fixes it by iterating through each secret in the string and replacing only the `$secret{key}` fragment in the OMElement value with the decrypted secret.

:bangbang: **Requires to get `carbon-secvault` changes before merging this PR.**

### Related issue
- https://github.com/wso2/product-is/issues/14109

### Related PR
- https://github.com/wso2/carbon-secvault/pull/79
