### PR TITLE
Add configuration to add custom password validity period for new users

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
@@ -24,6 +24,7 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.CarbonConstants;
+import org.wso2.carbon.base.ServerConfiguration;
 import org.wso2.carbon.context.CarbonContext;
 import org.wso2.carbon.user.api.RealmConfiguration;
 import org.wso2.carbon.user.core.NotImplementedException;
@@ -77,6 +78,7 @@ import org.wso2.carbon.user.core.service.RealmService;
 import org.wso2.carbon.user.core.system.SystemUserRoleManager;
 import org.wso2.carbon.user.core.util.UserCoreUtil;
 import org.wso2.carbon.utils.Secret;
+import org.wso2.carbon.utils.ServerConstants;
 import org.wso2.carbon.utils.UnsupportedSecretTypeException;
 import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 
@@ -169,6 +171,8 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
     private static final String MULTI_ATTRIBUTE_SEPARATOR = "MultiAttributeSeparator";
     private static final String LOCATION_CLAIM_URI = "http://wso2.org/claims/location";
     private static Log log = LogFactory.getLog(AbstractUserStoreManager.class);
+    private static final int DEFAULT_PASSWORD_VALIDITY_PERIOD_VALUE = 24;
+    protected static int pwValidityTimeoutInt = getDefaultPasswordValidityPeriodInHours();
     protected int tenantId;
     protected DataSource dataSource = null;
     protected RealmConfiguration realmConfig = null;
@@ -17934,5 +17938,20 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
     public void removeGroupRoleMappingByGroupName(String groupName) throws UserStoreException {
 
         hybridRoleManager.removeGroupRoleMappingByGroupName(groupName);
+    }
+
+    /**
+     * The password validity timeout value is set by server configuration value from carbon.xml file.
+     * If value is not present the default value of DEFAULT_PASSWORD_VALIDITY_PERIOD_VALUE is returned.
+     * @return password validity timeout in hours.
+     */
+    private static int getDefaultPasswordValidityPeriodInHours() {
+
+        String pwValidityTimeoutStr = ServerConfiguration.getInstance()
+                .getFirstProperty(ServerConstants.DEFAULT_PASSWORD_VALIDITY_PERIOD);
+        if (!StringUtils.isBlank(pwValidityTimeoutStr)) {
+            return Integer.parseInt(pwValidityTimeoutStr);
+        }
+        return DEFAULT_PASSWORD_VALIDITY_PERIOD_VALUE;
     }
 }

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/JDBCUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/JDBCUserStoreManager.java
@@ -41,7 +41,6 @@ import org.wso2.carbon.user.core.common.RoleContext;
 import org.wso2.carbon.user.core.constants.UserCoreErrorConstants;
 import org.wso2.carbon.user.core.dto.RoleDTO;
 import org.wso2.carbon.user.core.exceptions.HashProviderException;
-import org.wso2.carbon.user.core.hash.HashProvider;
 import org.wso2.carbon.user.core.hash.HashProviderFactory;
 import org.wso2.carbon.user.core.hybrid.HybridJDBCConstants;
 import org.wso2.carbon.user.core.internal.UserStoreMgtDataHolder;
@@ -1451,7 +1450,7 @@ public class JDBCUserStoreManager extends AbstractUserStoreManager {
                 Timestamp changedTime = rs.getTimestamp(6);
 
                 GregorianCalendar gc = new GregorianCalendar();
-                gc.add(GregorianCalendar.HOUR, -24);
+                gc.add(GregorianCalendar.HOUR, - AbstractUserStoreManager.pwValidityTimeoutInt);
                 Date date = gc.getTime();
 
                 if (requireChange == true && changedTime.before(date)) {
@@ -2618,7 +2617,7 @@ public class JDBCUserStoreManager extends AbstractUserStoreManager {
                 if (requireChange) {
                     GregorianCalendar gc = new GregorianCalendar();
                     gc.setTime(changedTime);
-                    gc.add(GregorianCalendar.HOUR, 24);
+                    gc.add(GregorianCalendar.HOUR, AbstractUserStoreManager.pwValidityTimeoutInt);
                     date = gc.getTime();
                 }
             }

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCUserStoreManager.java
@@ -41,6 +41,7 @@ import org.wso2.carbon.user.core.common.RoleBreakdown;
 import org.wso2.carbon.user.core.common.RoleContext;
 import org.wso2.carbon.user.core.common.UniqueIDPaginatedSearchResult;
 import org.wso2.carbon.user.core.common.User;
+import org.wso2.carbon.user.core.common.AbstractUserStoreManager;
 import org.wso2.carbon.user.core.jdbc.caseinsensitive.JDBCCaseInsensitiveConstants;
 import org.wso2.carbon.user.core.model.Condition;
 import org.wso2.carbon.user.core.model.ExpressionAttribute;
@@ -710,7 +711,7 @@ public class UniqueIDJDBCUserStoreManager extends JDBCUserStoreManager {
                 Timestamp changedTime = rs.getTimestamp(6);
 
                 GregorianCalendar gc = new GregorianCalendar();
-                gc.add(GregorianCalendar.HOUR, -24);
+                gc.add(GregorianCalendar.HOUR, - AbstractUserStoreManager.pwValidityTimeoutInt);
                 Date date = gc.getTime();
 
                 if (requireChange && changedTime.before(date)) {
@@ -855,7 +856,7 @@ public class UniqueIDJDBCUserStoreManager extends JDBCUserStoreManager {
                 Timestamp changedTime = rs.getTimestamp(6);
 
                 GregorianCalendar gc = new GregorianCalendar();
-                gc.add(GregorianCalendar.HOUR, -24);
+                gc.add(GregorianCalendar.HOUR, - AbstractUserStoreManager.pwValidityTimeoutInt);
                 Date date = gc.getTime();
 
                 if (requireChange && changedTime.before(date)) {
@@ -943,7 +944,7 @@ public class UniqueIDJDBCUserStoreManager extends JDBCUserStoreManager {
                 Timestamp changedTime = rs.getTimestamp(6);
 
                 GregorianCalendar gc = new GregorianCalendar();
-                gc.add(GregorianCalendar.HOUR, -24);
+                gc.add(GregorianCalendar.HOUR, - AbstractUserStoreManager.pwValidityTimeoutInt);
                 Date date = gc.getTime();
 
                 if (requireChange && changedTime.before(date)) {
@@ -1049,7 +1050,7 @@ public class UniqueIDJDBCUserStoreManager extends JDBCUserStoreManager {
                 Timestamp changedTime = rs.getTimestamp(6);
 
                 GregorianCalendar gc = new GregorianCalendar();
-                gc.add(GregorianCalendar.HOUR, -24);
+                gc.add(GregorianCalendar.HOUR, - AbstractUserStoreManager.pwValidityTimeoutInt);
                 Date date = gc.getTime();
 
                 if (requireChange && changedTime.before(date)) {
@@ -2092,7 +2093,7 @@ public class UniqueIDJDBCUserStoreManager extends JDBCUserStoreManager {
                 if (requireChange) {
                     GregorianCalendar gc = new GregorianCalendar();
                     gc.setTime(changedTime);
-                    gc.add(GregorianCalendar.HOUR, 24);
+                    gc.add(GregorianCalendar.HOUR, AbstractUserStoreManager.pwValidityTimeoutInt);
                     date = gc.getTime();
                 }
             }

--- a/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/ServerConstants.java
+++ b/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/ServerConstants.java
@@ -153,6 +153,7 @@ public final class ServerConstants {
     public static final String GENERATED_PAGES = "local_wso2wsas.generated.pages";
     public static final String CONFIGURATION_CONTEXT = "CONFIGURATION_CONTEXT";
     public static final String STS_NAME = "wso2carbon-sts";
+    public static final String DEFAULT_PASSWORD_VALIDITY_PERIOD = "DefaultPasswordValidityPeriod";
 
 
     public static class Axis2ParameterNames {

--- a/distribution/kernel/carbon-home/repository/resources/conf/templates/repository/conf/carbon.xml.j2
+++ b/distribution/kernel/carbon-home/repository/resources/conf/templates/repository/conf/carbon.xml.j2
@@ -786,4 +786,7 @@
         <enableRestart>{{server.enable_restart_from_api}}</enableRestart>
      </enableShutdownRestartFromAPI>
 
+    <!-- Configure password validity period for initially set password -->
+    <DefaultPasswordValidityPeriod>{{password.default_validity_period}}</DefaultPasswordValidityPeriod>
+
 </Server>


### PR DESCRIPTION
## Purpose
> Adds configuration through `deployment.toml` file to change the default password validity period for a newly created user. The default validity period is set as 24 hours incase no configuration is available in `deployment.toml` file.

## Related Issue
> https://github.com/wso2/product-is/issues/15071