### PR TITLE
[4.8.x] Refactoring pom versions and upgrading config mapper version

### DIFF
--- a/core/feature-manager/org.wso2.carbon.feature.mgt.core/pom.xml
+++ b/core/feature-manager/org.wso2.carbon.feature.mgt.core/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.wso2.carbon</groupId>
         <artifactId>feature-manager</artifactId>
-        <version>4.7.1</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/feature-manager/org.wso2.carbon.feature.mgt.services/pom.xml
+++ b/core/feature-manager/org.wso2.carbon.feature.mgt.services/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.wso2.carbon</groupId>
         <artifactId>feature-manager</artifactId>
-        <version>4.7.1</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/feature-manager/org.wso2.carbon.feature.mgt.ui/pom.xml
+++ b/core/feature-manager/org.wso2.carbon.feature.mgt.ui/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.wso2.carbon</groupId>
         <artifactId>feature-manager</artifactId>
-        <version>4.7.1</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/feature-manager/pom.xml
+++ b/core/feature-manager/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon</groupId>
         <artifactId>carbon-kernel</artifactId>
-        <version>4.7.1</version>
+        <version>4.8.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
@@ -37,4 +37,3 @@
     </modules>
 
 </project>
-

--- a/core/javax.cache/pom.xml
+++ b/core/javax.cache/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>org.wso2.carbon</groupId>
         <artifactId>carbon-kernel</artifactId>
-        <version>4.7.1</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/org.wso2.carbon.addressing/pom.xml
+++ b/core/org.wso2.carbon.addressing/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon</groupId>
         <artifactId>carbon-kernel</artifactId>
-        <version>4.7.1</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/org.wso2.carbon.application.deployer/pom.xml
+++ b/core/org.wso2.carbon.application.deployer/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon</groupId>
         <artifactId>carbon-kernel</artifactId>
-        <version>4.7.1</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/org.wso2.carbon.authenticator.proxy/pom.xml
+++ b/core/org.wso2.carbon.authenticator.proxy/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon</groupId>
         <artifactId>carbon-kernel</artifactId>
-        <version>4.7.1</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/org.wso2.carbon.base/pom.xml
+++ b/core/org.wso2.carbon.base/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon</groupId>
         <artifactId>carbon-kernel</artifactId>
-        <version>4.7.1</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/org.wso2.carbon.bootstrap/pom.xml
+++ b/core/org.wso2.carbon.bootstrap/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon</groupId>
         <artifactId>carbon-kernel</artifactId>
-        <version>4.7.1</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/org.wso2.carbon.bridge/pom.xml
+++ b/core/org.wso2.carbon.bridge/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon</groupId>
         <artifactId>carbon-kernel</artifactId>
-        <version>4.7.1</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/org.wso2.carbon.cluster.mgt.core/pom.xml
+++ b/core/org.wso2.carbon.cluster.mgt.core/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon</groupId>
         <artifactId>carbon-kernel</artifactId>
-        <version>4.7.1</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/org.wso2.carbon.coordination.common/pom.xml
+++ b/core/org.wso2.carbon.coordination.common/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.wso2.carbon</groupId>
         <artifactId>carbon-kernel</artifactId>
-        <version>4.7.1</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/org.wso2.carbon.coordination.core/pom.xml
+++ b/core/org.wso2.carbon.coordination.core/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.wso2.carbon</groupId>
         <artifactId>carbon-kernel</artifactId>
-        <version>4.7.1</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/org.wso2.carbon.core.bootup.validator/pom.xml
+++ b/core/org.wso2.carbon.core.bootup.validator/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>org.wso2.carbon</groupId>
         <artifactId>carbon-kernel</artifactId>
-        <version>4.7.1</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/org.wso2.carbon.core.common/pom.xml
+++ b/core/org.wso2.carbon.core.common/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon</groupId>
         <artifactId>carbon-kernel</artifactId>
-        <version>4.7.1</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/org.wso2.carbon.core.services/pom.xml
+++ b/core/org.wso2.carbon.core.services/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon</groupId>
         <artifactId>carbon-kernel</artifactId>
-        <version>4.7.1</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/org.wso2.carbon.core/pom.xml
+++ b/core/org.wso2.carbon.core/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon</groupId>
         <artifactId>carbon-kernel</artifactId>
-        <version>4.7.1</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/org.wso2.carbon.framework.exporter/pom.xml
+++ b/core/org.wso2.carbon.framework.exporter/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.wso2.carbon</groupId>
         <artifactId>carbon-kernel</artifactId>
-        <version>4.7.1</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -54,4 +54,3 @@
     </build>
 
 </project>
-

--- a/core/org.wso2.carbon.http.bridge/pom.xml
+++ b/core/org.wso2.carbon.http.bridge/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon</groupId>
         <artifactId>carbon-kernel</artifactId>
-        <version>4.7.1</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/org.wso2.carbon.i18n/pom.xml
+++ b/core/org.wso2.carbon.i18n/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon</groupId>
         <artifactId>carbon-kernel</artifactId>
-        <version>4.7.1</version>
+        <version>4.8.0-SNAPSHOT</version>
 	<relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/org.wso2.carbon.ndatasource.common/pom.xml
+++ b/core/org.wso2.carbon.ndatasource.common/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.wso2.carbon</groupId>
         <artifactId>carbon-kernel</artifactId>
-        <version>4.7.1</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/org.wso2.carbon.ndatasource.core/pom.xml
+++ b/core/org.wso2.carbon.ndatasource.core/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.wso2.carbon</groupId>
         <artifactId>carbon-kernel</artifactId>
-        <version>4.7.1</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/org.wso2.carbon.ndatasource.rdbms/pom.xml
+++ b/core/org.wso2.carbon.ndatasource.rdbms/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.wso2.carbon</groupId>
         <artifactId>carbon-kernel</artifactId>
-        <version>4.7.1</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
 
     </parent>

--- a/core/org.wso2.carbon.osgi.security/pom.xml
+++ b/core/org.wso2.carbon.osgi.security/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon</groupId>
         <artifactId>carbon-kernel</artifactId>
-        <version>4.7.1</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/org.wso2.carbon.pax-logging-log4j2-plugins/pom.xml
+++ b/core/org.wso2.carbon.pax-logging-log4j2-plugins/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon</groupId>
         <artifactId>carbon-kernel</artifactId>
-        <version>4.7.1</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/org.wso2.carbon.queuing/pom.xml
+++ b/core/org.wso2.carbon.queuing/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon</groupId>
         <artifactId>carbon-kernel</artifactId>
-        <version>4.7.1</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -54,4 +54,3 @@
         </plugins>
     </build>
 </project>
-

--- a/core/org.wso2.carbon.registry.api/pom.xml
+++ b/core/org.wso2.carbon.registry.api/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon</groupId>
         <artifactId>carbon-kernel</artifactId>
-        <version>4.7.1</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/org.wso2.carbon.registry.core/pom.xml
+++ b/core/org.wso2.carbon.registry.core/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon</groupId>
         <artifactId>carbon-kernel</artifactId>
-        <version>4.7.1</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/org.wso2.carbon.registry.server/pom.xml
+++ b/core/org.wso2.carbon.registry.server/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon</groupId>
         <artifactId>carbon-kernel</artifactId>
-        <version>4.7.1</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -90,4 +90,3 @@
     </dependencies>
 
 </project>
-

--- a/core/org.wso2.carbon.registry.xboot/pom.xml
+++ b/core/org.wso2.carbon.registry.xboot/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon</groupId>
         <artifactId>carbon-kernel</artifactId>
-        <version>4.7.1</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/org.wso2.carbon.securevault/pom.xml
+++ b/core/org.wso2.carbon.securevault/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon</groupId>
         <artifactId>carbon-kernel</artifactId>
-        <version>4.7.1</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/org.wso2.carbon.server.admin.common/pom.xml
+++ b/core/org.wso2.carbon.server.admin.common/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon</groupId>
         <artifactId>carbon-kernel</artifactId>
-        <version>4.7.1</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/org.wso2.carbon.server.admin.ui/pom.xml
+++ b/core/org.wso2.carbon.server.admin.ui/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon</groupId>
         <artifactId>carbon-kernel</artifactId>
-        <version>4.7.1</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -77,4 +77,3 @@
     </build>
 
 </project>
-

--- a/core/org.wso2.carbon.server.admin/pom.xml
+++ b/core/org.wso2.carbon.server.admin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon</groupId>
         <artifactId>carbon-kernel</artifactId>
-        <version>4.7.1</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/org.wso2.carbon.server/pom.xml
+++ b/core/org.wso2.carbon.server/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon</groupId>
         <artifactId>carbon-kernel</artifactId>
-        <version>4.7.1</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/org.wso2.carbon.servletbridge/pom.xml
+++ b/core/org.wso2.carbon.servletbridge/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon</groupId>
         <artifactId>carbon-kernel</artifactId>
-        <version>4.7.1</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -57,4 +57,3 @@
     </build>
 
 </project>
-

--- a/core/org.wso2.carbon.tomcat.ext/pom.xml
+++ b/core/org.wso2.carbon.tomcat.ext/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon</groupId>
         <artifactId>carbon-kernel</artifactId>
-        <version>4.7.1</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/org.wso2.carbon.tomcat/pom.xml
+++ b/core/org.wso2.carbon.tomcat/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon</groupId>
         <artifactId>carbon-kernel</artifactId>
-        <version>4.7.1</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/org.wso2.carbon.ui.menu/org.wso2.carbon.ui.menu.general/pom.xml
+++ b/core/org.wso2.carbon.ui.menu/org.wso2.carbon.ui.menu.general/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon</groupId>
         <artifactId>carbon-ui-menu-parent</artifactId>
-        <version>4.7.1</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/org.wso2.carbon.ui.menu/org.wso2.carbon.ui.menu.governance/pom.xml
+++ b/core/org.wso2.carbon.ui.menu/org.wso2.carbon.ui.menu.governance/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon</groupId>
         <artifactId>carbon-ui-menu-parent</artifactId>
-        <version>4.7.1</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/org.wso2.carbon.ui.menu/org.wso2.carbon.ui.menu.registry/pom.xml
+++ b/core/org.wso2.carbon.ui.menu/org.wso2.carbon.ui.menu.registry/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon</groupId>
         <artifactId>carbon-ui-menu-parent</artifactId>
-        <version>4.7.1</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/org.wso2.carbon.ui.menu/org.wso2.carbon.ui.menu.tools/pom.xml
+++ b/core/org.wso2.carbon.ui.menu/org.wso2.carbon.ui.menu.tools/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon</groupId>
         <artifactId>carbon-ui-menu-parent</artifactId>
-        <version>4.7.1</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/org.wso2.carbon.ui.menu/pom.xml
+++ b/core/org.wso2.carbon.ui.menu/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon</groupId>
         <artifactId>carbon-kernel</artifactId>
-        <version>4.7.1</version>
+        <version>4.8.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
@@ -37,4 +37,3 @@
     </modules>
 
 </project>
-

--- a/core/org.wso2.carbon.ui/pom.xml
+++ b/core/org.wso2.carbon.ui/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon</groupId>
         <artifactId>carbon-kernel</artifactId>
-        <version>4.7.1</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/org.wso2.carbon.ui/src/main/resources/web/docs/about.html
+++ b/core/org.wso2.carbon.ui/src/main/resources/web/docs/about.html
@@ -21,7 +21,7 @@
 <link href="../admin/css/documentation.css" rel="stylesheet" type="text/css" media="all"/>
 </head>
 <body>
-<h1>Version 4.7.0-SNAPSHOT</h1>
+<h1>Version 4.8.0-m1</h1>
 <h2>About WSO2 Carbon </h2>
 <p>WSO2 Carbon is a component based Enterprise SOA platform. The
 design of

--- a/core/org.wso2.carbon.ui/src/main/resources/web/docs/about.html
+++ b/core/org.wso2.carbon.ui/src/main/resources/web/docs/about.html
@@ -21,7 +21,7 @@
 <link href="../admin/css/documentation.css" rel="stylesheet" type="text/css" media="all"/>
 </head>
 <body>
-<h1>Version 4.8.0-m1</h1>
+<h1>Version 4.7.0-SNAPSHOT</h1>
 <h2>About WSO2 Carbon </h2>
 <p>WSO2 Carbon is a component based Enterprise SOA platform. The
 design of

--- a/core/org.wso2.carbon.user.api/pom.xml
+++ b/core/org.wso2.carbon.user.api/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon</groupId>
         <artifactId>carbon-kernel</artifactId>
-        <version>4.7.1</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/org.wso2.carbon.user.core/pom.xml
+++ b/core/org.wso2.carbon.user.core/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon</groupId>
         <artifactId>carbon-kernel</artifactId>
-        <version>4.7.1</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/org.wso2.carbon.utils/pom.xml
+++ b/core/org.wso2.carbon.utils/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>org.wso2.carbon</groupId>
         <artifactId>carbon-kernel</artifactId>
-        <version>4.7.1</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon</groupId>
         <artifactId>carbon-parent</artifactId>
-        <version>4.7.1</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 

--- a/core/server-role-manager/org.wso2.carbon.roles.mgt.ui/pom.xml
+++ b/core/server-role-manager/org.wso2.carbon.roles.mgt.ui/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.wso2.carbon</groupId>
         <artifactId>server-role-manager</artifactId>
-        <version>4.7.1</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/server-role-manager/org.wso2.carbon.roles.mgt/pom.xml
+++ b/core/server-role-manager/org.wso2.carbon.roles.mgt/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.wso2.carbon</groupId>
         <artifactId>server-role-manager</artifactId>
-        <version>4.7.1</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/server-role-manager/pom.xml
+++ b/core/server-role-manager/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon</groupId>
         <artifactId>carbon-kernel</artifactId>
-        <version>4.7.1</version>
+        <version>4.8.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
@@ -36,4 +36,3 @@
     </modules>
 
 </project>
-

--- a/distribution/integration/axis2-sample-service/pom.xml
+++ b/distribution/integration/axis2-sample-service/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon</groupId>
         <artifactId>integration</artifactId>
-        <version>4.7.1</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/distribution/integration/pom.xml
+++ b/distribution/integration/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.wso2.carbon</groupId>
         <artifactId>carbon-parent</artifactId>
-        <version>4.7.1</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
 

--- a/distribution/integration/sample-servlet/pom.xml
+++ b/distribution/integration/sample-servlet/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon</groupId>
         <artifactId>integration</artifactId>
-        <version>4.7.1</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/distribution/integration/security-verifier/pom.xml
+++ b/distribution/integration/security-verifier/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon</groupId>
         <artifactId>integration</artifactId>
-        <version>4.7.1</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/distribution/integration/test-common/admin-clients/pom.xml
+++ b/distribution/integration/test-common/admin-clients/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.wso2.carbon</groupId>
         <artifactId>org.wso2.carbon.integration.test.common</artifactId>
-        <version>4.7.1</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/distribution/integration/test-common/extensions/pom.xml
+++ b/distribution/integration/test-common/extensions/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.wso2.carbon</groupId>
         <artifactId>org.wso2.carbon.integration.test.common</artifactId>
-        <version>4.7.1</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/distribution/integration/test-common/integration-test-utils/pom.xml
+++ b/distribution/integration/test-common/integration-test-utils/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.wso2.carbon</groupId>
         <artifactId>org.wso2.carbon.integration.test.common</artifactId>
-        <version>4.7.1</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/distribution/integration/test-common/pom.xml
+++ b/distribution/integration/test-common/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.wso2.carbon</groupId>
         <artifactId>integration</artifactId>
-        <version>4.7.1</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/distribution/integration/test-common/ui-pages/pom.xml
+++ b/distribution/integration/test-common/ui-pages/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.wso2.carbon</groupId>
         <artifactId>org.wso2.carbon.integration.test.common</artifactId>
-        <version>4.7.1</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/distribution/integration/tests-integration/pom.xml
+++ b/distribution/integration/tests-integration/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.wso2.carbon</groupId>
         <artifactId>integration</artifactId>
-        <version>4.7.1</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/distribution/integration/tests-integration/tests/pom.xml
+++ b/distribution/integration/tests-integration/tests/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>org.wso2.carbon.integration.tests.integration</artifactId>
         <groupId>org.wso2.carbon</groupId>
-        <version>4.7.1</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/distribution/kernel/carbon.product
+++ b/distribution/kernel/carbon.product
@@ -2,7 +2,7 @@
 <?pde version="3.5"?>
 
 <product name="Carbon Product" uid="carbon.product.id" id="carbon.product" application="carbon.application"
-version="4.7.1" useFeatures="true" includeLaunchers="true">
+version="4.8.0.m1" useFeatures="true" includeLaunchers="true">
 
    <configIni use="default">
    </configIni>
@@ -14,7 +14,7 @@ version="4.7.1" useFeatures="true" includeLaunchers="true">
    </plugins>
 
    <features>
-      <feature id="org.wso2.carbon.core.runtime" version="4.7.1"/>
+      <feature id="org.wso2.carbon.core.runtime" version="4.8.0.m1"/>
    </features>
 
   <configurations>

--- a/distribution/kernel/carbon.product
+++ b/distribution/kernel/carbon.product
@@ -2,7 +2,7 @@
 <?pde version="3.5"?>
 
 <product name="Carbon Product" uid="carbon.product.id" id="carbon.product" application="carbon.application"
-version="4.8.0.m1" useFeatures="true" includeLaunchers="true">
+version="4.7.1" useFeatures="true" includeLaunchers="true">
 
    <configIni use="default">
    </configIni>
@@ -14,7 +14,7 @@ version="4.8.0.m1" useFeatures="true" includeLaunchers="true">
    </plugins>
 
    <features>
-      <feature id="org.wso2.carbon.core.runtime" version="4.8.0.m1"/>
+      <feature id="org.wso2.carbon.core.runtime" version="4.7.1"/>
    </features>
 
   <configurations>

--- a/distribution/kernel/pom.xml
+++ b/distribution/kernel/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon</groupId>
         <artifactId>carbon-parent</artifactId>
-        <version>4.7.1</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
 

--- a/distribution/kernel/src/assembly/filter.properties
+++ b/distribution/kernel/src/assembly/filter.properties
@@ -1,2 +1,2 @@
-carbon.version=4.7.1
+carbon.version=4.8.0-m1
 p2.repo.url=http://product-dist.wso2.com/p2/carbon/releases/wilkes/

--- a/distribution/kernel/src/assembly/filter.properties
+++ b/distribution/kernel/src/assembly/filter.properties
@@ -1,2 +1,2 @@
-carbon.version=4.8.0-m1
+carbon.version=4.7.1
 p2.repo.url=http://product-dist.wso2.com/p2/carbon/releases/wilkes/

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.wso2.carbon</groupId>
         <artifactId>carbon-parent</artifactId>
-        <version>4.7.1</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 

--- a/distribution/product/modules/distribution/pom.xml
+++ b/distribution/product/modules/distribution/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon</groupId>
         <artifactId>carbon-product</artifactId>
-        <version>4.7.1</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/distribution/product/modules/distribution/src/assembly/filter.properties
+++ b/distribution/product/modules/distribution/src/assembly/filter.properties
@@ -1,8 +1,8 @@
 product.name=WSO2 Carbon
-product.version=4.8.0-m1
+product.version=4.7.1
 product.key=Carbon
-carbon.product.version=4.8.0-m1
-carbon.version=4.8.0-m1
+carbon.product.version=4.7.1
+carbon.version=4.7.1
 default.server.role=CarbonServer
 hotdeployment=true
 hotupdate=true

--- a/distribution/product/modules/distribution/src/assembly/filter.properties
+++ b/distribution/product/modules/distribution/src/assembly/filter.properties
@@ -1,8 +1,8 @@
 product.name=WSO2 Carbon
-product.version=4.7.1
+product.version=4.8.0-m1
 product.key=Carbon
-carbon.product.version=4.7.1
-carbon.version=4.7.1
+carbon.product.version=4.8.0-m1
+carbon.version=4.8.0-m1
 default.server.role=CarbonServer
 hotdeployment=true
 hotupdate=true

--- a/distribution/product/modules/features/org.wso2.carbon.styles.feature/pom.xml
+++ b/distribution/product/modules/features/org.wso2.carbon.styles.feature/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon</groupId>
         <artifactId>carbon-product</artifactId>
-        <version>4.7.1</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
 

--- a/distribution/product/modules/p2-profile-gen/pom.xml
+++ b/distribution/product/modules/p2-profile-gen/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon</groupId>
         <artifactId>carbon-product</artifactId>
-        <version>4.7.1</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/distribution/product/modules/styles/pom.xml
+++ b/distribution/product/modules/styles/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon</groupId>
         <artifactId>carbon-product</artifactId>
-        <version>4.7.1</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/distribution/product/pom.xml
+++ b/distribution/product/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon</groupId>
         <artifactId>carbon-parent</artifactId>
-        <version>4.7.1</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
 

--- a/features/org.wso2.carbon.core.common.feature/pom.xml
+++ b/features/org.wso2.carbon.core.common.feature/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon</groupId>
         <artifactId>carbon-kernel-features</artifactId>
-        <version>4.7.1</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/org.wso2.carbon.core.feature/pom.xml
+++ b/features/org.wso2.carbon.core.feature/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon</groupId>
         <artifactId>carbon-kernel-features</artifactId>
-        <version>4.7.1</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/org.wso2.carbon.core.runtime.feature/pom.xml
+++ b/features/org.wso2.carbon.core.runtime.feature/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon</groupId>
         <artifactId>carbon-kernel-features</artifactId>
-        <version>4.7.1</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/org.wso2.carbon.core.server.feature/pom.xml
+++ b/features/org.wso2.carbon.core.server.feature/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon</groupId>
         <artifactId>carbon-kernel-features</artifactId>
-        <version>4.7.1</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/org.wso2.carbon.core.ui.feature/pom.xml
+++ b/features/org.wso2.carbon.core.ui.feature/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon</groupId>
         <artifactId>carbon-kernel-features</artifactId>
-        <version>4.7.1</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/pom.xml
+++ b/features/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon</groupId>
         <artifactId>carbon-parent</artifactId>
-        <version>4.7.1</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 
@@ -39,4 +39,3 @@
     </modules>
 
 </project>
-

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -651,7 +651,7 @@
         <version.org.apache.felix.scr.ds-annotations>1.2.10</version.org.apache.felix.scr.ds-annotations>
         <maven.felix.scr.plugin.version>1.25.0</maven.felix.scr.plugin.version>
         <import.package.version.commons.logging>[1.2.0,2.0.0)</import.package.version.commons.logging>
-        <config.mapper.version>1.0.13</config.mapper.version>
+        <config.mapper.version>1.0.20</config.mapper.version>
         <version.stax.ex>1.8.3</version.stax.ex>
         <version.saaj.impl>1.5.0</version.saaj.impl>
     </properties>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -10,7 +10,7 @@
     <groupId>org.wso2.carbon</groupId>
     <artifactId>carbon-parent</artifactId>
     <packaging>pom</packaging>
-    <version>4.7.1</version>
+    <version>4.8.0-SNAPSHOT</version>
     <name>WSO2 Carbon - Parent Pom</name>
     <description>WSO2 Carbon Kernel Parent Pom</description>
     <url>http://wso2.org</url>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>org.wso2.carbon</groupId>
     <artifactId>carbon</artifactId>
     <packaging>pom</packaging>
-    <version>4.7.1</version>
+    <version>4.8.0-SNAPSHOT</version>
     <name>WSO2 Carbon - Aggregate Pom</name>
     <description>WSO2 Carbon Platform with all its components, features and products
     </description>

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>org.wso2.carbon</groupId>
     <artifactId>samples</artifactId>
-    <version>4.7.1</version>
+    <version>4.8.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>WSO2 Carbon - Samples</name>
     <description>Carbon kernel sample</description>

--- a/samples/student-manager/components/org.wso2.carbon.student.mgt.ui/pom.xml
+++ b/samples/student-manager/components/org.wso2.carbon.student.mgt.ui/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.wso2.carbon</groupId>
         <artifactId>student-manager-components</artifactId>
-        <version>4.7.1</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/samples/student-manager/components/org.wso2.carbon.student.mgt/pom.xml
+++ b/samples/student-manager/components/org.wso2.carbon.student.mgt/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.wso2.carbon</groupId>
         <artifactId>student-manager-components</artifactId>
-        <version>4.7.1</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/samples/student-manager/components/pom.xml
+++ b/samples/student-manager/components/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.wso2.carbon</groupId>
         <artifactId>student-manager</artifactId>
-        <version>4.7.1</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/samples/student-manager/features/org.wso2.carbon.student.mgt.feature/pom.xml
+++ b/samples/student-manager/features/org.wso2.carbon.student.mgt.feature/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.wso2.carbon</groupId>
         <artifactId>student-manager-features</artifactId>
-        <version>4.7.1</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/samples/student-manager/features/org.wso2.carbon.student.mgt.server.feature/pom.xml
+++ b/samples/student-manager/features/org.wso2.carbon.student.mgt.server.feature/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.wso2.carbon</groupId>
         <artifactId>student-manager-features</artifactId>
-        <version>4.7.1</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/samples/student-manager/features/org.wso2.carbon.student.mgt.ui.feature/pom.xml
+++ b/samples/student-manager/features/org.wso2.carbon.student.mgt.ui.feature/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.wso2.carbon</groupId>
         <artifactId>student-manager-features</artifactId>
-        <version>4.7.1</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/samples/student-manager/features/pom.xml
+++ b/samples/student-manager/features/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.wso2.carbon</groupId>
         <artifactId>student-manager</artifactId>
-        <version>4.7.1</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/samples/student-manager/pom.xml
+++ b/samples/student-manager/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.wso2.carbon</groupId>
         <artifactId>samples</artifactId>
-        <version>4.7.1</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/samples/student-manager/repository/pom.xml
+++ b/samples/student-manager/repository/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>student-manager</artifactId>
         <groupId>org.wso2.carbon</groupId>
-        <version>4.7.1</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/service-stubs/org.wso2.carbon.authenticator.stub/pom.xml
+++ b/service-stubs/org.wso2.carbon.authenticator.stub/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.wso2.carbon</groupId>
         <artifactId>carbon-kernel-service-stubs</artifactId>
-        <version>4.7.1</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/service-stubs/org.wso2.carbon.core.commons.stub/pom.xml
+++ b/service-stubs/org.wso2.carbon.core.commons.stub/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon</groupId>
         <artifactId>carbon-kernel-service-stubs</artifactId>
-        <version>4.7.1</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/service-stubs/org.wso2.carbon.feature.mgt.stub/pom.xml
+++ b/service-stubs/org.wso2.carbon.feature.mgt.stub/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon</groupId>
         <artifactId>carbon-kernel-service-stubs</artifactId>
-        <version>4.7.1</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/service-stubs/org.wso2.carbon.roles.mgt.stub/pom.xml
+++ b/service-stubs/org.wso2.carbon.roles.mgt.stub/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon</groupId>
         <artifactId>carbon-kernel-service-stubs</artifactId>
-        <version>4.7.1</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/service-stubs/org.wso2.carbon.server.admin.stub/pom.xml
+++ b/service-stubs/org.wso2.carbon.server.admin.stub/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon</groupId>
         <artifactId>carbon-kernel-service-stubs</artifactId>
-        <version>4.7.1</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/service-stubs/pom.xml
+++ b/service-stubs/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon</groupId>
         <artifactId>carbon-parent</artifactId>
-        <version>4.7.1</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
## Purpose
- To refactor pom versions to prepare for 4.8.x releases
- To upgrade the config mapper version since the 4.6.x also has the latest

## Goals
Refactoring pom versions and upgrading config mapper version

## Approach
- Refactor the pom versions to 4.8.0-SNAPSHOT
- Bump the config mapper version to 1.0.20