### PR TITLE
Fix blank page shown after user login

### DIFF
--- a/core/org.wso2.carbon.ui/src/main/java/org/wso2/carbon/ui/CarbonUILoginUtil.java
+++ b/core/org.wso2.carbon.ui/src/main/java/org/wso2/carbon/ui/CarbonUILoginUtil.java
@@ -45,6 +45,7 @@ public final class CarbonUILoginUtil {
     private static final String USER_NOT_FOUND_ERROR_CODE = "17001";
     private static final String INVALID_CREDENTIALS_ERROR_CODE = "Invalid user credentials.";
     private static final String SAML_RESPONSE_KEY = "SAMLResponse";
+    private static final String SAML_SSO_ACS_AUTH_FAILURE_PATH = "/carbon/sso-acs/authFailure.jsp";
     private static Log log = LogFactory.getLog(CarbonUILoginUtil.class);
     private static Pattern tenantEnabledUriPattern;
     private static final String TENANT_ENABLED_URI_PATTERN = "(/.*/|/)"
@@ -490,7 +491,7 @@ public final class CarbonUILoginUtil {
                 request.getSession().invalidate();
                 CarbonUIAuthenticator carbonUIAuthenticator = getAuthenticator(request);
                 if (carbonUIAuthenticator == null && request.getParameterMap().containsKey(SAML_RESPONSE_KEY)) {
-                    response.sendRedirect(contextPath + "/carbon/sso-acs/authFailure.jsp");
+                    response.sendRedirect(contextPath + SAML_SSO_ACS_AUTH_FAILURE_PATH);
                     return false;
                 }
                 carbonUIAuthenticator.unauthenticate(request);

--- a/core/org.wso2.carbon.ui/src/main/java/org/wso2/carbon/ui/CarbonUILoginUtil.java
+++ b/core/org.wso2.carbon.ui/src/main/java/org/wso2/carbon/ui/CarbonUILoginUtil.java
@@ -44,6 +44,7 @@ public final class CarbonUILoginUtil {
     private static final String ACCOUNT_LOCK_ERROR_MESSAGE = "Cannot login until the account is unlocked.";
     private static final String USER_NOT_FOUND_ERROR_CODE = "17001";
     private static final String INVALID_CREDENTIALS_ERROR_CODE = "Invalid user credentials.";
+    private static final String SAML_RESPONSE_KEY = "SAMLResponse";
     private static Log log = LogFactory.getLog(CarbonUILoginUtil.class);
     private static Pattern tenantEnabledUriPattern;
     private static final String TENANT_ENABLED_URI_PATTERN = "(/.*/|/)"
@@ -487,7 +488,12 @@ public final class CarbonUILoginUtil {
             log.debug("Authentication failure ...", e);
             try {
                 request.getSession().invalidate();
-                getAuthenticator(request).unauthenticate(request);
+                CarbonUIAuthenticator carbonUIAuthenticator = getAuthenticator(request);
+                if (carbonUIAuthenticator == null && request.getParameterMap().containsKey(SAML_RESPONSE_KEY)) {
+                    response.sendRedirect(contextPath + "/carbon/sso-acs/authFailure.jsp");
+                    return false;
+                }
+                carbonUIAuthenticator.unauthenticate(request);
 
                 if (isLoginFailureReasonEnabled()) {
                     if (e.getCause().getMessage().contains(ACCOUNT_LOCK_ERROR_CODE) || e.getCause().getMessage()


### PR DESCRIPTION
## Description

Blank page is showing when login into the management console with IDP initiated SSO flow by using a federated identity provider. If a user is not part of the management console primary userstore and trying to login through the IDP user Instead of getting a login failed screen it is redirected to a blank page, in logs the authentication failed is shown but not in UI. Flow is working as expected when the federated user is also present in the IS with at least the login permissions and in the SP initiated SSO.

## Related Issue
- https://github.com/wso2/product-is/issues/14977