### PR TITLE
Clear the MDC

### DIFF
--- a/core/org.wso2.carbon.tomcat.ext/src/main/java/org/wso2/carbon/tomcat/ext/valves/RequestCorrelationIdValve.java
+++ b/core/org.wso2.carbon.tomcat.ext/src/main/java/org/wso2/carbon/tomcat/ext/valves/RequestCorrelationIdValve.java
@@ -144,6 +144,7 @@ public class RequestCorrelationIdValve extends ValveBase {
             }
             disAssociateFromThread();
             ThreadContext.remove(correlationIdMdc);
+            MDC.clear();
         }
     }
 


### PR DESCRIPTION
Purpose:
Currently we’re not clearing the service provider value from MDC at the end of the thread. There are some other values which are passed to the MDC but not cleared at the end[1]. Hence the thread owns the data and prints during the next iteration.
To solve this issue we clear the MDC at the end of the execution.

[1] https://github.com/wso2/product-is/issues/9119

Related issues:

ServiceProviderName gets printed in the audit log even without actions related to a Service Provider wso2/product-is#15166