### PR TITLE
Add configuration to add custom password validity period for new users.

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
@@ -24,6 +24,7 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.CarbonConstants;
+import org.wso2.carbon.base.ServerConfiguration;
 import org.wso2.carbon.context.CarbonContext;
 import org.wso2.carbon.user.api.RealmConfiguration;
 import org.wso2.carbon.user.core.NotImplementedException;
@@ -70,6 +71,7 @@ import org.wso2.carbon.user.core.service.RealmService;
 import org.wso2.carbon.user.core.system.SystemUserRoleManager;
 import org.wso2.carbon.user.core.util.UserCoreUtil;
 import org.wso2.carbon.utils.Secret;
+import org.wso2.carbon.utils.ServerConstants;
 import org.wso2.carbon.utils.UnsupportedSecretTypeException;
 import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 
@@ -16170,5 +16172,20 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
         String errorCode = ErrorMessages.ERROR_CODE_NON_EXISTING_USER.getCode();
         handleGetUserClaimValuesFailure(errorCode, errorMessage, userName, null, profileName);
         throw new UserStoreException(errorCode + " - " + errorMessage);
+    }
+
+    /**
+     * The password validity timeout value is set by server configuration value from carbon.xml file.
+     * If value is not present the default value of 24 hours is returned.
+     * @return password validity timeout in hours.
+     */
+    protected int getDefaultPasswordValidityPeriodInHours() throws UserStoreException {
+
+        String pwValidityTimeoutStr = ServerConfiguration.getInstance()
+                .getFirstProperty(ServerConstants.DEFAULT_PASSWORD_VALIDITY_PERIOD);
+        if (!StringUtils.isBlank(pwValidityTimeoutStr)){
+            return Integer.parseInt(pwValidityTimeoutStr);
+        }
+        return 24;
     }
 }

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
@@ -140,6 +140,7 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
     private static final String MULTI_ATTRIBUTE_SEPARATOR = "MultiAttributeSeparator";
     private static final String LOCATION_CLAIM_URI = "http://wso2.org/claims/location";
     private static final int DEFAULT_PASSWORD_VALIDITY_PERIOD_VALUE = 24;
+    protected static int pwValidityTimeoutInt = getDefaultPasswordValidityPeriodInHours();
     private static Log log = LogFactory.getLog(AbstractUserStoreManager.class);
     protected int tenantId;
     protected DataSource dataSource = null;
@@ -16177,16 +16178,18 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
 
     /**
      * The password validity timeout value is set by server configuration value from carbon.xml file.
-     * If value is not present the default value of 24 hours is returned.
+     * If value is not present the default value of DEFAULT_PASSWORD_VALIDITY_PERIOD_VALUE is returned.
      * @return password validity timeout in hours.
      */
-    protected int getDefaultPasswordValidityPeriodInHours() throws UserStoreException {
+    private static int getDefaultPasswordValidityPeriodInHours() {
 
         String pwValidityTimeoutStr = ServerConfiguration.getInstance()
                 .getFirstProperty(ServerConstants.DEFAULT_PASSWORD_VALIDITY_PERIOD);
-        if (!StringUtils.isBlank(pwValidityTimeoutStr)){
+        if (!StringUtils.isBlank(pwValidityTimeoutStr)) {
             return Integer.parseInt(pwValidityTimeoutStr);
         }
-        return DEFAULT_PASSWORD_VALIDITY_PERIOD_VALUE;
+        else {
+            return DEFAULT_PASSWORD_VALIDITY_PERIOD_VALUE;
+        }
     }
 }

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
@@ -139,6 +139,7 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
     private static final String PROPERTY_PASSWORD_ERROR_MSG = "PasswordJavaRegExViolationErrorMsg";
     private static final String MULTI_ATTRIBUTE_SEPARATOR = "MultiAttributeSeparator";
     private static final String LOCATION_CLAIM_URI = "http://wso2.org/claims/location";
+    private static final int DEFAULT_PASSWORD_VALIDITY_PERIOD_VALUE = 24;
     private static Log log = LogFactory.getLog(AbstractUserStoreManager.class);
     protected int tenantId;
     protected DataSource dataSource = null;
@@ -16186,6 +16187,6 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
         if (!StringUtils.isBlank(pwValidityTimeoutStr)){
             return Integer.parseInt(pwValidityTimeoutStr);
         }
-        return 24;
+        return DEFAULT_PASSWORD_VALIDITY_PERIOD_VALUE;
     }
 }

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/JDBCUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/JDBCUserStoreManager.java
@@ -1370,7 +1370,7 @@ public class JDBCUserStoreManager extends AbstractUserStoreManager {
                 Timestamp changedTime = rs.getTimestamp(6);
 
                 GregorianCalendar gc = new GregorianCalendar();
-                gc.add(GregorianCalendar.HOUR, -1 * getDefaultPasswordValidityPeriodInHours());
+                gc.add(GregorianCalendar.HOUR, - AbstractUserStoreManager.pwValidityTimeoutInt);
                 Date date = gc.getTime();
 
                 if (requireChange == true && changedTime.before(date)) {
@@ -2538,7 +2538,7 @@ public class JDBCUserStoreManager extends AbstractUserStoreManager {
                 if (requireChange) {
                     GregorianCalendar gc = new GregorianCalendar();
                     gc.setTime(changedTime);
-                    gc.add(GregorianCalendar.HOUR, getDefaultPasswordValidityPeriodInHours());
+                    gc.add(GregorianCalendar.HOUR, AbstractUserStoreManager.pwValidityTimeoutInt);
                     date = gc.getTime();
                 }
             }

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/JDBCUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/JDBCUserStoreManager.java
@@ -1370,7 +1370,7 @@ public class JDBCUserStoreManager extends AbstractUserStoreManager {
                 Timestamp changedTime = rs.getTimestamp(6);
 
                 GregorianCalendar gc = new GregorianCalendar();
-                gc.add(GregorianCalendar.HOUR, -24);
+                gc.add(GregorianCalendar.HOUR, -1 * getDefaultPasswordValidityPeriodInHours());
                 Date date = gc.getTime();
 
                 if (requireChange == true && changedTime.before(date)) {
@@ -2538,7 +2538,7 @@ public class JDBCUserStoreManager extends AbstractUserStoreManager {
                 if (requireChange) {
                     GregorianCalendar gc = new GregorianCalendar();
                     gc.setTime(changedTime);
-                    gc.add(GregorianCalendar.HOUR, 24);
+                    gc.add(GregorianCalendar.HOUR, getDefaultPasswordValidityPeriodInHours());
                     date = gc.getTime();
                 }
             }

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCUserStoreManager.java
@@ -708,7 +708,7 @@ public class UniqueIDJDBCUserStoreManager extends JDBCUserStoreManager {
                 Timestamp changedTime = rs.getTimestamp(6);
 
                 GregorianCalendar gc = new GregorianCalendar();
-                gc.add(GregorianCalendar.HOUR, -24);
+                gc.add(GregorianCalendar.HOUR, -1 * getDefaultPasswordValidityPeriodInHours());
                 Date date = gc.getTime();
 
                 if (requireChange && changedTime.before(date)) {
@@ -853,7 +853,7 @@ public class UniqueIDJDBCUserStoreManager extends JDBCUserStoreManager {
                 Timestamp changedTime = rs.getTimestamp(6);
 
                 GregorianCalendar gc = new GregorianCalendar();
-                gc.add(GregorianCalendar.HOUR, -24);
+                gc.add(GregorianCalendar.HOUR, -1 * getDefaultPasswordValidityPeriodInHours());
                 Date date = gc.getTime();
 
                 if (requireChange && changedTime.before(date)) {
@@ -941,7 +941,7 @@ public class UniqueIDJDBCUserStoreManager extends JDBCUserStoreManager {
                 Timestamp changedTime = rs.getTimestamp(6);
 
                 GregorianCalendar gc = new GregorianCalendar();
-                gc.add(GregorianCalendar.HOUR, -24);
+                gc.add(GregorianCalendar.HOUR, -1 * getDefaultPasswordValidityPeriodInHours());
                 Date date = gc.getTime();
 
                 if (requireChange && changedTime.before(date)) {
@@ -1047,7 +1047,7 @@ public class UniqueIDJDBCUserStoreManager extends JDBCUserStoreManager {
                 Timestamp changedTime = rs.getTimestamp(6);
 
                 GregorianCalendar gc = new GregorianCalendar();
-                gc.add(GregorianCalendar.HOUR, -24);
+                gc.add(GregorianCalendar.HOUR, -1 * getDefaultPasswordValidityPeriodInHours());
                 Date date = gc.getTime();
 
                 if (requireChange && changedTime.before(date)) {
@@ -2090,7 +2090,7 @@ public class UniqueIDJDBCUserStoreManager extends JDBCUserStoreManager {
                 if (requireChange) {
                     GregorianCalendar gc = new GregorianCalendar();
                     gc.setTime(changedTime);
-                    gc.add(GregorianCalendar.HOUR, 24);
+                    gc.add(GregorianCalendar.HOUR, getDefaultPasswordValidityPeriodInHours());
                     date = gc.getTime();
                 }
             }

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCUserStoreManager.java
@@ -33,14 +33,7 @@ import org.wso2.carbon.user.core.UserStoreClientException;
 import org.wso2.carbon.user.core.UserStoreException;
 import org.wso2.carbon.user.core.UserStoreManager;
 import org.wso2.carbon.user.core.claim.ClaimManager;
-import org.wso2.carbon.user.core.common.AuthenticationResult;
-import org.wso2.carbon.user.core.common.FailureReason;
-import org.wso2.carbon.user.core.common.LoginIdentifier;
-import org.wso2.carbon.user.core.common.PaginatedSearchResult;
-import org.wso2.carbon.user.core.common.RoleBreakdown;
-import org.wso2.carbon.user.core.common.RoleContext;
-import org.wso2.carbon.user.core.common.UniqueIDPaginatedSearchResult;
-import org.wso2.carbon.user.core.common.User;
+import org.wso2.carbon.user.core.common.*;
 import org.wso2.carbon.user.core.jdbc.caseinsensitive.JDBCCaseInsensitiveConstants;
 import org.wso2.carbon.user.core.model.Condition;
 import org.wso2.carbon.user.core.model.ExpressionAttribute;
@@ -708,7 +701,7 @@ public class UniqueIDJDBCUserStoreManager extends JDBCUserStoreManager {
                 Timestamp changedTime = rs.getTimestamp(6);
 
                 GregorianCalendar gc = new GregorianCalendar();
-                gc.add(GregorianCalendar.HOUR, -1 * getDefaultPasswordValidityPeriodInHours());
+                gc.add(GregorianCalendar.HOUR, - AbstractUserStoreManager.pwValidityTimeoutInt);
                 Date date = gc.getTime();
 
                 if (requireChange && changedTime.before(date)) {
@@ -853,7 +846,7 @@ public class UniqueIDJDBCUserStoreManager extends JDBCUserStoreManager {
                 Timestamp changedTime = rs.getTimestamp(6);
 
                 GregorianCalendar gc = new GregorianCalendar();
-                gc.add(GregorianCalendar.HOUR, -1 * getDefaultPasswordValidityPeriodInHours());
+                gc.add(GregorianCalendar.HOUR, - AbstractUserStoreManager.pwValidityTimeoutInt);
                 Date date = gc.getTime();
 
                 if (requireChange && changedTime.before(date)) {
@@ -941,7 +934,7 @@ public class UniqueIDJDBCUserStoreManager extends JDBCUserStoreManager {
                 Timestamp changedTime = rs.getTimestamp(6);
 
                 GregorianCalendar gc = new GregorianCalendar();
-                gc.add(GregorianCalendar.HOUR, -1 * getDefaultPasswordValidityPeriodInHours());
+                gc.add(GregorianCalendar.HOUR, - AbstractUserStoreManager.pwValidityTimeoutInt);
                 Date date = gc.getTime();
 
                 if (requireChange && changedTime.before(date)) {
@@ -1047,7 +1040,7 @@ public class UniqueIDJDBCUserStoreManager extends JDBCUserStoreManager {
                 Timestamp changedTime = rs.getTimestamp(6);
 
                 GregorianCalendar gc = new GregorianCalendar();
-                gc.add(GregorianCalendar.HOUR, -1 * getDefaultPasswordValidityPeriodInHours());
+                gc.add(GregorianCalendar.HOUR, - AbstractUserStoreManager.pwValidityTimeoutInt);
                 Date date = gc.getTime();
 
                 if (requireChange && changedTime.before(date)) {
@@ -2090,7 +2083,7 @@ public class UniqueIDJDBCUserStoreManager extends JDBCUserStoreManager {
                 if (requireChange) {
                     GregorianCalendar gc = new GregorianCalendar();
                     gc.setTime(changedTime);
-                    gc.add(GregorianCalendar.HOUR, getDefaultPasswordValidityPeriodInHours());
+                    gc.add(GregorianCalendar.HOUR, AbstractUserStoreManager.pwValidityTimeoutInt);
                     date = gc.getTime();
                 }
             }

--- a/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/ServerConstants.java
+++ b/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/ServerConstants.java
@@ -145,7 +145,6 @@ public final class ServerConstants {
     public static final String STS_NAME = "wso2carbon-sts";
     public static final String DEFAULT_PASSWORD_VALIDITY_PERIOD = "DefaultPasswordValidityPeriod";
 
-
     public static class Axis2ParameterNames {
         public static final String CONTEXT_ROOT = "contextRoot";
         public static final String SERVICE_PATH = "servicePath";

--- a/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/ServerConstants.java
+++ b/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/ServerConstants.java
@@ -143,6 +143,7 @@ public final class ServerConstants {
     public static final String GENERATED_PAGES = "local_wso2wsas.generated.pages";
     public static final String CONFIGURATION_CONTEXT = "CONFIGURATION_CONTEXT";
     public static final String STS_NAME = "wso2carbon-sts";
+    public static final String DEFAULT_PASSWORD_VALIDITY_PERIOD = "DefaultPasswordValidityPeriod";
 
 
     public static class Axis2ParameterNames {

--- a/distribution/kernel/carbon-home/repository/resources/conf/templates/repository/conf/carbon.xml.j2
+++ b/distribution/kernel/carbon-home/repository/resources/conf/templates/repository/conf/carbon.xml.j2
@@ -851,4 +851,7 @@
      </CorrelationLogs>
      {% endif %}
 
+    <!-- Configure password validity period for initially set password -->
+    <DefaultPasswordValidityPeriod>{{password.default_validity_period}}</DefaultPasswordValidityPeriod>
+
 </Server>


### PR DESCRIPTION
## Purpose
> Adds configuration through `deployment.toml` file to change the default password validity period for a newly created user. The default validity period is set as 24 hours incase no configuration is available in `deployment.toml` file.

## Related Issue
> https://github.com/wso2/product-is/issues/15071
