### PR TITLE
Improve authentication failure audit logs

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
@@ -1786,8 +1786,8 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
         }
 
         if (!authenticated) {
-            handleOnAuthenticateFailure(ErrorMessages.ERROR_CODE_ERROR_WHILE_AUTHENTICATION.getCode(),
-                    String.format(ErrorMessages.ERROR_CODE_ERROR_WHILE_AUTHENTICATION.getMessage(),
+            handleOnAuthenticateFailure(ErrorMessages.ERROR_CODE_ERROR_INVALID_CREDENTIAL.getCode(),
+                    String.format(ErrorMessages.ERROR_CODE_ERROR_INVALID_CREDENTIAL.getMessage(),
                             "Authentication failed"), userName, credential);
         }
 
@@ -10545,8 +10545,8 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
             if (log.isDebugEnabled()) {
                 log.debug("Authentication failure. Invalid username or password is provided.");
             }
-            handleOnAuthenticateFailure(ErrorMessages.ERROR_CODE_ERROR_WHILE_AUTHENTICATION.getCode(),
-                    String.format(ErrorMessages.ERROR_CODE_ERROR_WHILE_AUTHENTICATION.getMessage(),
+            handleOnAuthenticateFailure(ErrorMessages.ERROR_CODE_ERROR_INVALID_CREDENTIAL.getCode(),
+                    String.format(ErrorMessages.ERROR_CODE_ERROR_INVALID_CREDENTIAL.getMessage(),
                             "Authentication failed"), userName, credential);
             throw new UserStoreException("Authentication failed. Invalid username or password.");
         }
@@ -10871,8 +10871,8 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
         }
 
         if (!authenticated) {
-            handleOnAuthenticateFailureWithID(ErrorMessages.ERROR_CODE_ERROR_WHILE_AUTHENTICATION.getCode(),
-                    String.format(ErrorMessages.ERROR_CODE_ERROR_WHILE_AUTHENTICATION.getMessage(),
+            handleOnAuthenticateFailureWithID(ErrorMessages.ERROR_CODE_ERROR_INVALID_CREDENTIAL.getCode(),
+                    String.format(ErrorMessages.ERROR_CODE_ERROR_INVALID_CREDENTIAL.getMessage(),
                             "Authentication failed"), loginIdentifiers, credential);
         }
 
@@ -11090,8 +11090,8 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
                 if (log.isDebugEnabled()) {
                     log.debug("Authentication failure. Invalid username or password is provided.");
                 }
-                handleOnAuthenticateFailure(ErrorMessages.ERROR_CODE_ERROR_WHILE_AUTHENTICATION.getCode(),
-                        String.format(ErrorMessages.ERROR_CODE_ERROR_WHILE_AUTHENTICATION.getMessage(),
+                handleOnAuthenticateFailure(ErrorMessages.ERROR_CODE_ERROR_INVALID_CREDENTIAL.getCode(),
+                        String.format(ErrorMessages.ERROR_CODE_ERROR_INVALID_CREDENTIAL.getMessage(),
                                 "Authentication failed"), preferredUserNameValue, credential);
                 throw new UserStoreException("Authentication failed. Invalid username or password.");
             }
@@ -11340,8 +11340,8 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
         }
 
         if (!authenticated) {
-            handleOnAuthenticateFailureWithID(ErrorMessages.ERROR_CODE_ERROR_WHILE_AUTHENTICATION.getCode(),
-                    String.format(ErrorMessages.ERROR_CODE_ERROR_WHILE_AUTHENTICATION.getMessage(),
+            handleOnAuthenticateFailureWithID(ErrorMessages.ERROR_CODE_ERROR_INVALID_CREDENTIAL.getCode(),
+                    String.format(ErrorMessages.ERROR_CODE_ERROR_INVALID_CREDENTIAL.getMessage(),
                             "Authentication failed"), preferredUserNameClaim, preferredUserNameValue, credential);
         }
 
@@ -11556,8 +11556,8 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
         }
 
         if (!authenticated) {
-            handleOnAuthenticateFailureWithID(ErrorMessages.ERROR_CODE_ERROR_WHILE_AUTHENTICATION.getCode(),
-                    String.format(ErrorMessages.ERROR_CODE_ERROR_WHILE_AUTHENTICATION.getMessage(),
+            handleOnAuthenticateFailureWithID(ErrorMessages.ERROR_CODE_ERROR_INVALID_CREDENTIAL.getCode(),
+                    String.format(ErrorMessages.ERROR_CODE_ERROR_INVALID_CREDENTIAL.getMessage(),
                             "Authentication failed"), userID, credential);
         }
 

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/constants/UserCoreErrorConstants.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/constants/UserCoreErrorConstants.java
@@ -59,6 +59,8 @@ public class UserCoreErrorConstants {
         ERROR_CODE_ERROR_WHILE_PRE_AUTHENTICATION("31002", "Un-expected error while pre-authenticating, %s"),
         ERROR_CODE_TENANT_DEACTIVATED("31003", "Tenant has been deactivated. TenantID : %s"),
         ERROR_CODE_ERROR_WHILE_POST_AUTHENTICATION("31004", "TUn-expected error while post-authentication, %s"),
+        ERROR_CODE_ERROR_INVALID_CREDENTIAL(
+                "31005", "Authentication failure. Invalid username or password is provided."),
 
         // Error code related with getClaimValue
         ERROR_CODE_ERROR_WHILE_GETTING_USER_CLAIM_VALUE("32001", "Un-expected error while getting user-claim value, "


### PR DESCRIPTION
Related issue:
- https://github.com/wso2/product-is/issues/15173

Introduce new error constant to indicate any invalid username or password is provided for authentication.
`Authentication failure. Invalid username or password is provided.`