### PR TITLE
Make Carbon Kernel 5.2.x compilable on Java 11

### DIFF
--- a/archetypes/carbon-component-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/archetypes/carbon-component-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -28,6 +28,12 @@
                 <include>**/*.java</include>
             </includes>
         </fileSet>
+        <fileSet filtered="true" packaged="false" encoding="UTF-8">
+            <directory></directory>
+            <includes>
+                <include>spotbugs-exclude.xml</include>
+            </includes>
+        </fileSet>
     </fileSets>
 
     <requiredProperties>

--- a/archetypes/carbon-component-archetype/src/main/resources/archetype-resources/spotbugs-exclude.xml
+++ b/archetypes/carbon-component-archetype/src/main/resources/archetype-resources/spotbugs-exclude.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2022, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+  ~
+  ~ WSO2 LLC. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied. See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<FindBugsFilter>
+    <Match>
+        <Package name="~org\.test\.component\.*" />
+        <Bug pattern="CRLF_INJECTION_LOGS" />
+    </Match>
+</FindBugsFilter>

--- a/archetypes/carbon-component-archetype/src/test/resources/projects/component/reference/spotbugs-exclude.xml
+++ b/archetypes/carbon-component-archetype/src/test/resources/projects/component/reference/spotbugs-exclude.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2022, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+  ~
+  ~ WSO2 LLC. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied. See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<FindBugsFilter>
+    <Match>
+        <Package name="~org\.test\.component\.*" />
+        <Bug pattern="CRLF_INJECTION_LOGS" />
+    </Match>
+</FindBugsFilter>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -109,10 +109,6 @@
             <groupId>com.sun.istack</groupId>
             <artifactId>istack-commons-runtime</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.wso2.orbit.javax.activation</groupId>
-            <artifactId>activation</artifactId>
-        </dependency>
     </dependencies>
 
     <build>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -46,7 +46,7 @@
             <artifactId>org.wso2.carbon.config</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.eclipse.osgi</groupId>
+            <groupId>org.eclipse.platform</groupId>
             <artifactId>org.eclipse.osgi</artifactId>
             <optional>true</optional>
         </dependency>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -91,6 +91,28 @@
             <artifactId>powermock-module-testng</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <!-- Java11 dependencies -->
+        <dependency>
+            <groupId>org.wso2.orbit.javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.orbit.sun.xml.bind</groupId>
+            <artifactId>jaxb</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.geronimo.specs</groupId>
+            <artifactId>geronimo-activation_1.1_spec</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.istack</groupId>
+            <artifactId>istack-commons-runtime</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.orbit.javax.activation</groupId>
+            <artifactId>activation</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/core/src/main/java/org/wso2/carbon/kernel/internal/startupresolver/StartupServiceCache.java
+++ b/core/src/main/java/org/wso2/carbon/kernel/internal/startupresolver/StartupServiceCache.java
@@ -93,7 +93,7 @@ public class StartupServiceCache {
             return availableServices.entrySet()
                     .stream()
                     .collect(Collectors.toMap(Map.Entry::getKey,
-                            stringLongEntry -> Long.valueOf(stringLongEntry.getValue())));
+                            stringLongEntry -> (stringLongEntry.getValue())));
         }
     }
 }

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -126,6 +126,14 @@
             <plugin>
                 <groupId>org.wso2.carbon.maven</groupId>
                 <artifactId>carbon-feature-plugin</artifactId>
+                <dependencies>
+                    <dependency>
+                        <groupId>com.sun.activation</groupId>
+                        <artifactId>javax.activation</artifactId>
+                        <version>${com.sun.activation.javax.activation.version}</version>
+                        <type>jar</type>
+                    </dependency>
+                </dependencies>
                 <executions>
                     <execution>
                         <id>p2-repo-generation</id>

--- a/features/org.wso2.carbon.osgi.feature/pom.xml
+++ b/features/org.wso2.carbon.osgi.feature/pom.xml
@@ -34,7 +34,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.wso2.eclipse.osgi</groupId>
+            <groupId>org.eclipse.platform</groupId>
             <artifactId>org.eclipse.osgi</artifactId>
         </dependency>
         <dependency>
@@ -78,7 +78,7 @@
             <artifactId>org.eclipse.equinox.frameworkadmin.equinox</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.eclipse.equinox</groupId>
+            <groupId>org.eclipse.platform</groupId>
             <artifactId>org.eclipse.equinox.console</artifactId>
         </dependency>
         <dependency>
@@ -168,7 +168,7 @@
                                 </bundle>
                                 <bundle>
                                     <symbolicName>org.eclipse.osgi</symbolicName>
-                                    <version>${equinox.osgi.version}</version>
+                                    <version>${equinox.osgi.bundle.version}</version>
                                 </bundle>
                                 <bundle>
                                     <symbolicName>org.eclipse.equinox.concurrent</symbolicName>
@@ -192,7 +192,7 @@
                                 </bundle>
                                 <bundle>
                                     <symbolicName>org.eclipse.equinox.console</symbolicName>
-                                    <version>${equinox.console.version}</version>
+                                    <version>${equinox.console.bundle.version}</version>
                                 </bundle>
                                 <bundle>
                                     <symbolicName>org.apache.felix.gogo.command</symbolicName>

--- a/features/org.wso2.carbon.osgi.feature/pom.xml
+++ b/features/org.wso2.carbon.osgi.feature/pom.xml
@@ -126,10 +126,6 @@
             <artifactId>jaxb</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.orbit.javax.activation</groupId>
-            <artifactId>activation</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.wso2.orbit.xml-apis</groupId>
             <artifactId>xml-apis</artifactId>
         </dependency>
@@ -249,10 +245,6 @@
                                 <bundle>
                                     <symbolicName>org.wso2.orbit.javax.xml.bind.jaxb-api</symbolicName>
                                     <version>${org.wso2.orbit.javax.xml.bind.version}</version>
-                                </bundle>
-                                <bundle>
-                                    <symbolicName>org.wso2.orbit.javax.activation.activation</symbolicName>
-                                    <version>${com.sun.activation.version}</version>
                                 </bundle>
                                 <bundle>
                                     <symbolicName>org.wso2.orbit.xml-apis.xml-apis</symbolicName>

--- a/features/org.wso2.carbon.osgi.feature/pom.xml
+++ b/features/org.wso2.carbon.osgi.feature/pom.xml
@@ -117,6 +117,22 @@
             <groupId>org.wso2.eclipse.osgi</groupId>
             <artifactId>org.eclipse.osgi.compatibility.state</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.orbit.javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.orbit.sun.xml.bind</groupId>
+            <artifactId>jaxb</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.orbit.javax.activation</groupId>
+            <artifactId>activation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.orbit.xml-apis</groupId>
+            <artifactId>xml-apis</artifactId>
+        </dependency>
     </dependencies>
 
     <build>
@@ -225,6 +241,22 @@
                                 <bundle>
                                     <symbolicName>org.eclipse.osgi.compatibility.state</symbolicName>
                                     <version>${equinox.osgi.compatibility.state.version}</version>
+                                </bundle>
+                                <bundle>
+                                    <symbolicName>org.wso2.orbit.sun.xml.bind.jaxb</symbolicName>
+                                    <version>${org.wso2.orbit.sun.xml.bind.version}</version>
+                                </bundle>
+                                <bundle>
+                                    <symbolicName>org.wso2.orbit.javax.xml.bind.jaxb-api</symbolicName>
+                                    <version>${org.wso2.orbit.javax.xml.bind.version}</version>
+                                </bundle>
+                                <bundle>
+                                    <symbolicName>org.wso2.orbit.javax.activation.activation</symbolicName>
+                                    <version>${com.sun.activation.version}</version>
+                                </bundle>
+                                <bundle>
+                                    <symbolicName>org.wso2.orbit.xml-apis.xml-apis</symbolicName>
+                                    <version>${org.wso2.orbit.xml-apis.version}</version>
                                 </bundle>
                             </bundles>
                         </configuration>

--- a/features/org.wso2.carbon.osgi.feature/pom.xml
+++ b/features/org.wso2.carbon.osgi.feature/pom.xml
@@ -133,6 +133,18 @@
             <groupId>org.wso2.orbit.xml-apis</groupId>
             <artifactId>xml-apis</artifactId>
         </dependency>
+        <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.orbit.javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-impl</artifactId>
+        </dependency>
     </dependencies>
 
     <build>
@@ -257,6 +269,22 @@
                                 <bundle>
                                     <symbolicName>org.wso2.orbit.xml-apis.xml-apis</symbolicName>
                                     <version>${org.wso2.orbit.xml-apis.version}</version>
+                                </bundle>
+                                <bundle>
+                                    <symbolicName>javax.annotation-api</symbolicName>
+                                    <version>${javax.annotation.version}</version>
+                                </bundle>
+                                <bundle>
+                                    <symbolicName>javax.annotation-api</symbolicName>
+                                    <version>${javax.annotation.version}</version>
+                                </bundle>
+                                <bundle>
+                                    <symbolicName>org.wso2.orbit.javax.xml.bind.jaxb-api</symbolicName>
+                                    <version>${org.wso2.orbit.javax.xml.bind.version}</version>
+                                </bundle>
+                                <bundle>
+                                    <symbolicName>com.sun.xml.bind.jaxb-impl</symbolicName>
+                                    <version>${com.sun.xml.bind.version}</version>
                                 </bundle>
                             </bundles>
                         </configuration>

--- a/features/org.wso2.carbon.runtime.feature/resources/wso2/default/bin/carbon.sh
+++ b/features/org.wso2.carbon.runtime.feature/resources/wso2/default/bin/carbon.sh
@@ -214,9 +214,9 @@ fi
 # ---------- Handle the SSL Issue with proper JDK version --------------------
 java_version=$("$JAVACMD" -version 2>&1 | awk -F '"' '/version/ {print $2}')
 java_version_formatted=$(echo "$java_version" | awk -F. '{printf("%02d%02d",$1,$2);}')
-if [ $java_version_formatted -lt 0108 ] || [ $java_version_formatted -gt 1100 ]; then
+if [ $java_version_formatted -lt 1100 ] || [ $java_version_formatted -gt 1700 ]; then
    echo " Starting WSO2 Carbon (in unsupported JDK)"
-   echo " [ERROR] CARBON is supported only on JDK 1.8, 9, 10 and 11"
+   echo " [ERROR] CARBON is supported only between JDK 11 and 17"
 fi
 
 CARBON_XBOOTCLASSPATH=""

--- a/features/org.wso2.carbon.runtime.feature/resources/wso2/default/bin/carbon.sh
+++ b/features/org.wso2.carbon.runtime.feature/resources/wso2/default/bin/carbon.sh
@@ -214,9 +214,9 @@ fi
 # ---------- Handle the SSL Issue with proper JDK version --------------------
 java_version=$("$JAVACMD" -version 2>&1 | awk -F '"' '/version/ {print $2}')
 java_version_formatted=$(echo "$java_version" | awk -F. '{printf("%02d%02d",$1,$2);}')
-if [ $java_version_formatted -lt 1100 ] || [ $java_version_formatted -gt 1700 ]; then
+if [ $java_version_formatted -lt 0108 ] || [ $java_version_formatted -gt 1700 ]; then
    echo " Starting WSO2 Carbon (in unsupported JDK)"
-   echo " [ERROR] CARBON is supported only between JDK 11 and 17"
+   echo " [ERROR] CARBON is supported only between JDK 1.8 and 17"
 fi
 
 CARBON_XBOOTCLASSPATH=""

--- a/features/org.wso2.carbon.server.feature/resources/bin/icf-provider.sh
+++ b/features/org.wso2.carbon.server.feature/resources/bin/icf-provider.sh
@@ -107,10 +107,11 @@ if [ -z "$JAVA_HOME" ]; then
   exit 1
 fi
 
-jdk_18=`$JAVA_HOME/bin/java -version 2>&1 | grep "1.[8]"`
-if [ "$jdk_18" = "" ]; then
+java_version=$("$JAVACMD" -version 2>&1 | awk -F '"' '/version/ {print $2}')
+java_version_formatted=$(echo "$java_version" | awk -F. '{printf("%02d%02d",$1,$2);}')
+if [ $java_version_formatted -lt 1100 ] || [ $java_version_formatted -gt 1700 ]; then
    echo " Starting WSO2 Carbon (in unsupported JDK)"
-   echo " [ERROR] CARBON is supported only on JDK 1.8"
+   echo " [ERROR] CARBON is supported only between JDK 11 and 17"
    exit 1
 fi
 

--- a/features/org.wso2.carbon.server.feature/resources/bin/icf-provider.sh
+++ b/features/org.wso2.carbon.server.feature/resources/bin/icf-provider.sh
@@ -109,9 +109,9 @@ fi
 
 java_version=$("$JAVACMD" -version 2>&1 | awk -F '"' '/version/ {print $2}')
 java_version_formatted=$(echo "$java_version" | awk -F. '{printf("%02d%02d",$1,$2);}')
-if [ $java_version_formatted -lt 1100 ] || [ $java_version_formatted -gt 1700 ]; then
+if [ $java_version_formatted -lt 0108 ] || [ $java_version_formatted -gt 1700 ]; then
    echo " Starting WSO2 Carbon (in unsupported JDK)"
-   echo " [ERROR] CARBON is supported only between JDK 11 and 17"
+   echo " [ERROR] CARBON is supported only between JDK 1.8 and 17"
    exit 1
 fi
 

--- a/features/org.wso2.carbon.server.feature/resources/bin/install-jars.sh
+++ b/features/org.wso2.carbon.server.feature/resources/bin/install-jars.sh
@@ -107,10 +107,11 @@ if [ -z "$JAVA_HOME" ]; then
   exit 1
 fi
 
-jdk_18=`$JAVA_HOME/bin/java -version 2>&1 | grep "1.[8]"`
-if [ "$jdk_18" = "" ]; then
+java_version=$("$JAVACMD" -version 2>&1 | awk -F '"' '/version/ {print $2}')
+java_version_formatted=$(echo "$java_version" | awk -F. '{printf("%02d%02d",$1,$2);}')
+if [ $java_version_formatted -lt 1100 ] || [ $java_version_formatted -gt 1700 ]; then
    echo " Starting WSO2 Carbon (in unsupported JDK)"
-   echo " [ERROR] CARBON is supported only on JDK 1.8"
+   echo " [ERROR] CARBON is supported only between JDK 11 and 17"
    exit 1
 fi
 

--- a/features/org.wso2.carbon.server.feature/resources/bin/install-jars.sh
+++ b/features/org.wso2.carbon.server.feature/resources/bin/install-jars.sh
@@ -109,9 +109,9 @@ fi
 
 java_version=$("$JAVACMD" -version 2>&1 | awk -F '"' '/version/ {print $2}')
 java_version_formatted=$(echo "$java_version" | awk -F. '{printf("%02d%02d",$1,$2);}')
-if [ $java_version_formatted -lt 1100 ] || [ $java_version_formatted -gt 1700 ]; then
+if [ $java_version_formatted -lt 0108 ] || [ $java_version_formatted -gt 1700 ]; then
    echo " Starting WSO2 Carbon (in unsupported JDK)"
-   echo " [ERROR] CARBON is supported only between JDK 11 and 17"
+   echo " [ERROR] CARBON is supported only between JDK 1.8 and 17"
    exit 1
 fi
 

--- a/features/org.wso2.carbon.server.feature/resources/bin/jartobundle.sh
+++ b/features/org.wso2.carbon.server.feature/resources/bin/jartobundle.sh
@@ -107,10 +107,11 @@ if [ -z "$JAVA_HOME" ]; then
   exit 1
 fi
 
-jdk_18=`$JAVA_HOME/bin/java -version 2>&1 | grep "1.[8]"`
-if [ "$jdk_18" = "" ]; then
+java_version=$("$JAVACMD" -version 2>&1 | awk -F '"' '/version/ {print $2}')
+java_version_formatted=$(echo "$java_version" | awk -F. '{printf("%02d%02d",$1,$2);}')
+if [ $java_version_formatted -lt 1100 ] || [ $java_version_formatted -gt 1700 ]; then
    echo " Starting WSO2 Carbon (in unsupported JDK)"
-   echo " [ERROR] CARBON is supported only on JDK 1.8"
+   echo " [ERROR] CARBON is supported only between JDK 11 and 17"
    exit 1
 fi
 

--- a/features/org.wso2.carbon.server.feature/resources/bin/jartobundle.sh
+++ b/features/org.wso2.carbon.server.feature/resources/bin/jartobundle.sh
@@ -109,9 +109,9 @@ fi
 
 java_version=$("$JAVACMD" -version 2>&1 | awk -F '"' '/version/ {print $2}')
 java_version_formatted=$(echo "$java_version" | awk -F. '{printf("%02d%02d",$1,$2);}')
-if [ $java_version_formatted -lt 1100 ] || [ $java_version_formatted -gt 1700 ]; then
+if [ $java_version_formatted -lt 0108 ] || [ $java_version_formatted -gt 1700 ]; then
    echo " Starting WSO2 Carbon (in unsupported JDK)"
-   echo " [ERROR] CARBON is supported only between JDK 11 and 17"
+   echo " [ERROR] CARBON is supported only between JDK 1.8 and 17"
    exit 1
 fi
 

--- a/features/org.wso2.carbon.server.feature/resources/bin/jni-provider.sh
+++ b/features/org.wso2.carbon.server.feature/resources/bin/jni-provider.sh
@@ -107,10 +107,11 @@ if [ -z "$JAVA_HOME" ]; then
   exit 1
 fi
 
-jdk_18=`$JAVA_HOME/bin/java -version 2>&1 | grep "1.[8]"`
-if [ "$jdk_18" = "" ]; then
+java_version=$("$JAVACMD" -version 2>&1 | awk -F '"' '/version/ {print $2}')
+java_version_formatted=$(echo "$java_version" | awk -F. '{printf("%02d%02d",$1,$2);}')
+if [ $java_version_formatted -lt 1100 ] || [ $java_version_formatted -gt 1700 ]; then
    echo " Starting WSO2 Carbon (in unsupported JDK)"
-   echo " [ERROR] CARBON is supported only on JDK 1.8"
+   echo " [ERROR] CARBON is supported only between JDK 11 and 17"
    exit 1
 fi
 

--- a/features/org.wso2.carbon.server.feature/resources/bin/jni-provider.sh
+++ b/features/org.wso2.carbon.server.feature/resources/bin/jni-provider.sh
@@ -109,9 +109,9 @@ fi
 
 java_version=$("$JAVACMD" -version 2>&1 | awk -F '"' '/version/ {print $2}')
 java_version_formatted=$(echo "$java_version" | awk -F. '{printf("%02d%02d",$1,$2);}')
-if [ $java_version_formatted -lt 1100 ] || [ $java_version_formatted -gt 1700 ]; then
+if [ $java_version_formatted -lt 0108 ] || [ $java_version_formatted -gt 1700 ]; then
    echo " Starting WSO2 Carbon (in unsupported JDK)"
-   echo " [ERROR] CARBON is supported only between JDK 11 and 17"
+   echo " [ERROR] CARBON is supported only between JDK 1.8 and 17"
    exit 1
 fi
 

--- a/features/org.wso2.carbon.server.feature/resources/bin/osgi-lib.sh
+++ b/features/org.wso2.carbon.server.feature/resources/bin/osgi-lib.sh
@@ -107,10 +107,11 @@ if [ -z "$JAVA_HOME" ]; then
   exit 1
 fi
 
-jdk_18=`$JAVA_HOME/bin/java -version 2>&1 | grep "1.[8]"`
-if [ "$jdk_18" = "" ]; then
+java_version=$("$JAVACMD" -version 2>&1 | awk -F '"' '/version/ {print $2}')
+java_version_formatted=$(echo "$java_version" | awk -F. '{printf("%02d%02d",$1,$2);}')
+if [ $java_version_formatted -lt 1100 ] || [ $java_version_formatted -gt 1700 ]; then
    echo " Starting WSO2 Carbon (in unsupported JDK)"
-   echo " [ERROR] CARBON is supported only on JDK 1.8"
+   echo " [ERROR] CARBON is supported only between JDK 11 and 17"
    exit 1
 fi
 

--- a/features/org.wso2.carbon.server.feature/resources/bin/osgi-lib.sh
+++ b/features/org.wso2.carbon.server.feature/resources/bin/osgi-lib.sh
@@ -109,9 +109,9 @@ fi
 
 java_version=$("$JAVACMD" -version 2>&1 | awk -F '"' '/version/ {print $2}')
 java_version_formatted=$(echo "$java_version" | awk -F. '{printf("%02d%02d",$1,$2);}')
-if [ $java_version_formatted -lt 1100 ] || [ $java_version_formatted -gt 1700 ]; then
+if [ $java_version_formatted -lt 0108 ] || [ $java_version_formatted -gt 1700 ]; then
    echo " Starting WSO2 Carbon (in unsupported JDK)"
-   echo " [ERROR] CARBON is supported only between JDK 11 and 17"
+   echo " [ERROR] CARBON is supported only between JDK 1.8 and 17"
    exit 1
 fi
 

--- a/features/org.wso2.carbon.server.feature/resources/bin/spi-provider.sh
+++ b/features/org.wso2.carbon.server.feature/resources/bin/spi-provider.sh
@@ -107,10 +107,11 @@ if [ -z "$JAVA_HOME" ]; then
   exit 1
 fi
 
-jdk_18=`$JAVA_HOME/bin/java -version 2>&1 | grep "1.[8]"`
-if [ "$jdk_18" = "" ]; then
+java_version=$("$JAVACMD" -version 2>&1 | awk -F '"' '/version/ {print $2}')
+java_version_formatted=$(echo "$java_version" | awk -F. '{printf("%02d%02d",$1,$2);}')
+if [ $java_version_formatted -lt 1100 ] || [ $java_version_formatted -gt 1700 ]; then
    echo " Starting WSO2 Carbon (in unsupported JDK)"
-   echo " [ERROR] CARBON is supported only on JDK 1.8"
+   echo " [ERROR] CARBON is supported only between JDK 11 and 17"
    exit 1
 fi
 

--- a/features/org.wso2.carbon.server.feature/resources/bin/spi-provider.sh
+++ b/features/org.wso2.carbon.server.feature/resources/bin/spi-provider.sh
@@ -109,9 +109,9 @@ fi
 
 java_version=$("$JAVACMD" -version 2>&1 | awk -F '"' '/version/ {print $2}')
 java_version_formatted=$(echo "$java_version" | awk -F. '{printf("%02d%02d",$1,$2);}')
-if [ $java_version_formatted -lt 1100 ] || [ $java_version_formatted -gt 1700 ]; then
+if [ $java_version_formatted -lt 0108 ] || [ $java_version_formatted -gt 1700 ]; then
    echo " Starting WSO2 Carbon (in unsupported JDK)"
-   echo " [ERROR] CARBON is supported only between JDK 11 and 17"
+   echo " [ERROR] CARBON is supported only between JDK 1.8 and 17"
    exit 1
 fi
 

--- a/launcher/pom.xml
+++ b/launcher/pom.xml
@@ -52,7 +52,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.wso2.eclipse.osgi</groupId>
+            <groupId>org.eclipse.platform</groupId>
             <artifactId>org.eclipse.osgi</artifactId>
             <scope>test</scope>
         </dependency>
@@ -130,7 +130,7 @@
                         <configuration>
                             <artifactItems>
                                 <artifactItem>
-                                    <groupId>org.wso2.eclipse.osgi</groupId>
+                                    <groupId>org.eclipse.platform</groupId>
                                     <artifactId>org.eclipse.osgi</artifactId>
                                     <version>${equinox.osgi.version}</version>
                                     <type>jar</type>
@@ -149,7 +149,7 @@
                                 </artifactItem>
                                 <!-- artifacts for OSGi-lib tests -->
                                 <artifactItem>
-                                    <groupId>org.wso2.eclipse.osgi</groupId>
+                                    <groupId>org.eclipse.platform</groupId>
                                     <artifactId>org.eclipse.osgi</artifactId>
                                     <version>${equinox.osgi.version}</version>
                                     <type>jar</type>

--- a/launcher/pom.xml
+++ b/launcher/pom.xml
@@ -103,7 +103,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <systemProperties>
-                        <equinox.osgi.version>${equinox.osgi.version}</equinox.osgi.version>
+                        <equinox.osgi.version>${equinox.osgi.bundle.version}</equinox.osgi.version>
                         <equinox.simpleconfigurator.version>${equinox.simpleconfigurator.version}
                         </equinox.simpleconfigurator.version>
                         <equinox.util.version>${equinox.util.version}</equinox.util.version>

--- a/launcher/src/main/resources/launch.properties
+++ b/launcher/src/main/resources/launch.properties
@@ -18,7 +18,7 @@
 carbon.osgi.repository=file\:wso2/lib
 carbon.runtime.repository=file\:wso2
 
-carbon.osgi.framework=file\:plugins/org.eclipse.osgi_3.11.0.v20160603-1336.jar
+carbon.osgi.framework=file\:plugins/org.eclipse.osgi_3.14.0.v20190517-1309.jar
 
 carbon.initial.osgi.bundles=\
   file\:plugins/org.eclipse.osgi.services_3.5.100.v20160504-1419.jar@1\:true,\

--- a/launcher/src/test/resources/launch.properties
+++ b/launcher/src/test/resources/launch.properties
@@ -18,7 +18,7 @@
 carbon.osgi.repository=file\:wso2/lib
 carbon.runtime.repository=file\:wso2
 
-carbon.osgi.framework=file\:plugins/org.eclipse.osgi_3.11.0.v20160603-1336.jar
+carbon.osgi.framework=file\:plugins/org.eclipse.osgi_3.14.0.v20190517-1309.jar
 
 carbon.initial.osgi.bundles=\
   file\:plugins/org.eclipse.equinox.simpleconfigurator_1.1.200.v20160504-1450.jar@1\:true

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -754,6 +754,7 @@
         <maven-plugin-annotations.version>3.4</maven-plugin-annotations.version>
         <maven-core.version>3.3.9</maven-core.version>
         <maven-bundle-plugin.version>3.3.0</maven-bundle-plugin.version>
+        <maven.spotbugsplugin.exclude.file>spotbugs-exclude.xml</maven.spotbugsplugin.exclude.file>
 
         <!--Pax Exam Versions-->
         <pax.exam.version>4.9.1</pax.exam.version>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -638,6 +638,44 @@
                 <type>zip</type>
                 <scope>test</scope>
             </dependency>
+
+            <!--Java 11 related dependencies-->
+            <dependency>
+                <groupId>org.wso2.orbit.javax.xml.bind</groupId>
+                <artifactId>jaxb-api</artifactId>
+                <version>${org.wso2.orbit.javax.xml.bind.version}</version>
+                <type>jar</type>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.orbit.sun.xml.bind</groupId>
+                <artifactId>jaxb</artifactId>
+                <version>${org.wso2.orbit.sun.xml.bind.version}</version>
+                <type>jar</type>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.orbit.javax.activation</groupId>
+                <artifactId>activation</artifactId>
+                <version>${com.sun.activation.version}</version>
+                <type>jar</type>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.orbit.xml-apis</groupId>
+                <artifactId>xml-apis</artifactId>
+                <version>${org.wso2.orbit.xml-apis.version}</version>
+                <type>jar</type>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.geronimo.specs</groupId>
+                <artifactId>geronimo-activation_1.1_spec</artifactId>
+                <version>${org.apache.geronimo.spec.version}</version>
+                <type>jar</type>
+            </dependency>
+            <dependency>
+                <groupId>com.sun.istack</groupId>
+                <artifactId>istack-commons-runtime</artifactId>
+                <version>${com.sun.istack.version}</version>
+                <type>jar</type>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -128,6 +128,9 @@
                             <goals>
                                 <goal>javadoc</goal>
                             </goals>
+                            <configuration>
+                                <additionalparam>-Xdoclint:none</additionalparam>
+                            </configuration>
                         </execution>
                     </executions>
                 </plugin>
@@ -135,6 +138,26 @@
                     <groupId>org.wso2.carbon.maven</groupId>
                     <artifactId>carbon-feature-plugin</artifactId>
                     <version>${carbon.feature.plugin.version}</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>com.sun.xml.bind</groupId>
+                            <artifactId>jaxb-core</artifactId>
+                            <version>${com.sun.xml.bind.version}</version>
+                            <type>jar</type>
+                        </dependency>
+                        <dependency>
+                            <groupId>com.sun.xml.bind</groupId>
+                            <artifactId>jaxb-impl</artifactId>
+                            <version>${com.sun.xml.bind.version}</version>
+                            <type>jar</type>
+                        </dependency>
+                        <dependency>
+                            <groupId>org.wso2.orbit.javax.xml.bind</groupId>
+                            <artifactId>jaxb-api</artifactId>
+                            <version>${org.wso2.orbit.javax.xml.bind.version}</version>
+                            <type>jar</type>
+                        </dependency>
+                    </dependencies>
                 </plugin>
                 <plugin>
                     <groupId>org.wso2.carbon.config</groupId>
@@ -147,6 +170,7 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
+                <version>${maven-bundle-plugin.version}</version>
                 <configuration>
                     <instructions>
                         <Bundle-SymbolicName>${bundle.symbolicName}</Bundle-SymbolicName>
@@ -691,6 +715,7 @@
         <maven-plugin-api.version>3.3.9</maven-plugin-api.version>
         <maven-plugin-annotations.version>3.4</maven-plugin-annotations.version>
         <maven-core.version>3.3.9</maven-core.version>
+        <maven-bundle-plugin.version>3.3.0</maven-bundle-plugin.version>
 
         <!--Pax Exam Versions-->
         <pax.exam.version>4.9.1</pax.exam.version>
@@ -709,23 +734,35 @@
         <!--Other dependency versions -->
         <carbon.feature.plugin.version>3.1.1</carbon.feature.plugin.version>
         <testng.version>6.9.4</testng.version>
-        <jacoco.version>0.7.5.201505241946</jacoco.version>
+        <jacoco.version>0.8.2</jacoco.version>
         <org.jacoco.ant.version>0.7.5.201505241946</org.jacoco.ant.version>
         <commons.io.version>2.4.0.wso2v1</commons.io.version>
         <commons.compress.version>1.4.1</commons.compress.version>
-        <org.kohsuke.metainf.services.version>1.2</org.kohsuke.metainf.services.version>
+        <org.kohsuke.metainf.services.version>1.9</org.kohsuke.metainf.services.version>
         <geronimo.jms.spec.version>1.1</geronimo.jms.spec.version>
         <easymock.version>3.4</easymock.version>
         <powermock.api.easymock.version>1.6.5</powermock.api.easymock.version>
         <powermock.module.testng.version>1.6.5</powermock.module.testng.version>
         <javax.management.import.version.range>[0.0.0,1.0.0)</javax.management.import.version.range>
         <javax.security.auth.import.version.range>[0.0.0,1.0.0)</javax.security.auth.import.version.range>
-        <javax.xml.import.version.range>[0.0.0,1.0.0)</javax.xml.import.version.range>
+        <javax.xml.import.version.range>[0.0.0,5.0.0)</javax.xml.import.version.range>
         <org.w3c.import.version.range>[0.0.0,1.0.0)</org.w3c.import.version.range>
         <org.xml.sax.import.version.range>[0.0.0,1.0.0)</org.xml.sax.import.version.range>
         <javax.crypto.version.range>[0.0.0,1.0.0)</javax.crypto.version.range>
         <org.eclipse.core.runtime.import.version.range>[3.0.0, 4.0.0)</org.eclipse.core.runtime.import.version.range>
         <org.eclipse.equinox.p2.engine.import.version.range>[2.0.0, 3.0.0)</org.eclipse.equinox.p2.engine.import.version.range>
         <org.eclipse.equinox.p2.touchpoint.eclipse.import.version.range>[2.0.0, 3.0.0)</org.eclipse.equinox.p2.touchpoint.eclipse.import.version.range>
+
+        <!-- Java 11 related dependencies -->
+        <javax.annotation.version>1.3.2</javax.annotation.version>
+        <org.wso2.orbit.xml-apis.version>1.4.01.wso2v1</org.wso2.orbit.xml-apis.version>
+        <org.wso2.orbit.javax.xml.bind.version>2.3.1.wso2v1</org.wso2.orbit.javax.xml.bind.version>
+        <org.wso2.orbit.sun.xml.bind.version>2.3.2.wso2v1</org.wso2.orbit.sun.xml.bind.version>
+        <com.sun.xml.bind.version>2.4.0-b180830.0438</com.sun.xml.bind.version>
+        <org.apache.geronimo.spec.version>1.1</org.apache.geronimo.spec.version>
+        <com.sun.istack.version>3.0.8</com.sun.istack.version>
+        <com.sun.activation.version>1.1.1.wso2v3</com.sun.activation.version>
+        <com.sun.xml.bind.version>2.3.0</com.sun.xml.bind.version>
+        <com.sun.activation.javax.activation.version>1.2.0</com.sun.activation.javax.activation.version>
     </properties>
 </project>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -19,8 +19,7 @@
     <parent>
         <groupId>org.wso2</groupId>
         <artifactId>wso2</artifactId>
-        <version>5</version>
-        <relativePath />
+        <version>5.3</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
@@ -653,12 +652,6 @@
                 <type>jar</type>
             </dependency>
             <dependency>
-                <groupId>org.wso2.orbit.javax.activation</groupId>
-                <artifactId>activation</artifactId>
-                <version>${com.sun.activation.version}</version>
-                <type>jar</type>
-            </dependency>
-            <dependency>
                 <groupId>org.wso2.orbit.xml-apis</groupId>
                 <artifactId>xml-apis</artifactId>
                 <version>${org.wso2.orbit.xml-apis.version}</version>
@@ -771,11 +764,11 @@
         <geronimo.atinject.spec.version>1.0</geronimo.atinject.spec.version>
 
         <!--Other dependency versions -->
-        <carbon.feature.plugin.version>3.1.1</carbon.feature.plugin.version>
+        <carbon.feature.plugin.version>3.1.5</carbon.feature.plugin.version>
         <testng.version>6.9.4</testng.version>
         <jacoco.version>0.8.2</jacoco.version>
         <org.jacoco.ant.version>0.7.5.201505241946</org.jacoco.ant.version>
-        <commons.io.version>2.4.0.wso2v1</commons.io.version>
+        <commons.io.version>2.11.0.wso2v1</commons.io.version>
         <commons.compress.version>1.4.1</commons.compress.version>
         <org.kohsuke.metainf.services.version>1.9</org.kohsuke.metainf.services.version>
         <geronimo.jms.spec.version>1.1</geronimo.jms.spec.version>
@@ -800,7 +793,6 @@
         <com.sun.xml.bind.version>2.4.0-b180830.0438</com.sun.xml.bind.version>
         <org.apache.geronimo.spec.version>1.1</org.apache.geronimo.spec.version>
         <com.sun.istack.version>3.0.8</com.sun.istack.version>
-        <com.sun.activation.version>1.1.1.wso2v3</com.sun.activation.version>
         <com.sun.xml.bind.version>2.3.0</com.sun.xml.bind.version>
         <com.sun.activation.javax.activation.version>1.2.0</com.sun.activation.javax.activation.version>
     </properties>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -255,7 +255,7 @@
                 <version>${osgi.compendium.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.wso2.eclipse.osgi</groupId>
+                <groupId>org.eclipse.platform</groupId>
                 <artifactId>org.eclipse.osgi</artifactId>
                 <version>${equinox.osgi.version}</version>
             </dependency>
@@ -320,7 +320,7 @@
                 <version>${equinox.simpleconfigurator.manipulator.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.wso2.eclipse.equinox</groupId>
+                <groupId>org.eclipse.platform</groupId>
                 <artifactId>org.eclipse.equinox.console</artifactId>
                 <version>${equinox.console.version}</version>
             </dependency>
@@ -648,7 +648,8 @@
 
         <!-- Equinox dependency versions -->
         <osgi.core.api.version>6.0.0</osgi.core.api.version>
-        <equinox.osgi.version>3.11.0.v20160603-1336</equinox.osgi.version>
+        <equinox.osgi.version>3.14.0</equinox.osgi.version>
+        <equinox.osgi.bundle.version>3.14.0.v20190517-1309</equinox.osgi.bundle.version>
         <equinox.osgi.services.version>3.5.100.v20160504-1419</equinox.osgi.services.version>
         <equinox.ds.version>1.4.400.v20160226-2036</equinox.ds.version>
         <equinox.common.version>3.8.0.v20160509-1230</equinox.common.version>
@@ -667,7 +668,8 @@
         <equinox.registry.version>3.5.400.v20140428-1507</equinox.registry.version>
         <equinox.simpleconfigurator.manipulator.version>2.0.200.v20160504-1450
         </equinox.simpleconfigurator.manipulator.version>
-        <equinox.console.version>1.1.200.v20150929-1405</equinox.console.version>
+        <equinox.console.version>1.3.300</equinox.console.version>
+        <equinox.console.bundle.version>1.3.300.v20190516-1504</equinox.console.bundle.version>
         <apache.felix.gogo.command.version>0.10.0.v201209301215</apache.felix.gogo.command.version>
         <apache.felix.gogo.shell.version>0.10.0.v201212101605</apache.felix.gogo.shell.version>
         <apache.felix.gogo.runtime.version>0.10.0.v201209301036</apache.felix.gogo.runtime.version>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.wso2</groupId>
         <artifactId>wso2</artifactId>
-        <version>5</version>
+        <version>5.3</version>
         <relativePath />
     </parent>
 
@@ -676,6 +676,24 @@
                 <version>${com.sun.istack.version}</version>
                 <type>jar</type>
             </dependency>
+            <dependency>
+                <groupId>javax.annotation</groupId>
+                <artifactId>javax.annotation-api</artifactId>
+                <version>${javax.annotation.version}</version>
+                <type>jar</type>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.orbit.javax.xml.bind</groupId>
+                <artifactId>jaxb-api</artifactId>
+                <version>${org.wso2.orbit.javax.xml.bind.version}</version>
+                <type>jar</type>
+            </dependency>
+            <dependency>
+                <groupId>com.sun.xml.bind</groupId>
+                <artifactId>jaxb-impl</artifactId>
+                <version>${com.sun.xml.bind.version}</version>
+                <type>jar</type>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -771,7 +789,7 @@
         <geronimo.atinject.spec.version>1.0</geronimo.atinject.spec.version>
 
         <!--Other dependency versions -->
-        <carbon.feature.plugin.version>3.1.1</carbon.feature.plugin.version>
+        <carbon.feature.plugin.version>3.1.5</carbon.feature.plugin.version>
         <testng.version>6.9.4</testng.version>
         <jacoco.version>0.8.2</jacoco.version>
         <org.jacoco.ant.version>0.7.5.201505241946</org.jacoco.ant.version>

--- a/pax-exam-container-carbon/org.wso2.carbon.container/pom.xml
+++ b/pax-exam-container-carbon/org.wso2.carbon.container/pom.xml
@@ -49,7 +49,7 @@
             <artifactId>pax-exam-container-remote</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.eclipse.osgi</groupId>
+            <groupId>org.eclipse.platform</groupId>
             <artifactId>org.eclipse.osgi</artifactId>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.wso2</groupId>
         <artifactId>wso2</artifactId>
-        <version>5</version>
+        <version>5.3</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -105,6 +105,17 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>com.github.spotbugs</groupId>
+                <artifactId>spotbugs-maven-plugin</artifactId>
+                <version>${maven.spotbugsplugin.version}</version>
+                <configuration>
+                    <effort>Max</effort>
+                    <threshold>Low</threshold>
+                    <xmlOutput>true</xmlOutput>
+                    <excludeFilterFile>${maven.spotbugsplugin.exclude.file}</excludeFilterFile>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/spotbugs-exclude.xml
+++ b/spotbugs-exclude.xml
@@ -1,0 +1,164 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2022, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+  ~
+  ~ WSO2 LLC. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied. See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<FindBugsFilter>
+    <!--  WSO2 Carbon Kernel - Launcher [BEGIN] -->
+    <Match>
+        <Package name="~org\.wso2\.carbon\.launcher.*" />
+        <Bug pattern="CRLF_INJECTION_LOGS" />
+    </Match>
+    <Match>
+        <Package name="~org\.wso2\.carbon\.launcher.*" />
+        <Bug pattern="PATH_TRAVERSAL_IN" />
+    </Match>
+
+    <Match>
+        <Class name="org.wso2.carbon.launcher.config.CarbonLaunchConfig" />
+        <Bug pattern="URLCONNECTION_SSRF_FD" />
+    </Match>
+
+    <!--  WSO2 Carbon Kernel - Launcher [END] -->
+
+    <!--  WSO2 Carbon Kernel - Core [BEGIN] -->
+    <Match>
+        <Class name="~org\.wso2\.carbon\.kernel.*"/>
+        <Bug pattern="CRLF_INJECTION_LOGS"/>
+    </Match>
+
+    <Match>
+        <Class name="org.wso2.carbon.kernel.internal.utils.Utils" />
+        <Bug pattern="PATH_TRAVERSAL_IN" />
+    </Match>
+    <Match>
+        <Class name="org.wso2.carbon.kernel.jmx.connection.SingleAddressRMIServerSocketFactory" />
+        <Bug pattern="UNENCRYPTED_SERVER_SOCKET" />
+    </Match>
+    <Match>
+        <!-- False positive reported by SpotBugs -->
+        <Class name="org.wso2.carbon.kernel.internal.startupresolver.StartupServiceCache" />
+        <Bug pattern="DLS_DEAD_LOCAL_STORE" />
+    </Match>
+    <Match>
+        <!-- False positive reported by SpotBugs -->
+        <Class name="org.wso2.carbon.kernel.internal.utils.Utils" />
+        <Bug pattern="RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE" />
+    </Match>
+
+
+    <!--  WSO2 Carbon Kernel - Core [END] -->
+
+    <!--  WSO2 Carbon Kernel - Tools - Core [BEGIN] -->
+
+    <Match>
+        <Class name="~org\.wso2\.carbon\.tools.*"/>
+        <Bug pattern="CRLF_INJECTION_LOGS"/>
+    </Match>
+    <Match>
+        <Package name="~org\.wso2\.carbon\.tools.*" />
+        <Bug pattern="PATH_TRAVERSAL_IN" />
+    </Match>
+
+    <Match>
+        <Class name="org.wso2.carbon.kernel.internal.utils.Utils" />
+        <Bug pattern="RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE" />
+    </Match>
+    <Match>
+        <Class name="org.wso2.carbon.tools.InstallJarsTool" />
+        <Bug pattern="IMPROPER_UNICODE" />
+    </Match>
+
+    <!-- False positives reported by SpotBugs -->
+    <Match>
+        <Class name="org.wso2.carbon.tools.converter.utils.BundleGeneratorUtils" />
+        <Method returns="void" name="createBundle"/>
+        <Bug pattern="RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE" />
+    </Match>
+    <Match>
+        <Class name="org.wso2.carbon.tools.converter.utils.BundleGeneratorUtils" />
+        <Method returns="void" name="createBundle"/>
+        <Bug pattern="RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE" />
+    </Match>
+    <Match>
+        <Class name="org.wso2.carbon.tools.converter.utils.BundleGeneratorUtils" />
+        <Method returns="boolean" name="isOSGiBundle"/>
+        <Bug pattern="RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE" />
+    </Match>
+    <Match>
+        <Class name="org.wso2.carbon.tools.converter.utils.BundleGeneratorUtils" />
+        <Method returns="java.util.List" name="listZipFileContent"/>
+        <Bug pattern="RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE" />
+    </Match>
+    <Match>
+        <Class name="org.wso2.carbon.tools.converter.utils.BundleGeneratorUtils" />
+        <Method returns="java.util.List" name="listFiles"/>
+        <Bug pattern="RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE" />
+    </Match>
+    <Match>
+        <Class name="org.wso2.carbon.tools.spi.ICFProviderTool" />
+        <Method returns="void" name="addBundleActivatorHeader"/>
+        <Bug pattern="RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE" />
+    </Match>
+    <Match>
+        <Class name="org.wso2.carbon.tools.spi.NativeLibraryProvider" />
+        <Method returns="void" name="addBundleActivatorHeader"/>
+        <Bug pattern="RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE" />
+    </Match>
+    <Match>
+        <Class name="org.wso2.carbon.tools.spi.SPIProviderTool" />
+        <Method returns="void" name="addBundleActivatorHeader"/>
+        <Bug pattern="RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE" />
+    </Match>
+
+    <Match>
+        <Class name="org.wso2.carbon.tools.spi.ICFProviderTool" />
+        <Bug pattern="COMMAND_INJECTION" />
+    </Match>
+    <Match>
+        <Class name="org.wso2.carbon.tools.spi.NativeLibraryProvider" />
+        <Bug pattern="COMMAND_INJECTION" />
+    </Match>
+    <Match>
+        <Class name="org.wso2.carbon.tools.spi.SPIProviderTool" />
+        <Bug pattern="COMMAND_INJECTION" />
+    </Match>
+
+    <!--  WSO2 Carbon Kernel - Tools - Core [END] -->
+
+    <!--  WSO2 Carbon Kernel - Tools - Pax Exam Container [BEGIN] -->
+
+    <Match>
+        <Class name="~org\.wso2\.carbon\.container.*"/>
+        <Bug pattern="CRLF_INJECTION_LOGS"/>
+    </Match>
+    <Match>
+        <Class name="~org\.wso2\.carbon\.container.*"/>
+        <Bug pattern="PATH_TRAVERSAL_IN"/>
+    </Match>
+
+    <Match>
+        <Class name="org.wso2.carbon.container.ArchiveExtractor" />
+        <Bug pattern="URLCONNECTION_SSRF_FD" />
+    </Match>
+    <Match>
+        <Class name="org.wso2.carbon.container.runner.InternalRunner" />
+        <Bug pattern="COMMAND_INJECTION" />
+    </Match>
+
+    <!--  WSO2 Carbon Kernel - Tools - Pax Exam Container [END] -->
+</FindBugsFilter>

--- a/tests/osgi-tests/pom.xml
+++ b/tests/osgi-tests/pom.xml
@@ -66,7 +66,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.wso2.eclipse.osgi</groupId>
+            <groupId>org.eclipse.platform</groupId>
             <artifactId>org.eclipse.osgi</artifactId>
             <optional>true</optional>
         </dependency>

--- a/tests/test-artifacts/carbon-context-test-artifact/pom.xml
+++ b/tests/test-artifacts/carbon-context-test-artifact/pom.xml
@@ -32,7 +32,7 @@
             <artifactId>org.wso2.carbon.core</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.eclipse.osgi</groupId>
+            <groupId>org.eclipse.platform</groupId>
             <artifactId>org.eclipse.osgi</artifactId>
             <optional>true</optional>
         </dependency>

--- a/tests/test-artifacts/startup-coordination/org.wso2.carbon.sample.datasource.mgt/pom.xml
+++ b/tests/test-artifacts/startup-coordination/org.wso2.carbon.sample.datasource.mgt/pom.xml
@@ -38,7 +38,7 @@
             <artifactId>org.wso2.carbon.sample.order.resolver</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.eclipse.osgi</groupId>
+            <groupId>org.eclipse.platform</groupId>
             <artifactId>org.eclipse.osgi</artifactId>
             <optional>true</optional>
         </dependency>

--- a/tests/test-artifacts/startup-coordination/org.wso2.carbon.sample.dbs.deployer/pom.xml
+++ b/tests/test-artifacts/startup-coordination/org.wso2.carbon.sample.dbs.deployer/pom.xml
@@ -38,7 +38,7 @@
             <artifactId>org.wso2.carbon.sample.deployer.mgt</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.eclipse.osgi</groupId>
+            <groupId>org.eclipse.platform</groupId>
             <artifactId>org.eclipse.osgi</artifactId>
             <optional>true</optional>
         </dependency>

--- a/tests/test-artifacts/startup-coordination/org.wso2.carbon.sample.deployer.mgt/pom.xml
+++ b/tests/test-artifacts/startup-coordination/org.wso2.carbon.sample.deployer.mgt/pom.xml
@@ -38,7 +38,7 @@
             <artifactId>org.wso2.carbon.sample.order.resolver</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.eclipse.osgi</groupId>
+            <groupId>org.eclipse.platform</groupId>
             <artifactId>org.eclipse.osgi</artifactId>
             <optional>true</optional>
         </dependency>

--- a/tests/test-artifacts/startup-coordination/org.wso2.carbon.sample.order.resolver/pom.xml
+++ b/tests/test-artifacts/startup-coordination/org.wso2.carbon.sample.order.resolver/pom.xml
@@ -34,7 +34,7 @@
             <artifactId>org.wso2.carbon.core</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.eclipse.osgi</groupId>
+            <groupId>org.eclipse.platform</groupId>
             <artifactId>org.eclipse.osgi</artifactId>
             <optional>true</optional>
         </dependency>

--- a/tests/test-artifacts/startup-coordination/org.wso2.carbon.sample.repository.mgt/pom.xml
+++ b/tests/test-artifacts/startup-coordination/org.wso2.carbon.sample.repository.mgt/pom.xml
@@ -42,7 +42,7 @@
             <artifactId>org.wso2.carbon.sample.runtime.mgt</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.eclipse.osgi</groupId>
+            <groupId>org.eclipse.platform</groupId>
             <artifactId>org.eclipse.osgi</artifactId>
             <optional>true</optional>
         </dependency>

--- a/tests/test-artifacts/startup-coordination/org.wso2.carbon.sample.runtime.bps/pom.xml
+++ b/tests/test-artifacts/startup-coordination/org.wso2.carbon.sample.runtime.bps/pom.xml
@@ -34,7 +34,7 @@
             <artifactId>org.wso2.carbon.sample.runtime.mgt</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.eclipse.osgi</groupId>
+            <groupId>org.eclipse.platform</groupId>
             <artifactId>org.eclipse.osgi</artifactId>
             <optional>true</optional>
         </dependency>

--- a/tests/test-artifacts/startup-coordination/org.wso2.carbon.sample.runtime.custom/pom.xml
+++ b/tests/test-artifacts/startup-coordination/org.wso2.carbon.sample.runtime.custom/pom.xml
@@ -34,7 +34,7 @@
             <artifactId>org.wso2.carbon.sample.runtime.mgt</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.eclipse.osgi</groupId>
+            <groupId>org.eclipse.platform</groupId>
             <artifactId>org.eclipse.osgi</artifactId>
             <optional>true</optional>
         </dependency>

--- a/tests/test-artifacts/startup-coordination/org.wso2.carbon.sample.runtime.jar/pom.xml
+++ b/tests/test-artifacts/startup-coordination/org.wso2.carbon.sample.runtime.jar/pom.xml
@@ -34,7 +34,7 @@
             <artifactId>org.wso2.carbon.sample.runtime.mgt</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.eclipse.osgi</groupId>
+            <groupId>org.eclipse.platform</groupId>
             <artifactId>org.eclipse.osgi</artifactId>
             <optional>true</optional>
         </dependency>

--- a/tests/test-artifacts/startup-coordination/org.wso2.carbon.sample.runtime.mgt/pom.xml
+++ b/tests/test-artifacts/startup-coordination/org.wso2.carbon.sample.runtime.mgt/pom.xml
@@ -38,7 +38,7 @@
             <artifactId>org.wso2.carbon.sample.order.resolver</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.eclipse.osgi</groupId>
+            <groupId>org.eclipse.platform</groupId>
             <artifactId>org.eclipse.osgi</artifactId>
             <optional>true</optional>
         </dependency>

--- a/tests/test-artifacts/startup-coordination/org.wso2.carbon.sample.runtime.mss/pom.xml
+++ b/tests/test-artifacts/startup-coordination/org.wso2.carbon.sample.runtime.mss/pom.xml
@@ -34,7 +34,7 @@
             <artifactId>org.wso2.carbon.sample.runtime.mgt</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.eclipse.osgi</groupId>
+            <groupId>org.eclipse.platform</groupId>
             <artifactId>org.eclipse.osgi</artifactId>
             <optional>true</optional>
         </dependency>

--- a/tests/test-artifacts/startup-coordination/org.wso2.carbon.sample.runtime.service/pom.xml
+++ b/tests/test-artifacts/startup-coordination/org.wso2.carbon.sample.runtime.service/pom.xml
@@ -36,7 +36,7 @@
             <artifactId>org.wso2.carbon.core</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.eclipse.osgi</groupId>
+            <groupId>org.eclipse.platform</groupId>
             <artifactId>org.eclipse.osgi</artifactId>
             <optional>true</optional>
         </dependency>

--- a/tests/test-artifacts/startup-coordination/org.wso2.carbon.sample.runtime.webapp/pom.xml
+++ b/tests/test-artifacts/startup-coordination/org.wso2.carbon.sample.runtime.webapp/pom.xml
@@ -34,7 +34,7 @@
             <artifactId>org.wso2.carbon.sample.runtime.mgt</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.eclipse.osgi</groupId>
+            <groupId>org.eclipse.platform</groupId>
             <artifactId>org.eclipse.osgi</artifactId>
             <optional>true</optional>
         </dependency>

--- a/tests/test-artifacts/startup-coordination/org.wso2.carbon.sample.transport.custom/pom.xml
+++ b/tests/test-artifacts/startup-coordination/org.wso2.carbon.sample.transport.custom/pom.xml
@@ -34,7 +34,7 @@
             <artifactId>org.wso2.carbon.sample.transport.mgt</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.eclipse.osgi</groupId>
+            <groupId>org.eclipse.platform</groupId>
             <artifactId>org.eclipse.osgi</artifactId>
             <optional>true</optional>
         </dependency>

--- a/tests/test-artifacts/startup-coordination/org.wso2.carbon.sample.transport.custom2/pom.xml
+++ b/tests/test-artifacts/startup-coordination/org.wso2.carbon.sample.transport.custom2/pom.xml
@@ -34,7 +34,7 @@
             <artifactId>org.wso2.carbon.sample.transport.mgt</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.eclipse.osgi</groupId>
+            <groupId>org.eclipse.platform</groupId>
             <artifactId>org.eclipse.osgi</artifactId>
             <optional>true</optional>
         </dependency>

--- a/tests/test-artifacts/startup-coordination/org.wso2.carbon.sample.transport.file/pom.xml
+++ b/tests/test-artifacts/startup-coordination/org.wso2.carbon.sample.transport.file/pom.xml
@@ -34,7 +34,7 @@
             <artifactId>org.wso2.carbon.sample.transport.mgt</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.eclipse.osgi</groupId>
+            <groupId>org.eclipse.platform</groupId>
             <artifactId>org.eclipse.osgi</artifactId>
             <optional>true</optional>
         </dependency>

--- a/tests/test-artifacts/startup-coordination/org.wso2.carbon.sample.transport.ftp/pom.xml
+++ b/tests/test-artifacts/startup-coordination/org.wso2.carbon.sample.transport.ftp/pom.xml
@@ -38,7 +38,7 @@
             <artifactId>org.wso2.carbon.sample.transport.mgt</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.eclipse.osgi</groupId>
+            <groupId>org.eclipse.platform</groupId>
             <artifactId>org.eclipse.osgi</artifactId>
             <optional>true</optional>
         </dependency>

--- a/tests/test-artifacts/startup-coordination/org.wso2.carbon.sample.transport.http/pom.xml
+++ b/tests/test-artifacts/startup-coordination/org.wso2.carbon.sample.transport.http/pom.xml
@@ -34,7 +34,7 @@
             <artifactId>org.wso2.carbon.sample.transport.mgt</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.eclipse.osgi</groupId>
+            <groupId>org.eclipse.platform</groupId>
             <artifactId>org.eclipse.osgi</artifactId>
             <optional>true</optional>
         </dependency>

--- a/tests/test-artifacts/startup-coordination/org.wso2.carbon.sample.transport.jetty/pom.xml
+++ b/tests/test-artifacts/startup-coordination/org.wso2.carbon.sample.transport.jetty/pom.xml
@@ -34,7 +34,7 @@
             <artifactId>org.wso2.carbon.sample.transport.mgt</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.eclipse.osgi</groupId>
+            <groupId>org.eclipse.platform</groupId>
             <artifactId>org.eclipse.osgi</artifactId>
             <optional>true</optional>
         </dependency>

--- a/tests/test-artifacts/startup-coordination/org.wso2.carbon.sample.transport.jms/pom.xml
+++ b/tests/test-artifacts/startup-coordination/org.wso2.carbon.sample.transport.jms/pom.xml
@@ -34,7 +34,7 @@
             <artifactId>org.wso2.carbon.sample.transport.mgt</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.eclipse.osgi</groupId>
+            <groupId>org.eclipse.platform</groupId>
             <artifactId>org.eclipse.osgi</artifactId>
             <optional>true</optional>
         </dependency>

--- a/tests/test-artifacts/startup-coordination/org.wso2.carbon.sample.transport.mgt/pom.xml
+++ b/tests/test-artifacts/startup-coordination/org.wso2.carbon.sample.transport.mgt/pom.xml
@@ -38,7 +38,7 @@
             <artifactId>org.wso2.carbon.sample.order.resolver</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.eclipse.osgi</groupId>
+            <groupId>org.eclipse.platform</groupId>
             <artifactId>org.eclipse.osgi</artifactId>
             <optional>true</optional>
         </dependency>

--- a/tools/tools-core/pom.xml
+++ b/tools/tools-core/pom.xml
@@ -127,6 +127,7 @@
                     <systemProperties>
                         <carbon.kernel.version>${carbon.kernel.version}</carbon.kernel.version>
                         <equinox.osgi.version>${equinox.osgi.version}</equinox.osgi.version>
+                        <equinox.osgi.bundle.version>${equinox.osgi.bundle.version}</equinox.osgi.bundle.version>
                         <equinox.simpleconfigurator.version>${equinox.simpleconfigurator.version}
                         </equinox.simpleconfigurator.version>
                         <equinox.util.version>${equinox.util.version}</equinox.util.version>

--- a/tools/tools-core/pom.xml
+++ b/tools/tools-core/pom.xml
@@ -47,7 +47,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.wso2.eclipse.osgi</groupId>
+            <groupId>org.eclipse.platform</groupId>
             <artifactId>org.eclipse.osgi</artifactId>
             <scope>test</scope>
         </dependency>
@@ -160,7 +160,7 @@
                                     <destFileName>tool-test-artifact-${carbon.kernel.version}.jar</destFileName>
                                 </artifactItem>
                                 <artifactItem>
-                                    <groupId>org.wso2.eclipse.osgi</groupId>
+                                    <groupId>org.eclipse.platform</groupId>
                                     <artifactId>org.eclipse.osgi</artifactId>
                                     <version>${equinox.osgi.version}</version>
                                     <type>jar</type>
@@ -176,7 +176,7 @@
                                     <destFileName>tool-test-artifact-${carbon.kernel.version}.jar</destFileName>
                                 </artifactItem>
                                 <artifactItem>
-                                    <groupId>org.wso2.eclipse.osgi</groupId>
+                                    <groupId>org.eclipse.platform</groupId>
                                     <artifactId>org.eclipse.osgi</artifactId>
                                     <version>${equinox.osgi.version}</version>
                                     <type>jar</type>

--- a/tools/tools-core/src/main/java/org/wso2/carbon/tools/spi/ICFProviderTool.java
+++ b/tools/tools-core/src/main/java/org/wso2/carbon/tools/spi/ICFProviderTool.java
@@ -102,7 +102,7 @@ public class ICFProviderTool implements CarbonTool {
         Path destination = Paths.get(toolArgs[2]);
         String osgiJar = (toolArgs.length == 4 && !toolArgs[3].isEmpty()) ? toolArgs[3] :
                          Paths.get(System.getProperty("carbon.home"), "wso2", "lib", "plugins",
-                                   "org.eclipse.osgi_3.11.0.v20160603-1336.jar").toString();
+                                   "org.eclipse.osgi_3.14.0").toString();
 
         Path fileName = jarFile.getFileName();
         if (fileName == null) {

--- a/tools/tools-core/src/main/java/org/wso2/carbon/tools/spi/NativeLibraryProvider.java
+++ b/tools/tools-core/src/main/java/org/wso2/carbon/tools/spi/NativeLibraryProvider.java
@@ -97,7 +97,7 @@ public class NativeLibraryProvider implements CarbonTool {
         String nativeLibString = toolArgs[2];
         String osgiJar = (toolArgs.length == 4 && !toolArgs[3].isEmpty()) ? toolArgs[3] :
                 Paths.get(System.getProperty("carbon.home"), "wso2", "lib", "plugins",
-                        "org.eclipse.osgi_3.11.0.v20160603-1336.jar").toString();
+                        "org.eclipse.osgi_3.14.0").toString();
 
         Path fileName = jarFile.getFileName();
         if (fileName == null) {

--- a/tools/tools-core/src/main/java/org/wso2/carbon/tools/spi/SPIProviderTool.java
+++ b/tools/tools-core/src/main/java/org/wso2/carbon/tools/spi/SPIProviderTool.java
@@ -100,7 +100,7 @@ public class SPIProviderTool implements CarbonTool {
         Path destination = Paths.get(toolArgs[3]);
         String osgiJar = (toolArgs.length == 5 && !toolArgs[4].isEmpty()) ? toolArgs[4] :
                 Paths.get(System.getProperty("carbon.home"), "wso2", "lib", "plugins",
-                        "org.eclipse.osgi_3.11.0.v20160603-1336.jar").toString();
+                        "org.eclipse.osgi_3.14.0.jar").toString();
 
         Path fileName = jarFile.getFileName();
         if (fileName == null) {

--- a/tools/tools-core/src/test/java/org/wso2/carbon/tools/TestConstants.java
+++ b/tools/tools-core/src/test/java/org/wso2/carbon/tools/TestConstants.java
@@ -30,6 +30,7 @@ public class TestConstants {
     public static final String CHILD_TEST_DIRECTORY_ONE = "sampleOne";
 
     public static final String EQUINOX_OSGI_VERSION = System.getProperty("equinox.osgi.version");
+    public static final String EQUINOX_OSGI_BUNDLE_VERSION = System.getProperty("equinox.osgi.bundle.version");
     public static final String EQUINOX_SMP_CONFIGURATOR_VERSION = System.
             getProperty("equinox.simpleconfigurator.version");
     public static final String EQUINOX_UTIL_VERSION = System.getProperty("equinox.util.version");

--- a/tools/tools-core/src/test/java/org/wso2/carbon/tools/osgilib/OSGiLibDeployerToolTest.java
+++ b/tools/tools-core/src/test/java/org/wso2/carbon/tools/osgilib/OSGiLibDeployerToolTest.java
@@ -233,8 +233,8 @@ public class OSGiLibDeployerToolTest {
 
     private static List<BundleInfo> getExpectedBundleInfo() {
         List<BundleInfo> bundleInfo = new ArrayList<>();
-        bundleInfo.add(BundleInfo.getInstance("org.eclipse.osgi," + TestConstants.EQUINOX_OSGI_VERSION + ",../../" +
-                Constants.OSGI_LIB + "/" + TestConstants.ARTIFACT_ONE + ",4,true"));
+        bundleInfo.add(BundleInfo.getInstance("org.eclipse.osgi," + TestConstants.EQUINOX_OSGI_BUNDLE_VERSION +
+                ",../../" + Constants.OSGI_LIB + "/" + TestConstants.ARTIFACT_ONE + ",4,true"));
         bundleInfo.add(BundleInfo.getInstance("org.eclipse.equinox.simpleconfigurator," +
                 TestConstants.EQUINOX_SMP_CONFIGURATOR_VERSION + ",../../" + Constants.OSGI_LIB +
                 "/" + TestConstants.ARTIFACT_TWO + ",4,true"));

--- a/tools/tools-core/src/test/java/org/wso2/carbon/tools/spi/ICFProviderToolTest.java
+++ b/tools/tools-core/src/test/java/org/wso2/carbon/tools/spi/ICFProviderToolTest.java
@@ -52,7 +52,7 @@ public class ICFProviderToolTest {
         String spiImpl = "org.wso2.carbon.impl.TestSPIImpl";
         icfProviderTool.execute(spiImpl, sampleJARFile.toString(), converterTestResources.toString(),
                                 converterTestResources.getParent().resolve("lib")
-                                                      .resolve("org.eclipse.osgi_3.11.0.v20160603-1336.jar")
+                                                      .resolve("org.eclipse.osgi_3.14.0.v20190517-1309.jar")
                                                       .toString());
 
         String jarFileName = sampleJARFile.getFileName().toString();


### PR DESCRIPTION
## Purpose
> $subject. Syncs changes from the temporary branch [`5.2.x-java11-compilation`](https://github.com/wso2/carbon-kernel/tree/5.2.x-java11-compilation) branch to master. See https://github.com/wso2/carbon-kernel/pull/3407 for details.

## Goals
> Make Carbon Kernel compilable on Java 11, and support running products based on this Kernel (eg: [WSO2 Streaming Integrator](https://github.com/wso2/streaming-integrator)) in JDK 17. Fixes https://github.com/wso2/api-manager/issues/631.

## Related PRs
> https://github.com/wso2/carbon-kernel/pull/3407
