### PR TITLE
Add configuration to add custom password expiry time for new users

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
@@ -24,6 +24,7 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.CarbonConstants;
+import org.wso2.carbon.base.ServerConfiguration;
 import org.wso2.carbon.context.CarbonContext;
 import org.wso2.carbon.user.api.RealmConfiguration;
 import org.wso2.carbon.user.core.NotImplementedException;
@@ -77,6 +78,7 @@ import org.wso2.carbon.user.core.service.RealmService;
 import org.wso2.carbon.user.core.system.SystemUserRoleManager;
 import org.wso2.carbon.user.core.util.UserCoreUtil;
 import org.wso2.carbon.utils.Secret;
+import org.wso2.carbon.utils.ServerConstants;
 import org.wso2.carbon.utils.UnsupportedSecretTypeException;
 import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 
@@ -17927,5 +17929,20 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
     public void removeGroupRoleMappingByGroupName(String groupName) throws UserStoreException {
 
         hybridRoleManager.removeGroupRoleMappingByGroupName(groupName);
+    }
+
+    /**
+     * The password validity timeout value is set by server configuration value from carbon.xml file.
+     * If value is not present the default value of 24 hours is returned.
+     * @return password validity timeout in hours.
+     */
+    protected int getDefaultPasswordValidityPeriodInHours() throws UserStoreException {
+
+        String pwValidityTimeoutStr = ServerConfiguration.getInstance()
+                .getFirstProperty(ServerConstants.DEFAULT_PASSWORD_VALIDITY_PERIOD);
+        if (!StringUtils.isBlank(pwValidityTimeoutStr)){
+            return Integer.parseInt(pwValidityTimeoutStr);
+        }
+        return 24;
     }
 }

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/JDBCUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/JDBCUserStoreManager.java
@@ -1464,7 +1464,7 @@ public class JDBCUserStoreManager extends AbstractUserStoreManager {
                 Timestamp changedTime = rs.getTimestamp(6);
 
                 GregorianCalendar gc = new GregorianCalendar();
-                gc.add(GregorianCalendar.HOUR, -24);
+                gc.add(GregorianCalendar.HOUR, -1 * getDefaultPasswordValidityPeriodInHours());
                 Date date = gc.getTime();
 
                 if (requireChange == true && changedTime.before(date)) {
@@ -2631,7 +2631,7 @@ public class JDBCUserStoreManager extends AbstractUserStoreManager {
                 if (requireChange) {
                     GregorianCalendar gc = new GregorianCalendar();
                     gc.setTime(changedTime);
-                    gc.add(GregorianCalendar.HOUR, 24);
+                    gc.add(GregorianCalendar.HOUR, getDefaultPasswordValidityPeriodInHours());
                     date = gc.getTime();
                 }
             }

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCUserStoreManager.java
@@ -710,7 +710,7 @@ public class UniqueIDJDBCUserStoreManager extends JDBCUserStoreManager {
                 Timestamp changedTime = rs.getTimestamp(6);
 
                 GregorianCalendar gc = new GregorianCalendar();
-                gc.add(GregorianCalendar.HOUR, -24);
+                gc.add(GregorianCalendar.HOUR, -1 * getDefaultPasswordValidityPeriodInHours());
                 Date date = gc.getTime();
 
                 if (requireChange && changedTime.before(date)) {
@@ -855,7 +855,7 @@ public class UniqueIDJDBCUserStoreManager extends JDBCUserStoreManager {
                 Timestamp changedTime = rs.getTimestamp(6);
 
                 GregorianCalendar gc = new GregorianCalendar();
-                gc.add(GregorianCalendar.HOUR, -24);
+                gc.add(GregorianCalendar.HOUR, -1 * getDefaultPasswordValidityPeriodInHours());
                 Date date = gc.getTime();
 
                 if (requireChange && changedTime.before(date)) {
@@ -943,7 +943,7 @@ public class UniqueIDJDBCUserStoreManager extends JDBCUserStoreManager {
                 Timestamp changedTime = rs.getTimestamp(6);
 
                 GregorianCalendar gc = new GregorianCalendar();
-                gc.add(GregorianCalendar.HOUR, -24);
+                gc.add(GregorianCalendar.HOUR, -1 * getDefaultPasswordValidityPeriodInHours());
                 Date date = gc.getTime();
 
                 if (requireChange && changedTime.before(date)) {
@@ -1049,7 +1049,7 @@ public class UniqueIDJDBCUserStoreManager extends JDBCUserStoreManager {
                 Timestamp changedTime = rs.getTimestamp(6);
 
                 GregorianCalendar gc = new GregorianCalendar();
-                gc.add(GregorianCalendar.HOUR, -24);
+                gc.add(GregorianCalendar.HOUR, -1 * getDefaultPasswordValidityPeriodInHours());
                 Date date = gc.getTime();
 
                 if (requireChange && changedTime.before(date)) {
@@ -2092,7 +2092,7 @@ public class UniqueIDJDBCUserStoreManager extends JDBCUserStoreManager {
                 if (requireChange) {
                     GregorianCalendar gc = new GregorianCalendar();
                     gc.setTime(changedTime);
-                    gc.add(GregorianCalendar.HOUR, 24);
+                    gc.add(GregorianCalendar.HOUR, getDefaultPasswordValidityPeriodInHours());
                     date = gc.getTime();
                 }
             }

--- a/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/ServerConstants.java
+++ b/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/ServerConstants.java
@@ -153,6 +153,7 @@ public final class ServerConstants {
     public static final String GENERATED_PAGES = "local_wso2wsas.generated.pages";
     public static final String CONFIGURATION_CONTEXT = "CONFIGURATION_CONTEXT";
     public static final String STS_NAME = "wso2carbon-sts";
+    public static final String DEFAULT_PASSWORD_VALIDITY_PERIOD = "DefaultPasswordValidityPeriod";
 
 
     public static class Axis2ParameterNames {

--- a/distribution/kernel/carbon-home/repository/resources/conf/default.json
+++ b/distribution/kernel/carbon-home/repository/resources/conf/default.json
@@ -219,6 +219,7 @@
   "versioning_configuration.enable_versioning_ratings": false,
   "versioning_configuration.enable_version_resources_on_change" : false,
   "sts.callback_handler" : "org.wso2.carbon.identity.sts.common.identity.provider.AttributeCallbackHandler",
-  "tenant_mgt.enable_tenant_theme_mgt" : true
+  "tenant_mgt.enable_tenant_theme_mgt" : true,
+  "password.default_validity_period":"24"
 
 }

--- a/distribution/kernel/carbon-home/repository/resources/conf/templates/repository/conf/carbon.xml.j2
+++ b/distribution/kernel/carbon-home/repository/resources/conf/templates/repository/conf/carbon.xml.j2
@@ -779,6 +779,9 @@
         <disableRestart>{{server.disable_restart_from_ui | default('false')}}</disableRestart>
      </disableShutdownRestartFromUI>
 
+     <!-- Configure password validity period for initially set password -->
+     <DefaultPasswordValidityPeriod>{{password.default_validity_period}}</DefaultPasswordValidityPeriod>
+
      {% if correlation_logs is defined %}
      <CorrelationLogs>
          <enable>{{correlation_logs.enable}}</enable>


### PR DESCRIPTION
### Purpose
To allow Configurable Password Expiry time when importing bulk users.

### Goal
Fixes: https://github.com/wso2/api-manager/issues/1154

Related PR: https://github.com/wso2-support/carbon-kernel/pull/2007