### PR TITLE
Store admin user id in realm

### DIFF
--- a/core/org.wso2.carbon.user.api/src/main/java/org/wso2/carbon/user/api/RealmConfiguration.java
+++ b/core/org.wso2.carbon.user.api/src/main/java/org/wso2/carbon/user/api/RealmConfiguration.java
@@ -35,6 +35,7 @@ public class RealmConfiguration {
     protected String addAdmin = null;
     protected String adminRoleName = null;
     protected String adminUserName = null;
+    protected String adminUserId = null;
     protected String adminPassword = null;
     protected String everyOneRoleName = null;
     protected String realmClassName = null;
@@ -137,6 +138,7 @@ public class RealmConfiguration {
         realmConfig.setAddAdmin(addAdmin);
         realmConfig.setAdminRoleName(adminRoleName);
         realmConfig.setAdminUserName(adminUserName);
+        realmConfig.setAdminUserId(adminUserId);
         realmConfig.setAdminPassword(adminPassword);
         realmConfig.setAssociatedOrganizationUUID(associatedOrganizationUUID);
         realmConfig.setEveryOneRoleName(everyOneRoleName);
@@ -346,5 +348,15 @@ public class RealmConfiguration {
     public String getAssociatedOrganizationUUID() {
 
         return associatedOrganizationUUID;
+    }
+
+    public String getAdminUserId() {
+
+        return adminUserId;
+    }
+
+    public void setAdminUserId(String adminUserId) {
+
+        this.adminUserId = adminUserId;
     }
 }

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/UserCoreConstants.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/UserCoreConstants.java
@@ -133,6 +133,7 @@ public class UserCoreConstants {
         public static final String LOCAL_NAME_ADMIN_USER = "AdminUser";
         public static final String LOCAL_NAME_USER_NAME = "UserName";
         public static final String LOCAL_NAME_PASSWORD = "Password";
+        public static final String LOCAL_NAME_USERID = "UserId";
         public static final String LOCAL_NAME_AUTHENTICATOR = "Authenticator";
         public static final String LOCAL_NAME_USER_STORE_MANAGER = "UserStoreManager";
         public static final String LOCAL_NAME_ATHZ_MANAGER = "AuthorizationManager";

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/config/RealmConfigXMLProcessor.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/config/RealmConfigXMLProcessor.java
@@ -89,12 +89,16 @@ public class RealmConfigXMLProcessor {
         OMElement adminUserNameElem = factory.createOMElement(new QName(
                 UserCoreConstants.RealmConfig.LOCAL_NAME_USER_NAME));
         adminUserNameElem.setText(realmConfig.getAdminUserName());
+        OMElement adminUserIdElem = factory.createOMElement(new QName(
+                UserCoreConstants.RealmConfig.LOCAL_NAME_USERID));
+        adminUserIdElem.setText(realmConfig.getAdminUserId());
         OMElement adminPasswordElem = factory.createOMElement(new QName(
                 UserCoreConstants.RealmConfig.LOCAL_NAME_PASSWORD));
         addAdmin.setText(UserCoreUtil.removeDomainFromName(realmConfig.getAddAdmin()));
         adminPasswordElem.setText(realmConfig.getAdminPassword());
         adminUser.addChild(adminUserNameElem);
         adminUser.addChild(adminPasswordElem);
+        adminUser.addChild(adminUserIdElem);
         mainConfig.addChild(addAdmin);
         mainConfig.addChild(adminUser);
 
@@ -298,6 +302,7 @@ public class RealmConfigXMLProcessor {
         String adminRoleName = null;
         String adminUserName = null;
         String adminPassword = null;
+        String adminUserId = null;
         String everyOneRoleName = null;
         String realmClass = null;
         String description = null;
@@ -376,6 +381,14 @@ public class RealmConfigXMLProcessor {
         OMElement adminPasswordElement =
                 adminUser.getFirstChildWithName(new QName(UserCoreConstants.RealmConfig.LOCAL_NAME_PASSWORD));
         adminPassword = MiscellaneousUtil.resolve(adminPasswordElement, secretResolver);
+
+        if (adminUser.getFirstChildWithName(new QName(UserCoreConstants.RealmConfig.LOCAL_NAME_USERID)) != null) {
+            adminUserId = adminUser
+                    .getFirstChildWithName(
+                            new QName(UserCoreConstants.RealmConfig.LOCAL_NAME_USERID)).getText()
+                    .trim();
+        }
+
         adminRoleName = mainConfig
                 .getFirstChildWithName(
                         new QName(UserCoreConstants.RealmConfig.LOCAL_NAME_ADMIN_ROLE)).getText()
@@ -475,6 +488,7 @@ public class RealmConfigXMLProcessor {
                     + everyOneRoleName);
             realmConfig.setAdminRoleName(adminRoleName);
             realmConfig.setAdminUserName(adminUserName);
+            realmConfig.setAdminUserId(adminUserId);
             realmConfig.setIsOverrideUsernameClaimFromInternalUsername(isOverrideUsernameClaimFromInternalUsername);
             realmConfig.setUserStoreProperties(userStoreProperties);
             realmConfig.setAuthzProperties(authzProperties);

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/config/multitenancy/CommonLDAPRealmConfigBuilder.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/config/multitenancy/CommonLDAPRealmConfigBuilder.java
@@ -50,6 +50,7 @@ public class CommonLDAPRealmConfigBuilder implements MultiTenantRealmConfigBuild
             realmConfig = bootStrapConfig.cloneRealmConfigurationWithoutSecondary();
             realmConfig.setAdminPassword(persistedConfig.getAdminPassword());
             realmConfig.setAdminUserName(persistedConfig.getAdminUserName());
+            realmConfig.setAdminUserId(persistedConfig.getAdminUserId());
             realmConfig.setAdminRoleName(persistedConfig.getAdminRoleName());
             realmConfig.setAssociatedOrganizationUUID(persistedConfig.getAssociatedOrganizationUUID());
             realmConfig.setEveryOneRoleName(persistedConfig.getEveryOneRoleName());
@@ -103,6 +104,7 @@ public class CommonLDAPRealmConfigBuilder implements MultiTenantRealmConfigBuild
 
             ldapRealmConfig.setAdminPassword(UserCoreUtil.getDummyPassword());
             ldapRealmConfig.setAdminUserName(tenantInfo.getAdminName());
+            ldapRealmConfig.setAdminUserId(tenantInfo.getAdminUserId());
             ldapRealmConfig.setTenantId(tenantId);
             ldapRealmConfig.setAssociatedOrganizationUUID(tenantInfo.getAssociatedOrganizationUUID());
 

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/config/multitenancy/FileSystemRealmConfigBuilder.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/config/multitenancy/FileSystemRealmConfigBuilder.java
@@ -49,6 +49,7 @@ public class FileSystemRealmConfigBuilder implements MultiTenantRealmConfigBuild
             realmConfig = bootStrapConfig.cloneRealmConfiguration();
             realmConfig.setAdminPassword(persistedConfig.getAdminPassword());
             realmConfig.setAdminUserName(persistedConfig.getAdminUserName());
+            realmConfig.setAdminUserId(persistedConfig.getAdminUserId());
             realmConfig.setAdminRoleName(persistedConfig.getAdminRoleName());
             realmConfig.setAssociatedOrganizationUUID(persistedConfig.getAssociatedOrganizationUUID());
             realmConfig.setEveryOneRoleName(persistedConfig.getEveryOneRoleName());
@@ -102,6 +103,7 @@ public class FileSystemRealmConfigBuilder implements MultiTenantRealmConfigBuild
             RealmConfiguration ldapRealmConfig = bootStrapConfig.cloneRealmConfiguration();
             ldapRealmConfig.setAdminPassword(UserCoreUtil.getDummyPassword());
             ldapRealmConfig.setAdminUserName(tenantInfo.getAdminName());
+            ldapRealmConfig.setAdminUserId(tenantInfo.getAdminUserId());
             ldapRealmConfig.setTenantId(tenantId);
             ldapRealmConfig.setAssociatedOrganizationUUID(tenantInfo.getAssociatedOrganizationUUID());
 

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/config/multitenancy/LDAPRealmConfigBuilder.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/config/multitenancy/LDAPRealmConfigBuilder.java
@@ -66,6 +66,7 @@ public class LDAPRealmConfigBuilder implements MultiTenantRealmConfigBuilder {
             //TODO: Random password generation. 
             ldapRealmConfig.setAdminPassword(UIDGenerator.generateUID());
             ldapRealmConfig.setAdminUserName(tenantInfo.getAdminName());
+            ldapRealmConfig.setAdminUserId(tenantInfo.getAdminUserId());
             ldapRealmConfig.setTenantId(tenantId);
             ldapRealmConfig.setAssociatedOrganizationUUID(tenantInfo.getAssociatedOrganizationUUID());
 

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/config/multitenancy/SimpleRealmConfigBuilder.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/config/multitenancy/SimpleRealmConfigBuilder.java
@@ -42,6 +42,7 @@ public class SimpleRealmConfigBuilder implements MultiTenantRealmConfigBuilder {
             realmConfig = bootStrapConfig.cloneRealmConfigurationWithoutSecondary();
             realmConfig.setAdminUserName(persistedConfig.getAdminUserName());
             realmConfig.setAdminPassword(persistedConfig.getAdminPassword());
+            realmConfig.setAdminUserId(persistedConfig.getAdminUserId());
             realmConfig.setAdminRoleName(persistedConfig.getAdminRoleName());
             realmConfig.setAssociatedOrganizationUUID(persistedConfig.getAssociatedOrganizationUUID());
             realmConfig.setEveryOneRoleName(persistedConfig.getEveryOneRoleName());
@@ -75,6 +76,7 @@ public class SimpleRealmConfigBuilder implements MultiTenantRealmConfigBuilder {
             removePropertiesFromTenantRealmConfig(realmConfig);
             realmConfig.setAdminUserName(UserCoreUtil.removeDomainFromName(tenantInfo.getAdminName()));
             realmConfig.setAdminPassword(UserCoreUtil.getDummyPassword());
+            realmConfig.setAdminUserId(tenantInfo.getAdminUserId());
             realmConfig.setAssociatedOrganizationUUID(tenantInfo.getAssociatedOrganizationUUID());
             realmConfig.setTenantId(tenantId);
 

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/tenant/JDBCTenantManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/tenant/JDBCTenantManager.java
@@ -473,6 +473,7 @@ public class JDBCTenantManager implements TenantManager {
                 tenant.setRealmConfig(realmConfig);
                 setSecondaryUserStoreConfig(realmConfig, tenantId);
                 tenant.setAdminName(realmConfig.getAdminUserName());
+                tenant.setAdminUserId(realmConfig.getAdminUserId());
                 if (tenantUUIDColumnExists) {
                     tenant.setTenantUniqueID(uniqueId);
                 }
@@ -802,9 +803,14 @@ public class JDBCTenantManager implements TenantManager {
                 tenant.setRealmConfig(realmConfig);
                 setSecondaryUserStoreConfig(realmConfig, id);
                 tenant.setAdminName(realmConfig.getAdminUserName());
-                // Handle the admin UUID resolution properly with https://github.com/wso2/product-is/issues/14001.
                 if (StringUtils.isNotBlank(tenant.getAssociatedOrganizationUUID())) {
-                    tenant.setAdminUserId(realmConfig.getAdminUserName());
+                    String adminId = realmConfig.getAdminUserId();
+                    if (StringUtils.isNotBlank(adminId)) {
+                        tenant.setAdminUserId(adminId);
+                    } else {
+                        // If realms were not migrated after https://github.com/wso2/product-is/issues/14001.
+                        tenant.setAdminUserId(realmConfig.getAdminUserName());
+                    }
                 } else {
                     tenant.setAdminUserId(getUserId(realmConfig.getAdminUserName(), id));
                 }


### PR DESCRIPTION
## Purpose
Fix https://github.com/wso2/product-is/issues/14001

Now realm config looks like follows. Having `<UserId></UserId>` is not mandatory.
```
            <AdminUser>
                <UserName></UserName>
                <Password></Password>
                <UserId></UserId>
            </AdminUser>
```