### PR TITLE
NPE handling fixed in getHybridRoleListOfUser

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/hybrid/HybridRoleManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/hybrid/HybridRoleManager.java
@@ -540,7 +540,7 @@ public class HybridRoleManager {
             if (domain != null) {
                 domain = domain.toUpperCase();
             }
-            if (filter.equals("*") || StringUtils.isEmpty(filter)) {
+            if (StringUtils.isEmpty(filter) || filter.equals("*")) {
                 sqlStmt = getHybridRoleListSqlStatement(
                         realmConfig.getRealmProperty(HybridJDBCConstants.GET_ROLE_LIST_OF_USER),
                         HybridJDBCConstants.GET_ROLE_LIST_OF_USER_SQL,


### PR DESCRIPTION
## Fixed the NPE handling

Resolves <https://github.com/wso2/product-is/issues/15311>

The filter and username attribute will be passed to the `getHybridROleListOfUser` method by the `doGetInternalRoleListOfUser` method in `org.wso2.carbon.user.core.common.AbstractUserStoreManager.doGetInternalRoleListOfUser`. In case this filter is null the current conditional check will throw an NPE from `filter. equals("*")`

This should have to fix as an improvement.
