### PR TITLE
Fix caching issue when resolving userid when multiple userstore presents

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
@@ -7518,11 +7518,6 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
 
         // Get the domain if it is already resolved in our cache or in local database.
         String domainName = groupUniqueIDDomainResolver.getDomainForGroupId(groupId, tenantId);
-        if (StringUtils.isNotBlank(domainName) && !UserCoreConstants.PRIMARY_DEFAULT_DOMAIN_NAME.equals(domainName) &&
-                !domainName.equals(getMyDomainName()) && !userStoreManagerHolder.containsKey(domainName)) {
-            domainName = null;
-            clearGroupIDResolverCache(groupId);
-        }
         if (domainName == null) {
             if (log.isDebugEnabled()) {
                 log.debug("Iterating though scim2 tables tenant: " + tenantId);
@@ -7629,11 +7624,6 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
         // First we have to check whether this user store is already resolved and we have it either in the cache or
         // in our local database. If so we can use that.
         String domainName = userUniqueIDDomainResolver.getDomainForUserId(userId, tenantId);
-        if (StringUtils.isNotBlank(domainName) && !UserCoreConstants.PRIMARY_DEFAULT_DOMAIN_NAME.equals(domainName) &&
-                !domainName.equals(getMyDomainName()) && !userStoreManagerHolder.containsKey(domainName)) {
-            domainName = null;
-            clearUserIDResolverCache(userId);
-        }
 
         // If we don't have the domain name in our side, then we have to iterate through each user store and find
         // where is this user id from and mark it as the user store domain.
@@ -17944,19 +17934,5 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
     public void removeGroupRoleMappingByGroupName(String groupName) throws UserStoreException {
 
         hybridRoleManager.removeGroupRoleMappingByGroupName(groupName);
-    }
-
-    private void clearUserIDResolverCache(String userId) {
-
-        UserIdResolverCache.getInstance().clearCacheEntry(userId, RESOLVE_USER_NAME_FROM_USER_ID_CACHE_NAME, tenantId);
-        UserIdResolverCache.getInstance()
-                .clearCacheEntry(userId, RESOLVE_USER_NAME_FROM_UNIQUE_USER_ID_CACHE_NAME, SUPER_TENANT_ID);
-    }
-
-    private void clearGroupIDResolverCache(String groupId) {
-
-        GroupIdResolverCache.getInstance()
-                .clearCacheEntry(groupId, RESOLVE_GROUP_NAME_FROM_USER_ID_CACHE_NAME, tenantId);
-
     }
 }

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
@@ -7518,6 +7518,11 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
 
         // Get the domain if it is already resolved in our cache or in local database.
         String domainName = groupUniqueIDDomainResolver.getDomainForGroupId(groupId, tenantId);
+        if (StringUtils.isNotBlank(domainName) && !UserCoreConstants.PRIMARY_DEFAULT_DOMAIN_NAME.equals(domainName) &&
+                !domainName.equals(getMyDomainName()) && !userStoreManagerHolder.containsKey(domainName)) {
+            domainName = null;
+            clearGroupIDResolverCache(groupId);
+        }
         if (domainName == null) {
             if (log.isDebugEnabled()) {
                 log.debug("Iterating though scim2 tables tenant: " + tenantId);
@@ -7624,6 +7629,11 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
         // First we have to check whether this user store is already resolved and we have it either in the cache or
         // in our local database. If so we can use that.
         String domainName = userUniqueIDDomainResolver.getDomainForUserId(userId, tenantId);
+        if (StringUtils.isNotBlank(domainName) && !UserCoreConstants.PRIMARY_DEFAULT_DOMAIN_NAME.equals(domainName) &&
+                !domainName.equals(getMyDomainName()) && !userStoreManagerHolder.containsKey(domainName)) {
+            domainName = null;
+            clearUserIDResolverCache(userId);
+        }
 
         // If we don't have the domain name in our side, then we have to iterate through each user store and find
         // where is this user id from and mark it as the user store domain.
@@ -17934,5 +17944,19 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
     public void removeGroupRoleMappingByGroupName(String groupName) throws UserStoreException {
 
         hybridRoleManager.removeGroupRoleMappingByGroupName(groupName);
+    }
+
+    private void clearUserIDResolverCache(String userId) {
+
+        UserIdResolverCache.getInstance().clearCacheEntry(userId, RESOLVE_USER_NAME_FROM_USER_ID_CACHE_NAME, tenantId);
+        UserIdResolverCache.getInstance()
+                .clearCacheEntry(userId, RESOLVE_USER_NAME_FROM_UNIQUE_USER_ID_CACHE_NAME, SUPER_TENANT_ID);
+    }
+
+    private void clearGroupIDResolverCache(String groupId) {
+
+        GroupIdResolverCache.getInstance()
+                .clearCacheEntry(groupId, RESOLVE_GROUP_NAME_FROM_USER_ID_CACHE_NAME, tenantId);
+
     }
 }

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/GroupUniqueIDDomainResolver.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/GroupUniqueIDDomainResolver.java
@@ -18,7 +18,6 @@
 
 package org.wso2.carbon.user.core.common;
 
-import org.apache.commons.collections.MapUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
@@ -110,7 +109,7 @@ public class GroupUniqueIDDomainResolver {
                 // Read the domain name from the Database;
                 domainName = getDomainFromDB(groupId, tenantId);
                 // Update the cache.
-                if (domainName != null) {
+                if (org.apache.commons.lang.StringUtils.isNotBlank(domainName)) {
                     uniqueIdDomainCache.put(groupId, domainName);
                     if (log.isDebugEnabled()) {
                         log.debug("Domain with name: " + domainName + " retrieved from the database.");
@@ -304,7 +303,6 @@ public class GroupUniqueIDDomainResolver {
 
     private void deleteDomainFromDB(String userDomain, String groupId, int tenantId) throws UserStoreException {
 
-        String domainName = null;
         try (Connection dbConnection = getDBConnection();
              PreparedStatement preparedStatement = dbConnection.prepareStatement(DELETE_DOMAIN)) {
             preparedStatement.setString(1, userDomain);
@@ -314,7 +312,7 @@ public class GroupUniqueIDDomainResolver {
             preparedStatement.execute();
             commitTransaction(dbConnection);
         } catch (SQLException ex) {
-            throw new UserStoreException("Error occurred while deleting the domain name for user id from database.", ex);
+            throw new UserStoreException("Error occurred while deleting the domain name for group id from database.", ex);
         }
     }
 }

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/GroupUniqueIDDomainResolver.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/GroupUniqueIDDomainResolver.java
@@ -18,10 +18,15 @@
 
 package org.wso2.carbon.user.core.common;
 
+import org.apache.commons.collections.MapUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
+import org.wso2.carbon.user.api.UserStoreManager;
+import org.wso2.carbon.user.core.UserCoreConstants;
 import org.wso2.carbon.user.core.UserStoreException;
+import org.wso2.carbon.user.core.service.RealmService;
+import org.wso2.carbon.user.core.util.UserCoreUtil;
 import org.wso2.carbon.utils.xml.StringUtils;
 
 import java.sql.Connection;
@@ -32,6 +37,8 @@ import javax.cache.Cache;
 import javax.cache.CacheManager;
 import javax.cache.Caching;
 import javax.sql.DataSource;
+
+import static org.wso2.carbon.user.core.UserStoreConfigConstants.RESOLVE_GROUP_NAME_FROM_USER_ID_CACHE_NAME;
 
 /**
  * Purpose of this class is to keep a mapping between group unique id and the domain of that group to reduce the
@@ -60,6 +67,9 @@ public class GroupUniqueIDDomainResolver {
             "UM_TENANT_ID = ?), ?)";
     private static final String GET_DOMAIN = "SELECT UM_DOMAIN_NAME FROM UM_DOMAIN WHERE UM_DOMAIN_ID=(SELECT " +
             "UM_DOMAIN_ID FROM UM_GROUP_UUID_DOMAIN_MAPPER WHERE UM_GROUP_ID = ? AND UM_TENANT_ID = ?)";
+    private static final String DELETE_DOMAIN =
+            "DELETE FROM UM_GROUP_UUID_DOMAIN_MAPPER " +
+                    "WHERE UM_DOMAIN_ID = (SELECT UM_DOMAIN_ID FROM UM_DOMAIN WHERE UM_DOMAIN_NAME = ? AND UM_TENANT_ID = ?) AND UM_GROUP_ID = ? AND UM_TENANT_ID = ?";
 
     public GroupUniqueIDDomainResolver(DataSource dataSource) {
 
@@ -91,26 +101,37 @@ public class GroupUniqueIDDomainResolver {
 
             // Read the cache first.
             String domainName = uniqueIdDomainCache.get(groupId);
-            if (domainName != null) {
+
+            if (org.apache.commons.lang.StringUtils.isBlank(domainName)) {
+                // Domain name is not in the cache.
                 if (log.isDebugEnabled()) {
-                    log.debug("Cache hit for group id: " + groupId);
+                    log.debug("Cache miss for group id: " + groupId + " searching from the database");
                 }
-                return domainName;
+                // Read the domain name from the Database;
+                domainName = getDomainFromDB(groupId, tenantId);
+                // Update the cache.
+                if (domainName != null) {
+                    uniqueIdDomainCache.put(groupId, domainName);
+                    if (log.isDebugEnabled()) {
+                        log.debug("Domain with name: " + domainName + " retrieved from the database.");
+                    }
+                }
             }
-            // Domain name is not in the cache.
-            if (log.isDebugEnabled()) {
-                log.debug("Cache miss for group id: " + groupId + " searching from the database");
-            }
-            // Read the domain name from the Database;
-            domainName = getDomainFromDB(groupId, tenantId);
-            // Update the cache.
-            if (domainName != null) {
-                uniqueIdDomainCache.put(groupId, domainName);
-                if (log.isDebugEnabled()) {
-                    log.debug("Domain with name: " + domainName + " retrieved from the database.");
+            if (org.apache.commons.lang.StringUtils.isNotBlank(domainName) &&
+                    !UserCoreConstants.PRIMARY_DEFAULT_DOMAIN_NAME.equals(domainName)) {
+                RealmService realmService = UserCoreUtil.getRealmService();
+                UserStoreManager userStoreManager =
+                        ((AbstractUserStoreManager) realmService.getTenantUserRealm(tenantId)
+                                .getUserStoreManager()).getSecondaryUserStoreManager(domainName);
+                if (userStoreManager == null) {
+                    deleteDomainFromDB(domainName, groupId, tenantId);
+                    clearGroupIDResolverCache(groupId, tenantId);
+                    domainName = null;
                 }
             }
             return domainName;
+        } catch (org.wso2.carbon.user.api.UserStoreException e) {
+            throw new UserStoreException("Tenant user realm  cannot be resolved for tenantId: " + tenantId, e);
         } finally {
             PrivilegedCarbonContext.endTenantFlow();
         }
@@ -271,6 +292,29 @@ public class GroupUniqueIDDomainResolver {
             }
         } catch (SQLException e) {
             log.error("An error occurred while transaction rollback", e);
+        }
+    }
+
+    private void clearGroupIDResolverCache(String groupId, int tenantId) {
+
+        GroupIdResolverCache.getInstance()
+                .clearCacheEntry(groupId, RESOLVE_GROUP_NAME_FROM_USER_ID_CACHE_NAME, tenantId);
+
+    }
+
+    private void deleteDomainFromDB(String userDomain, String groupId, int tenantId) throws UserStoreException {
+
+        String domainName = null;
+        try (Connection dbConnection = getDBConnection();
+             PreparedStatement preparedStatement = dbConnection.prepareStatement(DELETE_DOMAIN)) {
+            preparedStatement.setString(1, userDomain);
+            preparedStatement.setInt(2, tenantId);
+            preparedStatement.setString(3, groupId);
+            preparedStatement.setInt(4, tenantId);
+            preparedStatement.execute();
+            commitTransaction(dbConnection);
+        } catch (SQLException ex) {
+            throw new UserStoreException("Error occurred while deleting the domain name for user id from database.", ex);
         }
     }
 }


### PR DESCRIPTION
## Purpose
> cache issue when resolving userId when multiple userstore presents. This PR will check for existence of the resolve userstore domain in the userstore chain to see if the resolve userstore domain is an existing one or not