### PR TITLE
Clear password validation thread local for input validation listener

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
@@ -13712,6 +13712,7 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
             }
         } finally {
             newCredentialObj.clear();
+            UserCoreUtil.removeSkipPasswordPatternValidationThreadLocal();
         }
         // #################### </Listeners> #####################################################
 

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
@@ -13712,6 +13712,8 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
             }
         } finally {
             newCredentialObj.clear();
+            // This value is set in the validation lister if the password gets validated
+            // against the configured set of rules.
             UserCoreUtil.removeSkipPasswordPatternValidationThreadLocal();
         }
         // #################### </Listeners> #####################################################


### PR DESCRIPTION
## Purpose
> Clear the thread local set in the validation listener to skip the password validation if it is handled in the validation listener


This PR needs to be merged with https://github.com/wso2/carbon-kernel/pull/3453