### PR TITLE
Skip username format validation when getSkipUsernamePatternValidationThreadLocal() returns true

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
@@ -8454,6 +8454,9 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
      */
     protected boolean checkUserNameValid(String userName) throws UserStoreException {
 
+        if (UserCoreUtil.getSkipUsernamePatternValidationThreadLocal()) {
+            return true;
+        }
         if (isValidUserName(userName)) {
             String regularExpression = realmConfig
                     .getUserStoreProperty(UserCoreConstants.RealmConfig.PROPERTY_USER_NAME_JAVA_REG_EX);


### PR DESCRIPTION
Skip username format validation if `UserCoreUtil.getSkipUsernamePatternValidationThreadLocal()` returns true. That we will only set to true, if the username format validation has happened in another listener with higher priority.

Related PR:
- https://github.com/wso2/carbon-identity-framework/pull/4428