### PR TITLE
[4.6.x] Update xmlbeans and xerces vesions

### DIFF
--- a/core/org.wso2.carbon.base/pom.xml
+++ b/core/org.wso2.carbon.base/pom.xml
@@ -119,7 +119,7 @@
             <artifactId>javax.servlet</artifactId>
         </dependency>
         <dependency>
-            <groupId>xerces.wso2</groupId>
+            <groupId>org.wso2.orbit.xerces</groupId>
             <artifactId>xercesImpl</artifactId>
             <scope>provided</scope>
         </dependency>

--- a/core/org.wso2.carbon.server/pom.xml
+++ b/core/org.wso2.carbon.server/pom.xml
@@ -36,7 +36,7 @@
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>xerces.wso2</groupId>
+            <groupId>org.wso2.orbit.xerces</groupId>
             <artifactId>xercesImpl</artifactId>
         </dependency>
         <dependency>

--- a/core/org.wso2.carbon.server/src/assembly/bin.xml
+++ b/core/org.wso2.carbon.server/src/assembly/bin.xml
@@ -31,7 +31,7 @@
         <dependencySet>
             <outputDirectory>lib</outputDirectory>
             <includes>
-                <include>xerces.wso2:xercesImpl:jar</include>
+                <include>org.wso2.orbit.xerces:xercesImpl:jar</include>
                 <include>xalan.wso2:xalan:jar</include>
                 <include>xml-apis.wso2:xml-apis:jar</include>
                 <include>org.wso2.carbon:org.wso2.carbon.server:jar</include>

--- a/core/org.wso2.carbon.user.core/pom.xml
+++ b/core/org.wso2.carbon.user.core/pom.xml
@@ -45,7 +45,7 @@
             <artifactId>org.wso2.carbon.user.api</artifactId>
         </dependency>
         <dependency>
-            <groupId>xerces.wso2</groupId>
+            <groupId>org.wso2.orbit.xerces</groupId>
             <artifactId>xercesImpl</artifactId>
         </dependency>
         <dependency>

--- a/core/org.wso2.carbon.utils/pom.xml
+++ b/core/org.wso2.carbon.utils/pom.xml
@@ -82,7 +82,7 @@
             <artifactId>smackx</artifactId>
         </dependency>
         <dependency>
-            <groupId>xerces.wso2</groupId>
+            <groupId>org.wso2.orbit.xerces</groupId>
             <artifactId>xercesImpl</artifactId>
         </dependency>
         <dependency>

--- a/distribution/kernel/pom.xml
+++ b/distribution/kernel/pom.xml
@@ -98,7 +98,7 @@
             <artifactId>geronimo-jms_1.1_spec</artifactId>
         </dependency>
         <dependency>
-            <groupId>xerces.wso2</groupId>
+            <groupId>org.wso2.orbit.xerces</groupId>
             <artifactId>xercesImpl</artifactId>
         </dependency>
         <dependency>

--- a/distribution/kernel/src/assembly/bin.xml
+++ b/distribution/kernel/src/assembly/bin.xml
@@ -123,7 +123,7 @@
         <dependencySet>
             <outputDirectory>lib</outputDirectory>
             <includes>
-                <include>xerces.wso2:xercesImpl:jar</include>
+                <include>org.wso2.orbit.xerces:xercesImpl:jar</include>
                 <include>org.wso2.orbit.xalan:xalan:jar</include>
                 <include>xml-apis:xml-apis:jar</include>
                 <include>xml-resolver:xml-resolver:jar</include>
@@ -151,7 +151,7 @@
                 <include>com.google.re2j:re2j:jar</include>
                 <include>commons-codec:commons-codec:jar</include>
                 <include>ant-contrib:ant-contrib:jar</include>
-                <include>xerces.wso2:xercesImpl:jar</include>
+                <include>org.wso2.orbit.xerces:xercesImpl:jar</include>
                 <include>org.wso2.ciphertool:org.wso2.ciphertool:jar</include>
                 <include>javax.xml.bind:jaxb-api:jar</include>
                 <include>com.sun.xml.bind:jaxb-impl:jar</include>

--- a/features/org.wso2.carbon.core.common.feature/pom.xml
+++ b/features/org.wso2.carbon.core.common.feature/pom.xml
@@ -81,7 +81,7 @@
                                 <bundleDef>org.wso2.orbit.com.hazelcast:hazelcast:${orbit.version.hazelcast}</bundleDef>
                                 <bundleDef>org.apache.tiles.wso2:tiles-jsp:${orbit.version.tiles}</bundleDef>
                                 <bundleDef>org.apache.ant.wso2:ant:${version.ant}</bundleDef>
-                                <bundleDef>org.apache.xmlbeans.wso2:xmlbeans:${version.xmlbeans}</bundleDef>
+                                <bundleDef>org.wso2.orbit.org.apache.xmlbeans:xmlbeans:${version.xmlbeans}</bundleDef>
                                 <bundleDef>org.apache.ws.commons.axiom.wso2:axiom:${orbit.version.axiom}</bundleDef>
                                 <bundleDef>org.wso2.orbit.org.apache.neethi:neethi:${neethi.osgi.version}</bundleDef>
                                 <bundleDef>org.apache.woden.wso2:woden:${version.woden}</bundleDef>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -422,7 +422,7 @@
         <version.ant.contrib>1.0b3</version.ant.contrib>
 
         <!-- Apache xmlbeans -->
-        <version.xmlbeans>2.3.0.wso2v1</version.xmlbeans>
+        <version.xmlbeans>3.1.0.wso2v1</version.xmlbeans>
 
         <!-- Apache woden-->
         <version.woden>1.0.0.M9-wso2v1</version.woden>
@@ -526,7 +526,7 @@
         <!--<version.opensaml2>2.4.1.wso2v1</version.opensaml2>-->
         <version.compass>2.0.1.wso2v2</version.compass>
 
-        <version.xercesImpl>2.8.1.wso2v2</version.xercesImpl>
+        <version.xercesImpl>2.12.2.wso2v1</version.xercesImpl>
         <version.xalan>2.7.2.wso2v2</version.xalan>
         <version.xml-apis>1.4.01</version.xml-apis>
         <version.xml-resolver>1.2</version.xml-resolver>
@@ -1038,7 +1038,7 @@
                 </exclusions>
             </dependency>
             <dependency>
-                <groupId>org.apache.xmlbeans.wso2</groupId>
+                <groupId>org.wso2.orbit.org.apache.xmlbeans</groupId>
                 <artifactId>xmlbeans</artifactId>
                 <version>${version.xmlbeans}</version>
             </dependency>
@@ -1053,7 +1053,7 @@
                 <version>${neethi.osgi.version}</version>
             </dependency>
             <dependency>
-                <groupId>xerces.wso2</groupId>
+                <groupId>org.wso2.orbit.xerces</groupId>
                 <artifactId>xercesImpl</artifactId>
                 <version>${version.xercesImpl}</version>
             </dependency>


### PR DESCRIPTION
## Purpose
Upgrades xmlbeans to `3.1.0` and xerces to `2.12.2`

Related internal: https://github.com/wso2-enterprise/wso2-apim-internal/issues/473