### PR TITLE
Change the MSSQL query tail for Claim filtering

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCUserStoreManager.java
@@ -3630,7 +3630,7 @@ public class UniqueIDJDBCUserStoreManager extends JDBCUserStoreManager {
                 }
             } else if (MSSQL.equals(dbType)) {
                 if (isClaimFiltering && !isGroupFiltering && totalMultiClaimFilters > 1) {
-                    StringBuilder subQuery = new StringBuilder(") As Q0");
+                    StringBuilder alias = new StringBuilder(") As Q0");
                     /*
                      * x is used to count the number of sub queries.
                      * (totalMultiClaimFilters * 2) --> totalMultiClaims are multiplied by 2 as 2 sub queries for
@@ -3639,11 +3639,11 @@ public class UniqueIDJDBCUserStoreManager extends JDBCUserStoreManager {
                      */
                     int x;
                     for ( x = 1; x <= (totalMultiClaimFilters * 2 - 1); x++) {
-                        subQuery = subQuery.append(" ) AS Q" + x );
+                        alias = alias.append(" ) AS Q" + x );
                     }
+                    String tail = alias.toString().concat(" WHERE Q" + String.valueOf(x-1) + ".RowNum BETWEEN ? AND ?");
                     // Handle multi attribute filtering without group filtering.
-                    sqlBuilder.setTail(subQuery.toString()
-                            .concat(" WHERE Q" + String.valueOf(x-1) + ".RowNum BETWEEN ? AND ?"), limit, offset);
+                    sqlBuilder.setTail(tail, limit, offset);
                 } else {
                     sqlBuilder.setTail(") AS R) AS P WHERE P.RowNum BETWEEN ? AND ?", limit, offset);
                 }

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCUserStoreManager.java
@@ -3630,8 +3630,19 @@ public class UniqueIDJDBCUserStoreManager extends JDBCUserStoreManager {
                 }
             } else if (MSSQL.equals(dbType)) {
                 if (isClaimFiltering && !isGroupFiltering && totalMultiClaimFilters > 1) {
+                    StringBuilder subQuery = new StringBuilder(") As Q");
+                    /*
+                     * x is used to count the number of sub queries.
+                     * (totalMultiClaimFilters * 2) --> totalMultiClaims are multiplied by 2 as 2 sub queries for
+                     * every new claim.
+                     * (totalMultiClaimFilters * 2) - 1 is deducted as there is 1 sub query in the SQL query.
+                     */
+                    for(int x = 0; x < (totalMultiClaimFilters * 2 - 1); x++) {
+                        subQuery = subQuery.append(" ) AS Q");
+                    }
                     // Handle multi attribute filtering without group filtering.
-                    sqlBuilder.setTail(") AS Q) AS S) AS R) AS P WHERE P.RowNum BETWEEN ? AND ?", limit, offset);
+                    sqlBuilder.setTail(subQuery.toString()
+                            .concat(" WHERE Q.RowNum BETWEEN ? AND ?"), limit, offset);
                 } else {
                     sqlBuilder.setTail(") AS R) AS P WHERE P.RowNum BETWEEN ? AND ?", limit, offset);
                 }

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCUserStoreManager.java
@@ -3630,19 +3630,20 @@ public class UniqueIDJDBCUserStoreManager extends JDBCUserStoreManager {
                 }
             } else if (MSSQL.equals(dbType)) {
                 if (isClaimFiltering && !isGroupFiltering && totalMultiClaimFilters > 1) {
-                    StringBuilder subQuery = new StringBuilder(") As Q");
+                    StringBuilder subQuery = new StringBuilder(") As Q0");
                     /*
                      * x is used to count the number of sub queries.
                      * (totalMultiClaimFilters * 2) --> totalMultiClaims are multiplied by 2 as 2 sub queries for
                      * every new claim.
                      * (totalMultiClaimFilters * 2) - 1 is deducted as there is 1 sub query in the SQL query.
                      */
-                    for(int x = 0; x < (totalMultiClaimFilters * 2 - 1); x++) {
-                        subQuery = subQuery.append(" ) AS Q");
+                    int x;
+                    for ( x = 1; x <= (totalMultiClaimFilters * 2 - 1); x++) {
+                        subQuery = subQuery.append(" ) AS Q" + x );
                     }
                     // Handle multi attribute filtering without group filtering.
                     sqlBuilder.setTail(subQuery.toString()
-                            .concat(" WHERE Q.RowNum BETWEEN ? AND ?"), limit, offset);
+                            .concat(" WHERE Q" + String.valueOf(x-1) + ".RowNum BETWEEN ? AND ?"), limit, offset);
                 } else {
                     sqlBuilder.setTail(") AS R) AS P WHERE P.RowNum BETWEEN ? AND ?", limit, offset);
                 }


### PR DESCRIPTION
### Purpose

- To fix the SQL query syntax error when trying claim filtering with more than 2 claims
- 

### Changes from the PR

- Change the query that used to set the tail to a dynamic query that can depends on the number of claims
- Going through a loop and add the sub queries to the tail of the sql query.

### Related issue
- https://github.com/wso2/product-is/issues/14957

### Related PR
- https://github.com/wso2-extensions/identity-governance/pull/623