### PR TITLE
Update the catalina-server.xml.j2 to configure additional attributes to AccessLogValve

### DIFF
--- a/distribution/kernel/carbon-home/repository/resources/conf/templates/repository/conf/tomcat/catalina-server.xml.j2
+++ b/distribution/kernel/carbon-home/repository/resources/conf/templates/repository/conf/tomcat/catalina-server.xml.j2
@@ -75,13 +75,20 @@
                 <Valve className="org.wso2.carbon.tomcat.ext.valves.ConfigurableLoggerAccessLogValve"
                     pattern="{{http_access_log.pattern}}"/>
                 {% else %}
+                <Valve
+                    className="org.apache.catalina.valves.AccessLogValve"
                     {% if http_access_log.directory is defined %}
-                    <Valve className="org.apache.catalina.valves.AccessLogValve" directory="{{http_access_log.directory}}"
-                           prefix="http_access_" suffix=".log" pattern="{{http_access_log.pattern}}"/>
+                    directory="{{http_access_log.directory}}"
                     {% else %}
-                    <Valve className="org.apache.catalina.valves.AccessLogValve" directory="${carbon.home}/repository/logs"
-                        prefix="http_access_" suffix=".log" pattern="{{http_access_log.pattern}}"/>
+                    directory="${carbon.home}/repository/logs"
                     {% endif %}
+                    prefix="http_access_"
+                    suffix=".log"
+                    pattern="{{http_access_log.pattern}}"
+                    {% for property,value in catalinaValves.accessLogValve.properties.items() %}
+                    {{property}}="{{value}}"
+                    {% endfor %}
+                 />
                 {% endif %}
                 <Valve className="org.wso2.carbon.tomcat.ext.valves.CarbonStuckThreadDetectionValve" threshold="600"/>
                 <Valve className="org.wso2.carbon.tomcat.ext.valves.CompositeValve"/>


### PR DESCRIPTION
## Purpose
Improve the `catalina-server.xml.j2 ` file to configure additional attributes to AccessLogValve

The following documentation highlights the additional attributes that can be incorporated to the valve.
https://tomcat.apache.org/tomcat-9.0-doc/config/valve.html#Access_Log_Valve/Attributes


Example
```
[catalinaValves.accessLogValve.properties]
resolveHosts = "true"
renameOnRotate = "false"
requestAttributesEnabled = "false"
rotatable = "false"
```

Relates Issues 
- https://github.com/wso2/product-is/issues/14433
