### PR TITLE
Add user attribute fix for case-insensitive username

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/JDBCUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/JDBCUserStoreManager.java
@@ -3504,12 +3504,20 @@ public class JDBCUserStoreManager extends AbstractUserStoreManager {
             throw new UserStoreException(msg, e);
         }
 
-        String sqlStmt = realmConfig.getUserStoreProperty(JDBCRealmConstants.ADD_USER_PROPERTY + "-" + type);
-        if (sqlStmt == null) {
-            sqlStmt = realmConfig.getUserStoreProperty(JDBCRealmConstants.ADD_USER_PROPERTY);
+        String sqlStmt;
+        if (isCaseSensitiveUsername()) {
+            sqlStmt = realmConfig.getUserStoreProperty(JDBCRealmConstants.ADD_USER_PROPERTY + "-" + type);
+        } else {
+            sqlStmt = realmConfig.getUserStoreProperty(
+                    JDBCCaseInsensitiveConstants.ADD_USER_PROPERTY_CASE_INSENSITIVE + "-" + type);
         }
         if (sqlStmt == null) {
-            throw new UserStoreException("The sql statement for add user property sql is null");
+            if (isCaseSensitiveUsername()) {
+                sqlStmt = realmConfig.getUserStoreProperty(JDBCRealmConstants.ADD_USER_PROPERTY);
+            } else {
+                sqlStmt = realmConfig
+                        .getUserStoreProperty(JDBCCaseInsensitiveConstants.ADD_USER_PROPERTY_CASE_INSENSITIVE);
+            }
         }
 
         PreparedStatement prepStmt = null;

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/caseinsensitive/JDBCCaseInsensitiveConstants.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/caseinsensitive/JDBCCaseInsensitiveConstants.java
@@ -55,6 +55,7 @@ public class JDBCCaseInsensitiveConstants {
     public static final String GET_USERID_FROM_USERNAME_CASE_INSENSITIVE = "GetUserIDFromUserNameSQLCaseInsensitive";
     public static final String GET_TENANT_ID_FROM_USERNAME_CASE_INSENSITIVE =
             "GetTenantIDFromUserNameSQLCaseInsensitive";
+    public static final String ADD_USER_PROPERTY_CASE_INSENSITIVE = "AddUserPropertySQLCaseInsensitive";
     public static final String ADD_USER_TO_ROLE_CASE_INSENSITIVE = "AddUserToRoleSQLCaseInsensitive";
     public static final String ADD_ROLE_TO_USER_CASE_INSENSITIVE = "AddRoleToUserSQLCaseInsensitive";
     public static final String ADD_SHARED_ROLE_TO_USER_CASE_INSENSITIVE = "AddSharedRoleToUserSQLCaseInsensitive";
@@ -68,6 +69,9 @@ public class JDBCCaseInsensitiveConstants {
     public static final String ON_DELETE_USER_REMOVE_ATTRIBUTE_CASE_INSENSITIVE =
             "OnDeleteUserRemoveUserAttributeSQLCaseInsensitive";
     public static final String UPDATE_USER_PASSWORD_CASE_INSENSITIVE = "UpdateUserPasswordSQLCaseInsensitive";
+    public static final String ADD_USER_PROPERTY_SQL_CASE_INSENSITIVE = "INSERT INTO UM_USER_ATTRIBUTE " +
+            "(UM_USER_ID, UM_ATTR_NAME, UM_ATTR_VALUE, UM_PROFILE_ID, UM_TENANT_ID) VALUES " +
+            "((SELECT UM_ID FROM UM_USER WHERE LOWER(UM_USER_NAME)=LOWER(?) AND UM_TENANT_ID=?), ?, ?, ?, ?)";
     public static final String UPDATE_USER_PROPERTY_CASE_INSENSITIVE = "UpdateUserPropertySQLCaseInsensitive";
     public static final String DELETE_USER_PROPERTY_CASE_INSENSITIVE = "DeleteUserPropertySQLCaseInsensitive";
     public static final String USER_NAME_UNIQUE_CASE_INSENSITIVE = "UserNameUniqueAcrossTenantsSQLCaseInsensitive";

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/util/JDBCRealmUtil.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/util/JDBCRealmUtil.java
@@ -686,6 +686,10 @@ public class JDBCRealmUtil {
             properties.put(JDBCCaseInsensitiveConstants.USER_NAME_UNIQUE_CASE_INSENSITIVE_WITH_ID,
                     JDBCCaseInsensitiveConstants.USER_NAME_UNIQUE_SQL_CASE_INSENSITIVE_WITH_ID);
         }
+        if (!properties.containsKey(JDBCCaseInsensitiveConstants.ADD_USER_PROPERTY_CASE_INSENSITIVE)) {
+            properties.put(JDBCCaseInsensitiveConstants.ADD_USER_PROPERTY_CASE_INSENSITIVE,
+                    JDBCCaseInsensitiveConstants.ADD_USER_PROPERTY_SQL_CASE_INSENSITIVE);
+        }
         if (!properties.containsKey(JDBCCaseInsensitiveConstants.UPDATE_USER_PROPERTY_CASE_INSENSITIVE)) {
             properties.put(JDBCCaseInsensitiveConstants.UPDATE_USER_PROPERTY_CASE_INSENSITIVE,
                     JDBCCaseInsensitiveConstants.UPDATE_USER_PROPERTY_SQL_CASE_INSENSITIVE);


### PR DESCRIPTION
## Description
With https://github.com/wso2/product-is/issues/11578 was introduced a change to support "updating" claims on a JDBC userstore when the userstore is configured to be case insensitive. Nonetheless "adding" claims on a JDBC userstore when the userstore is configured to be case insensitive is not supported still.

## Related Issue
- https://github.com/wso2/product-is/issues/15159