### PR TITLE
Make JCE provider configurable

### DIFF
--- a/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/util/CryptoUtil.java
+++ b/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/util/CryptoUtil.java
@@ -21,11 +21,13 @@ import org.apache.axiom.om.util.Base64;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.base.ServerConfiguration;
 import org.wso2.carbon.base.api.ServerConfigurationService;
 import org.wso2.carbon.core.internal.CarbonCoreDataHolder;
 import org.wso2.carbon.crypto.api.CipherMetaDataHolder;
 import org.wso2.carbon.crypto.api.CryptoService;
 import org.wso2.carbon.registry.core.service.RegistryService;
+import org.wso2.carbon.utils.ServerConstants;
 
 import java.nio.charset.Charset;
 import java.security.MessageDigest;
@@ -49,8 +51,6 @@ public class CryptoUtil {
                                                             'C', 'D', 'E', 'F'};
 
     private static final String DEFAULT_CRYPTO_ALGORITHM = "RSA";
-
-    private static final String CRYPTO_API_PROVIDER_BC = "BC";
 
     /**
      * This method returns CryptoUtil object, where this should only be used at runtime,
@@ -141,7 +141,7 @@ public class CryptoUtil {
                 }
             }
             encryptedKey = cryptoService
-                    .encrypt(plainTextBytes, algorithm, CRYPTO_API_PROVIDER_BC, returnSelfContainedCipherText);
+                    .encrypt(plainTextBytes, algorithm, getJCEProvider(), returnSelfContainedCipherText);
         } catch (Exception e) {
             throw new CryptoException("An error occurred while encrypting data.", e);
         }
@@ -202,7 +202,7 @@ public class CryptoUtil {
                     }
                 }
                 encryptedKey = cryptoService
-                        .encrypt(plainTextBytes, algorithm, CRYPTO_API_PROVIDER_BC, returnSelfContainedCipherText,
+                        .encrypt(plainTextBytes, algorithm, getJCEProvider(), returnSelfContainedCipherText,
                                 internalCryptoProviderType);
 
             }
@@ -308,7 +308,7 @@ public class CryptoUtil {
                     log.debug("Ciphertext is empty. An empty array will be used as the plaintext bytes.");
                 }
             } else {
-                decryptedValue = cryptoService.decrypt(cipherTextBytes, algorithm, CRYPTO_API_PROVIDER_BC);
+                decryptedValue = cryptoService.decrypt(cipherTextBytes, algorithm, getJCEProvider());
             }
 
             return decryptedValue;
@@ -358,7 +358,7 @@ public class CryptoUtil {
                     log.debug("Ciphertext is empty. An empty array will be used as the plaintext bytes.");
                 }
             }else {
-                decryptedValue = cryptoService.decrypt(cipherTextBytes, algorithm, CRYPTO_API_PROVIDER_BC);
+                decryptedValue = cryptoService.decrypt(cipherTextBytes, algorithm, getJCEProvider());
             }
 
             return decryptedValue;
@@ -409,7 +409,7 @@ public class CryptoUtil {
                     log.debug("Ciphertext is empty. An empty array will be used as the plaintext bytes.");
                 }
             } else {
-                decryptedValue = cryptoService.decrypt(cipherTextBytes, algorithm, CRYPTO_API_PROVIDER_BC,
+                decryptedValue = cryptoService.decrypt(cipherTextBytes, algorithm, getJCEProvider(),
                         internalCryptoProviderType);
             }
             return decryptedValue;
@@ -598,6 +598,15 @@ public class CryptoUtil {
         if (StringUtils.isBlank(internalCryptoProviderType)) {
             throw new CryptoException("Internal crypto provider can't be null.");
         }
+    }
+
+    public static String getJCEProvider() {
+
+        String provider = ServerConfiguration.getInstance().getFirstProperty(ServerConstants.JCE_PROVIDER);
+        if (!StringUtils.isBlank(provider)) {
+            return provider;
+        }
+        return ServerConstants.JCE_PROVIDER_BC;
     }
 }
 

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/config/UserStoreConfigXMLProcessor.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/config/UserStoreConfigXMLProcessor.java
@@ -31,6 +31,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.osgi.framework.BundleContext;
 import org.wso2.carbon.CarbonException;
+import org.wso2.carbon.base.ServerConfiguration;
 import org.wso2.carbon.base.api.ServerConfigurationService;
 import org.wso2.carbon.crypto.api.CipherMetaDataHolder;
 import org.wso2.carbon.crypto.api.CryptoException;
@@ -44,6 +45,7 @@ import org.wso2.carbon.user.core.internal.UserStoreMgtDataHolder;
 import org.wso2.carbon.user.core.tracker.UserStoreManagerRegistry;
 import org.wso2.carbon.user.core.util.UserCoreUtil;
 import org.wso2.carbon.utils.CarbonUtils;
+import org.wso2.carbon.utils.ServerConstants;
 import org.wso2.securevault.SecretResolver;
 import org.wso2.securevault.SecretResolverFactory;
 import org.wso2.securevault.commons.MiscellaneousUtil;
@@ -81,7 +83,6 @@ public class UserStoreConfigXMLProcessor {
     private SecretResolver secretResolver;
     private String filePath = null;
     private Gson gson = new Gson();
-    private static final String CRYPTO_API_PROVIDER_BC = "BC";
     private static final String ENCRYPTION_KEYSTORE = "Security.UserStorePasswordEncryption";
     private static final String INTERNAL_KEYSTORE = "InternalKeystore";
     private static final String CRYPTO_PROVIDER = "CryptoService.InternalCryptoProviderClassName";
@@ -490,7 +491,7 @@ public class UserStoreConfigXMLProcessor {
                     log.debug("Ciphertext is empty. An empty array will be used as the plaintext bytes.");
                 }
             } else {
-                decryptedValue = cryptoService.decrypt(cipherTextBytes, algorithm, CRYPTO_API_PROVIDER_BC);
+                decryptedValue = cryptoService.decrypt(cipherTextBytes, algorithm, getJCEProvider());
             }
             return new String(decryptedValue);
 
@@ -524,14 +525,14 @@ public class UserStoreConfigXMLProcessor {
                         log.debug("Cipher transformation for decryption : " + cipherHolder.getTransformation());
                     }
 
-                    keyStoreCipher = Cipher.getInstance(cipherHolder.getTransformation(), "BC");
+                    keyStoreCipher = Cipher.getInstance(cipherHolder.getTransformation(), getJCEProvider());
 
                     cipherTextBytes = cipherHolder.getCipherBase64Decoded();
                 } else {
                     // If the ciphertext is not a self-contained, directly decrypt using transformation configured in
                     // carbon.properties file
 
-                    keyStoreCipher = Cipher.getInstance(cipherTransformation, "BC");
+                    keyStoreCipher = Cipher.getInstance(cipherTransformation, getJCEProvider());
 
                 }
             } else {
@@ -541,7 +542,7 @@ public class UserStoreConfigXMLProcessor {
                     log.debug("Cipher transformation property is not available.Hence RSA is considered as default " +
                             "cipher transformation.");
                 }
-                keyStoreCipher = Cipher.getInstance("RSA", "BC");
+                keyStoreCipher = Cipher.getInstance("RSA", getJCEProvider());
 
             }
 
@@ -576,4 +577,12 @@ public class UserStoreConfigXMLProcessor {
         }
     }
 
+    private String getJCEProvider() {
+
+        String provider = ServerConfiguration.getInstance().getFirstProperty(ServerConstants.JCE_PROVIDER);
+        if (!StringUtils.isBlank(provider)) {
+            return provider;
+        }
+        return ServerConstants.JCE_PROVIDER_BC;
+    }
 }

--- a/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/ServerConstants.java
+++ b/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/ServerConstants.java
@@ -155,6 +155,9 @@ public final class ServerConstants {
     public static final String STS_NAME = "wso2carbon-sts";
     public static final String DEFAULT_PASSWORD_VALIDITY_PERIOD = "DefaultPasswordValidityPeriod";
 
+    public static final String JCE_PROVIDER = "JCEProvider";
+    public static final String JCE_PROVIDER_BC = "BC";
+    public static final String JCE_PROVIDER_BCFIPS = "BCFIPS";
 
     public static class Axis2ParameterNames {
         public static final String CONTEXT_ROOT = "contextRoot";

--- a/distribution/kernel/carbon-home/repository/conf/carbon.xml
+++ b/distribution/kernel/carbon-home/repository/conf/carbon.xml
@@ -715,4 +715,7 @@
         <enableRestart>false</enableRestart>
     </enableShutdownRestartFromAPI>
 
+    <!-- Configure JCE provider -->
+    <JCEProvider>BC</JCEProvider>
+
 </Server>

--- a/distribution/kernel/carbon-home/repository/resources/conf/default.json
+++ b/distribution/kernel/carbon-home/repository/resources/conf/default.json
@@ -219,6 +219,7 @@
   "versioning_configuration.enable_versioning_ratings": false,
   "versioning_configuration.enable_version_resources_on_change" : false,
   "sts.callback_handler" : "org.wso2.carbon.identity.sts.common.identity.provider.AttributeCallbackHandler",
-  "tenant_mgt.enable_tenant_theme_mgt" : true
+  "tenant_mgt.enable_tenant_theme_mgt" : true,
+  "jce_provider.provider_name" : "BC"
 
 }

--- a/distribution/kernel/carbon-home/repository/resources/conf/templates/repository/conf/carbon.xml.j2
+++ b/distribution/kernel/carbon-home/repository/resources/conf/templates/repository/conf/carbon.xml.j2
@@ -789,4 +789,8 @@
     <!-- Configure password validity period for initially set password -->
     <DefaultPasswordValidityPeriod>{{password.default_validity_period}}</DefaultPasswordValidityPeriod>
 
+    <!-- Configure JCE provider -->
+    {% if jce_provider.provider_name is defined %}
+        <JCEProvider>{{jce_provider.provider_name}}</JCEProvider>
+    {% endif %}
 </Server>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -506,7 +506,7 @@
 
         <!-- bouncycastle -->
         <bouncycastle.version>1.70.0.wso2v1</bouncycastle.version>
-        <imp.pkg.version.bcp>[1.52.0, 2.0.0)</imp.pkg.version.bcp>
+        <imp.pkg.version.bcp>[1.0.0, 2.0.0)</imp.pkg.version.bcp>
 
         <!--BPS specific-->
         <saxon-bps.wso2.version.human-task>9.0.0.x-wso2v1</saxon-bps.wso2.version.human-task>


### PR DESCRIPTION
## Purpose

Resolves - https://github.com/wso2/product-is/issues/15428

Remove the hardcoded use cases of BC as a JCE provider and make it configurable through a configuration.

The following config needs to be added to the deployment.toml to configure FIPS complaint JCE provider.
```
[jce_provider]
provider_name = "BCFIPS"

```
