### PR TITLE
Add runtime configurable correlation log support

### DIFF
--- a/core/org.wso2.carbon.logging.correlation/pom.xml
+++ b/core/org.wso2.carbon.logging.correlation/pom.xml
@@ -76,7 +76,7 @@
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Bundle-Name>${project.artifactId}</Bundle-Name>
                         <Export-Package>
-                            org.wso2.carbon.logging.correlation.internal.*,
+                            !org.wso2.carbon.logging.correlation.internal.*,
                             org.wso2.carbon.logging.correlation.*,
                         </Export-Package>
                         <Import-Package>

--- a/core/org.wso2.carbon.logging.correlation/pom.xml
+++ b/core/org.wso2.carbon.logging.correlation/pom.xml
@@ -76,7 +76,7 @@
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Bundle-Name>${project.artifactId}</Bundle-Name>
                         <Export-Package>
-                            !org.wso2.carbon.logging.correlation.internal.*,
+                            org.wso2.carbon.logging.correlation.internal.*,
                             org.wso2.carbon.logging.correlation.*,
                         </Export-Package>
                         <Import-Package>

--- a/core/org.wso2.carbon.logging.correlation/src/main/java/org/wso2/carbon/logging/correlation/CorrelationLogConfigurable.java
+++ b/core/org.wso2.carbon.logging.correlation/src/main/java/org/wso2/carbon/logging/correlation/CorrelationLogConfigurable.java
@@ -32,6 +32,8 @@ public interface CorrelationLogConfigurable {
      */
     String getName();
 
+    ImmutableCorrelationLogConfig getConfiguration();
+
     /**
      * Receives an instance of <code>ImmutableCorrelationLogConfig</code> class which holds the component-specific
      * configuration.

--- a/core/org.wso2.carbon.logging.correlation/src/main/java/org/wso2/carbon/logging/correlation/internal/CorrelationLogManager.java
+++ b/core/org.wso2.carbon.logging.correlation/src/main/java/org/wso2/carbon/logging/correlation/internal/CorrelationLogManager.java
@@ -48,6 +48,7 @@ public class CorrelationLogManager implements CorrelationLogConfigurator {
     private static Log log = LogFactory.getLog(CorrelationLogManager.class);
 
     private CorrelationLogConfig config;
+    private boolean systemEnableCorrelationLogs;
 
     public CorrelationLogManager() {
         // Load root configurations from the carbon.xml file.
@@ -130,7 +131,7 @@ public class CorrelationLogManager implements CorrelationLogConfigurator {
                 System.getProperty(CorrelationLogConstants.CORRELATION_LOGS_SYS_PROPERTY));
         if (systemEnable) {
             enable = true;
-            components = CorrelationLogConstants.DEFAULT_COMPONENTS;
+            systemEnableCorrelationLogs = true;
             String systemDeniedThreads = System.getProperty(CorrelationLogConstants.DENIED_THREADS_SYS_PROPERTY);
             deniedThreads = (systemDeniedThreads != null) ?
                     CorrelationLogUtil.toArray(systemDeniedThreads) : CorrelationLogConstants.DEFAULT_DENIED_THREADS;
@@ -163,7 +164,8 @@ public class CorrelationLogManager implements CorrelationLogConfigurator {
     private ImmutableCorrelationLogConfig getComponentSpecificConfiguration(String componentName) {
         // Build component specific immutable configuration object
         return new ImmutableCorrelationLogConfig(
-                config.isEnable() && CorrelationLogUtil.isComponentAllowed(componentName, config.getComponents()),
+                systemEnableCorrelationLogs || (config.isEnable() &&
+                        CorrelationLogUtil.isComponentAllowed(componentName, config.getComponents())),
                 config.getDeniedThreads(),
                 config.getComponentConfigs().get(componentName).isLogAllMethods());
     }

--- a/core/org.wso2.carbon.logging.correlation/src/main/java/org/wso2/carbon/logging/correlation/internal/CorrelationLogManager.java
+++ b/core/org.wso2.carbon.logging.correlation/src/main/java/org/wso2/carbon/logging/correlation/internal/CorrelationLogManager.java
@@ -134,7 +134,9 @@ public class CorrelationLogManager implements CorrelationLogConfigurator {
         if (systemEnable) {
             enable = true;
             components = CorrelationLogConstants.DEFAULT_COMPONENTS;
-            deniedThreads = CorrelationLogConstants.DEFAULT_DENIED_THREADS;
+            String systemDeniedThreads = System.getProperty(CorrelationLogConstants.DENIED_THREADS_SYS_PROPERTY);
+            deniedThreads = (systemDeniedThreads != null) ?
+                    CorrelationLogUtil.toArray(systemDeniedThreads) : CorrelationLogConstants.DEFAULT_DENIED_THREADS;
             log.debug("Correlation log configuration enabled from the System parameter");
             CorrelationLogHolder.getInstance().setSystemEnabledCorrelationLogs(true);
         } else {

--- a/core/org.wso2.carbon.logging.correlation/src/main/java/org/wso2/carbon/logging/correlation/internal/CorrelationLogManager.java
+++ b/core/org.wso2.carbon.logging.correlation/src/main/java/org/wso2/carbon/logging/correlation/internal/CorrelationLogManager.java
@@ -47,14 +47,11 @@ import org.wso2.carbon.logging.correlation.utils.CorrelationLogUtil;
 public class CorrelationLogManager implements CorrelationLogConfigurator {
     private static Log log = LogFactory.getLog(CorrelationLogManager.class);
 
-
-
     private CorrelationLogConfig config;
 
     public CorrelationLogManager() {
         // Load root configurations from the carbon.xml file.
         this.config = loadRootConfigurations();
-
     }
 
     @Activate
@@ -142,7 +139,6 @@ public class CorrelationLogManager implements CorrelationLogConfigurator {
         } else {
             log.debug("Correlation log configurations are loaded from the carbon.xml file.");
         }
-
         return new CorrelationLogConfig(enable, components, deniedThreads);
     }
 
@@ -171,6 +167,4 @@ public class CorrelationLogManager implements CorrelationLogConfigurator {
                 config.getDeniedThreads(),
                 config.getComponentConfigs().get(componentName).isLogAllMethods());
     }
-
-
 }

--- a/core/org.wso2.carbon.logging.correlation/src/main/java/org/wso2/carbon/logging/correlation/internal/CorrelationLogManager.java
+++ b/core/org.wso2.carbon.logging.correlation/src/main/java/org/wso2/carbon/logging/correlation/internal/CorrelationLogManager.java
@@ -113,6 +113,8 @@ public class CorrelationLogManager implements CorrelationLogConfigurator {
      *
      * @return
      */
+
+
     private CorrelationLogConfig loadRootConfigurations() {
         boolean enable = Boolean.parseBoolean(
                 ServerConfiguration.getInstance().getFirstProperty(CorrelationLogConstants.CONFIG_PATH_ENABLE));
@@ -123,7 +125,17 @@ public class CorrelationLogManager implements CorrelationLogConfigurator {
         String[] deniedThreads = deniedThreadsList != null ?
                 CorrelationLogUtil.toArray(deniedThreadsList) : CorrelationLogConstants.DEFAULT_DENIED_THREADS;
 
-        log.debug("Correlation log configurations are loaded from the carbon.xml file.");
+        boolean systemEnable = Boolean.parseBoolean(
+                System.getProperty(CorrelationLogConstants.CORRELATION_LOGS_SYS_PROPERTY));
+        if (systemEnable) {
+            enable = true;
+            components = CorrelationLogConstants.DEFAULT_COMPONENTS;
+            deniedThreads = CorrelationLogConstants.DEFAULT_DENIED_THREADS;
+            log.debug("Correlation log configuration enabled from the System parameter");
+        } else {
+            log.debug("Correlation log configurations are loaded from the carbon.xml file.");
+        }
+
         return new CorrelationLogConfig(enable, components, deniedThreads);
     }
 

--- a/core/org.wso2.carbon.logging.correlation/src/main/java/org/wso2/carbon/logging/correlation/utils/CorrelationLogConstants.java
+++ b/core/org.wso2.carbon.logging.correlation/src/main/java/org/wso2/carbon/logging/correlation/utils/CorrelationLogConstants.java
@@ -38,12 +38,4 @@ public class CorrelationLogConstants {
             "BPELServer",
             "CarbonDeploymentSchedulerThread"
     };
-
-    public static final String[] DEFAULT_COMPONENTS = {
-            "http",
-            "ldap" ,
-            "jdbc",
-            "synapse",
-            "method-calls"
-    };
 }

--- a/core/org.wso2.carbon.logging.correlation/src/main/java/org/wso2/carbon/logging/correlation/utils/CorrelationLogConstants.java
+++ b/core/org.wso2.carbon.logging.correlation/src/main/java/org/wso2/carbon/logging/correlation/utils/CorrelationLogConstants.java
@@ -29,6 +29,7 @@ public class CorrelationLogConstants {
     public static final String CONFIG_PATH_DENIED_THREADS = "CorrelationLogs.deniedThreads";
     public static final String CONFIG_PATH_COMPONENT_CONFIGS = "CorrelationLogs.componentConfigs";
     public static final String CORRELATION_LOGS_SYS_PROPERTY = "enableCorrelationLogs";
+    public static final String DENIED_THREADS_SYS_PROPERTY = "org.wso2.CorrelationLogInterceptor.BlacklistedThreads";
 
     // Defaults
     public static final String[] DEFAULT_DENIED_THREADS = {

--- a/core/org.wso2.carbon.logging.correlation/src/main/java/org/wso2/carbon/logging/correlation/utils/CorrelationLogConstants.java
+++ b/core/org.wso2.carbon.logging.correlation/src/main/java/org/wso2/carbon/logging/correlation/utils/CorrelationLogConstants.java
@@ -28,6 +28,7 @@ public class CorrelationLogConstants {
     public static final String CONFIG_PATH_COMPONENTS = "CorrelationLogs.components";
     public static final String CONFIG_PATH_DENIED_THREADS = "CorrelationLogs.deniedThreads";
     public static final String CONFIG_PATH_COMPONENT_CONFIGS = "CorrelationLogs.componentConfigs";
+    public static final String CORRELATION_LOGS_SYS_PROPERTY = "enableCorrelationLogs";
 
     // Defaults
     public static final String[] DEFAULT_DENIED_THREADS = {
@@ -35,5 +36,13 @@ public class CorrelationLogConstants {
             "HumanTaskServer" ,
             "BPELServer",
             "CarbonDeploymentSchedulerThread"
+    };
+
+    public static final String[] DEFAULT_COMPONENTS = {
+            "http",
+            "ldap" ,
+            "jdbc",
+            "synapse",
+            "method-calls"
     };
 }

--- a/core/org.wso2.carbon.logging.correlation/src/main/java/org/wso2/carbon/logging/correlation/utils/CorrelationLogHolder.java
+++ b/core/org.wso2.carbon.logging.correlation/src/main/java/org/wso2/carbon/logging/correlation/utils/CorrelationLogHolder.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2022, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
@@ -28,13 +28,12 @@ import org.wso2.carbon.logging.correlation.bean.ImmutableCorrelationLogConfig;
 public class CorrelationLogHolder {
 
     private static final Log log = LogFactory.getLog(CorrelationLogHolder.class);
-    private static HashMap<String, CorrelationLogConfigurable> services;
+    private static HashMap<String, CorrelationLogConfigurable> services = new HashMap<>();
     private static final CorrelationLogHolder correlationLogHolder = new CorrelationLogHolder();
 
     private boolean systemEnabledCorrelationLogs = false;
 
     private CorrelationLogHolder() {
-        services = new HashMap<>();
     }
 
     public static CorrelationLogHolder getInstance() {

--- a/core/org.wso2.carbon.logging.correlation/src/main/java/org/wso2/carbon/logging/correlation/utils/CorrelationLogHolder.java
+++ b/core/org.wso2.carbon.logging.correlation/src/main/java/org/wso2/carbon/logging/correlation/utils/CorrelationLogHolder.java
@@ -51,7 +51,9 @@ public class CorrelationLogHolder {
     public CorrelationLogConfigurable getLogServiceInstance(String serviceName) {
 
         if (services.containsKey(serviceName)) {
-            log.debug("Accessing Log Service Instance : " + serviceName);
+            if (log.isDebugEnabled()) {
+                log.debug("Accessing Log Service Instance : " + serviceName);
+            }
             return services.get(serviceName);
         }
         return null;

--- a/core/org.wso2.carbon.logging.correlation/src/main/java/org/wso2/carbon/logging/correlation/utils/CorrelationLogHolder.java
+++ b/core/org.wso2.carbon.logging.correlation/src/main/java/org/wso2/carbon/logging/correlation/utils/CorrelationLogHolder.java
@@ -41,7 +41,7 @@ public class CorrelationLogHolder {
     }
 
     public void addCorrelationLogConfigurableService(CorrelationLogConfigurable service) {
-        services.put(service.getName(), service);
+        services.put(service.getName().trim(), service);
     }
 
     public void removeCorrelationLogConfigurableService(String serviceName) {
@@ -60,7 +60,7 @@ public class CorrelationLogHolder {
     public void setCorrelationLogServiceConfigs(CorrelationLogConfig config) {
         if (!systemEnabledCorrelationLogs) {
             for (CorrelationLogConfigurable service : services.values()) {
-                String componentName = service.getName();
+                String componentName = service.getName().trim();
                 ImmutableCorrelationLogConfig componentConfig = new ImmutableCorrelationLogConfig(
                         config.isEnable() && CorrelationLogUtil.isComponentAllowed(componentName, config.getComponents()),
                         config.getDeniedThreads(),

--- a/core/org.wso2.carbon.logging.correlation/src/main/java/org/wso2/carbon/logging/correlation/utils/CorrelationLogHolder.java
+++ b/core/org.wso2.carbon.logging.correlation/src/main/java/org/wso2/carbon/logging/correlation/utils/CorrelationLogHolder.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.logging.correlation.utils;
+
+import java.util.HashMap;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.logging.correlation.CorrelationLogConfigurable;
+import org.wso2.carbon.logging.correlation.bean.CorrelationLogConfig;
+import org.wso2.carbon.logging.correlation.bean.ImmutableCorrelationLogConfig;
+
+public class CorrelationLogHolder {
+
+    private static final Log log = LogFactory.getLog(CorrelationLogHolder.class);
+    private static HashMap<String, CorrelationLogConfigurable> services;
+    private static final CorrelationLogHolder correlationLogHolder = new CorrelationLogHolder();
+
+    private boolean systemEnabledCorrelationLogs = false;
+
+    private CorrelationLogHolder() {
+        services = new HashMap<>();
+    }
+
+    public static CorrelationLogHolder getInstance() {
+        return correlationLogHolder;
+    }
+
+    public void addCorrelationLogConfigurableService(CorrelationLogConfigurable service) {
+        services.put(service.getName(), service);
+    }
+
+    public void removeCorrelationLogConfigurableService(String serviceName) {
+        services.remove(serviceName);
+    }
+
+    public CorrelationLogConfigurable getLogServiceInstance(String serviceName) {
+
+        if (services.containsKey(serviceName)) {
+            log.debug("Accessing Log Service Instance : " + serviceName);
+            return services.get(serviceName);
+        }
+        return null;
+    }
+
+    public void setCorrelationLogServiceConfigs(CorrelationLogConfig config) {
+        if (!systemEnabledCorrelationLogs) {
+            for (CorrelationLogConfigurable service : services.values()) {
+                String componentName = service.getName();
+                ImmutableCorrelationLogConfig componentConfig = new ImmutableCorrelationLogConfig(
+                        config.isEnable() && CorrelationLogUtil.isComponentAllowed(componentName, config.getComponents()),
+                        config.getDeniedThreads(),
+                        false);
+                service.onConfigure(componentConfig);
+            }
+        }
+    }
+
+    public void setSystemEnabledCorrelationLogs(boolean systemEnabledCorrelationLogs) {
+        this.systemEnabledCorrelationLogs = systemEnabledCorrelationLogs;
+    }
+}

--- a/core/org.wso2.carbon.ndatasource.rdbms/src/main/java/org/wso2/carbon/ndatasource/rdbms/JDBCConfigurableCorrelationLogService.java
+++ b/core/org.wso2.carbon.ndatasource.rdbms/src/main/java/org/wso2/carbon/ndatasource/rdbms/JDBCConfigurableCorrelationLogService.java
@@ -35,6 +35,12 @@ public class JDBCConfigurableCorrelationLogService implements CorrelationLogConf
     }
 
     @Override
+    public ImmutableCorrelationLogConfig getConfiguration() {
+        return new ImmutableCorrelationLogConfig(JDBCCorrelationConfigDataHolder.isEnable(),
+                JDBCCorrelationConfigDataHolder.getDeniedThreads(), false);
+    }
+
+    @Override
     public void onConfigure(ImmutableCorrelationLogConfig config) {
         JDBCCorrelationConfigDataHolder.setEnable(config.isEnable());
         JDBCCorrelationConfigDataHolder.setDeniedThreads(config.getDeniedThreads());

--- a/core/org.wso2.carbon.tomcat.ext/src/main/java/org/wso2/carbon/tomcat/ext/service/HTTPConfigurableCorrelationLogService.java
+++ b/core/org.wso2.carbon.tomcat.ext/src/main/java/org/wso2/carbon/tomcat/ext/service/HTTPConfigurableCorrelationLogService.java
@@ -34,6 +34,12 @@ public class HTTPConfigurableCorrelationLogService implements CorrelationLogConf
     }
 
     @Override
+    public ImmutableCorrelationLogConfig getConfiguration() {
+        return new ImmutableCorrelationLogConfig( HTTPCorrelationConfigDataHolder.isEnable(),
+                new String[0], false);
+    }
+
+    @Override
     public void onConfigure(ImmutableCorrelationLogConfig config) {
         HTTPCorrelationConfigDataHolder.setEnable(config.isEnable());
     }

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/LDAPConfigurableCorrelationLogService.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/LDAPConfigurableCorrelationLogService.java
@@ -35,6 +35,12 @@ public class LDAPConfigurableCorrelationLogService implements CorrelationLogConf
     }
 
     @Override
+    public ImmutableCorrelationLogConfig getConfiguration() {
+        return new ImmutableCorrelationLogConfig( LDAPCorrelationConfigDataHolder.isEnable(),
+                new String[0], false);
+    }
+
+    @Override
     public void onConfigure(ImmutableCorrelationLogConfig config) {
         LDAPCorrelationConfigDataHolder.setEnable(config.isEnable());
     }


### PR DESCRIPTION
## Purpose
> Fix: wso2/api-manager#275
> Fix: wso2/api-manager#340

## Approach
> Add support to read the system property while loading the correlation log configs from the carbon.xml file
> Add a correlation log service holder to store the instances of the correlation log services to be able to manipulate correlation log configs during the runtime

