### PR TITLE
[AM-4.2.0] Fix HTTPS-Sender I/O dispatcher' Entries Issue in Correlation Logs

### DIFF
--- a/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/multitenancy/transports/TenantTransportSender.java
+++ b/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/multitenancy/transports/TenantTransportSender.java
@@ -197,7 +197,8 @@ public class TenantTransportSender extends AbstractHandler implements TransportS
         superTenantOutMessageContext.setProperty(MultitenantConstants.COPY_CONTENT_LENGTH_FROM_INCOMING,
                 contentLengthCopy);
 
-
+        superTenantOutMessageContext.setProperty(MultitenantConstants.CORRELATION_ID,
+                msgContext.getProperty(MultitenantConstants.CORRELATION_ID));
 
         superTenantOutMessageContext.setProperty(Constants.Configuration.MESSAGE_TYPE,
                 msgContext.getProperty(Constants.Configuration.MESSAGE_TYPE));

--- a/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/multitenancy/MultitenantConstants.java
+++ b/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/multitenancy/MultitenantConstants.java
@@ -102,4 +102,5 @@ public class MultitenantConstants {
     public static final String NO_KEEPALIVE = "NO_KEEPALIVE";
 
     public static final String SYNAPSE_JSON_INPUT_STREAM = "org.apache.synapse.commons.json.JsonInputStream";
+    public static final String CORRELATION_ID = "correlation_id";
 }


### PR DESCRIPTION
### Purpose
To generate correlation_logs for HTTPS-Sender I/O dispatcher on non-super-tenant flow.

### Goal
Fixes https://github.com/wso2/api-manager/issues/1155

### Approach
Even though msgContext contains correlation_id, superTenantOutMessageContext does not. This data will go through multiple repositories and finally correation_id availability is checked in the Synapse before printing related correlation logs.

Hence, it fails to print the logs. In this fix, correlation_id was added to superTenantOutMessageContext at the Kernel level to avoid the unavailability.