### PR TITLE
Fix authentication for users in the non uid userstores and Fix role addition and deletion in AD userstores

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
@@ -11287,13 +11287,15 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
                             log.debug(message);
                         }
                     } else {
-                        boolean status = abstractUserStoreManager.doAuthenticate(users.get(0), credentialObj);
+                        boolean status = abstractUserStoreManager.doAuthenticate(UserCoreUtil.removeDomainFromName(
+                                users.get(0)), credentialObj);
                         authenticationResult = new AuthenticationResult(status ?
                                 AuthenticationResult.AuthenticationStatus.SUCCESS :
                                 AuthenticationResult.AuthenticationStatus.FAIL);
                         if (status) {
                             String userID = userUniqueIDManger.getUniqueId(users.get(0), this);
                             User user = userUniqueIDManger.getUser(userID, this);
+                            user.setTenantDomain(getTenantDomain(tenantId));
                             authenticationResult.setAuthenticatedUser(user);
                         } else {
                             authenticationResult.setFailureReason(new FailureReason("Invalid credentials."));

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/ReadWriteLDAPUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/ReadWriteLDAPUserStoreManager.java
@@ -1461,14 +1461,13 @@ public class ReadWriteLDAPUserStoreManager extends ReadOnlyLDAPUserStoreManager 
                                             searchBase);
                             // assume only one group with given group name
                             //TODO - https://github.com/wso2/product-is/issues/11925
-                            String groupDN = "cn=" + newRole;
                             if (!groupResults.hasMore()) {
-                                modifyUserInRole(userNameDN, groupDN, DirContext.ADD_ATTRIBUTE,
+                                modifyUserInRoleWithRecursiveSearch(userNameDN, newRole, DirContext.ADD_ATTRIBUTE,
                                         searchBase);
                             } else {
                                 errorMessage =
                                         "User: " + userName + " already belongs to role: " +
-                                                groupDN;
+                                                newRole;
                                 throw new UserStoreException(errorMessage);
                             }
 
@@ -1742,7 +1741,71 @@ public class ReadWriteLDAPUserStoreManager extends ReadOnlyLDAPUserStoreManager 
         }
     }
 
+    /**
+     * Either delete or add user from/to group while recursively checking in the sub-directory paths.
+     *
+     * @param userNameDN : distinguish name of user entry.
+     * @param groupRDN   : relative distinguish name of group entry
+     * @param modifyType : modify attribute type in DirCOntext.
+     * @throws UserStoreException
+     */
+    protected void modifyUserInRoleWithRecursiveSearch(String userNameDN, String groupRDN, int modifyType,
+                                                       String searchBase) throws UserStoreException {
 
+        if (log.isDebugEnabled()) {
+            logger.debug("Modifying role: " + groupRDN + " with type: " + modifyType + " user: " + userNameDN
+                    + " in search base: " + searchBase);
+        }
+        DirContext dirContext = this.connectionSource.getContext();
+        SearchControls searchControls = new SearchControls();
+        searchControls.setSearchScope(SearchControls.SUBTREE_SCOPE);
+        searchControls.setReturningAttributes(null);
+        String groupSearchFilter = realmConfig
+                .getUserStoreProperty(LDAPConstants.ROLE_NAME_FILTER);
+        groupSearchFilter = groupSearchFilter.replace("?", escapeSpecialCharactersForFilter(groupRDN));
+        NamingEnumeration<SearchResult> returnedResultList = null;
+        String returnedGroupEntry;
+        try {
+            returnedResultList = dirContext.search(escapeDNForSearch(groupSearchBase),
+                    groupSearchFilter, searchControls);
+            // Assume only one group is returned from the search.
+            returnedGroupEntry = returnedResultList.next().getName();
+        } catch (NamingException e) {
+            String errorMessage = "Results could not be retrieved from the directory context for group : " + groupRDN;
+            if (log.isDebugEnabled()) {
+                log.debug(errorMessage, e);
+            }
+            throw new UserStoreException(errorMessage, e);
+        } finally {
+            JNDIUtil.closeNamingEnumeration(returnedResultList);
+        }
+        DirContext mainDirContext = null;
+        DirContext groupContext = null;
+        try {
+            mainDirContext = this.connectionSource.getContext();
+            groupContext = (DirContext) mainDirContext.lookup(escapeDNForSearch(searchBase));
+            String memberAttributeName = realmConfig.getUserStoreProperty(LDAPConstants.MEMBERSHIP_ATTRIBUTE);
+            Attributes modifyingAttributes = new BasicAttributes(true);
+            Attribute memberAttribute = new BasicAttribute(memberAttributeName);
+            memberAttribute.add(userNameDN);
+            modifyingAttributes.put(memberAttribute);
+            groupContext.modifyAttributes(returnedGroupEntry, modifyType, modifyingAttributes);
+            if (log.isDebugEnabled()) {
+                logger.debug("User: " + userNameDN + " was successfully " + "modified in LDAP group: "
+                        + groupRDN);
+            }
+        } catch (NamingException e) {
+            String errorMessage = "Error occurred while modifying user entry: " + userNameDN
+                    + " in LDAP role: " + groupRDN;
+            if (log.isDebugEnabled()) {
+                log.debug(errorMessage, e);
+            }
+            throw new UserStoreException(errorMessage);
+        } finally {
+            JNDIUtil.closeContext(groupContext);
+            JNDIUtil.closeContext(mainDirContext);
+        }
+    }
 
 
     /**

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/UniqueIDActiveDirectoryUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/UniqueIDActiveDirectoryUserStoreManager.java
@@ -374,6 +374,34 @@ public class UniqueIDActiveDirectoryUserStoreManager extends UniqueIDReadWriteLD
         DirContext dirContext = null;
         NamingEnumeration<SearchResult> answer = null;
 
+        DirContext groupDirContext = this.connectionSource.getContext();
+        SearchControls searchControls = new SearchControls();
+        searchControls.setSearchScope(SearchControls.SUBTREE_SCOPE);
+        searchControls.setReturningAttributes(null);
+
+        String groupSearchFilter = realmConfig
+                .getUserStoreProperty(LDAPConstants.ROLE_NAME_FILTER);
+        groupSearchFilter = groupSearchFilter.replace("?", escapeSpecialCharactersForFilter(
+                context.getRoleName()));
+        NamingEnumeration<SearchResult> returnedResultList = null;
+        String returnedGroupEntry;
+
+        try {
+            returnedResultList = groupDirContext.search(escapeDNForSearch(groupSearchBase),
+                    groupSearchFilter, searchControls);
+            // Assume only one group is returned from the search.
+            returnedGroupEntry = returnedResultList.next().getName();
+        } catch (NamingException e) {
+            String errorMessage = "Results could not be retrieved from the directory context for user : " +
+                    context.getRoleName();
+            if (logger.isDebugEnabled()) {
+                logger.debug(errorMessage, e);
+            }
+            throw new UserStoreException(errorMessage, e);
+        } finally {
+            JNDIUtil.closeNamingEnumeration(returnedResultList);
+        }
+
         try {
             SearchControls searchCtls = new SearchControls();
             searchCtls.setSearchScope(SearchControls.SUBTREE_SCOPE);
@@ -383,10 +411,9 @@ public class UniqueIDActiveDirectoryUserStoreManager extends UniqueIDReadWriteLD
             String groupSearchBase = realmConfig.getUserStoreProperty(LDAPConstants.GROUP_SEARCH_BASE);
             String userListFilter = realmConfig.getUserStoreProperty(LDAPConstants.USER_NAME_LIST_FILTER);
             String memberOFAttribute = realmConfig.getUserStoreProperty(LDAPConstants.MEMBEROF_ATTRIBUTE);
-            String groupNameAttribute = realmConfig.getUserStoreProperty(LDAPConstants.GROUP_NAME_ATTRIBUTE);
             userSearchBase = realmConfig.getUserStoreProperty(LDAPConstants.USER_SEARCH_BASE);
-            String searchFilter = "(&" + userListFilter + "(" + memberOFAttribute + "=" + groupNameAttribute + "="
-                    + escapeSpecialCharactersForFilter(context.getRoleName()) + "," + groupSearchBase + "))";
+            String searchFilter = "(&" + userListFilter + "(" + memberOFAttribute + "="
+                    + escapeSpecialCharactersForFilter(returnedGroupEntry) + "," + groupSearchBase + "))";
             String userNameProperty = realmConfig.getUserStoreProperty(LDAPConstants.USER_NAME_ATTRIBUTE);
             String displayNameAttribute = realmConfig.getUserStoreProperty(LDAPConstants.DISPLAY_NAME_ATTRIBUTE);
             String userIDAttribute = realmConfig.getUserStoreProperty(LDAPConstants.USER_ID_ATTRIBUTE);

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/UniqueIDReadWriteLDAPUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/UniqueIDReadWriteLDAPUserStoreManager.java
@@ -1662,11 +1662,11 @@ public class UniqueIDReadWriteLDAPUserStoreManager extends UniqueIDReadOnlyLDAPU
                                     returningAttributes, SearchControls.SUBTREE_SCOPE, mainDirContext, searchBase);
                             // assume only one group with given group name
                             //TODO - https://github.com/wso2/product-is/issues/11925
-                            String groupDN = "cn=" + newRole;
                             if (!groupResults.hasMore()) {
-                                modifyUserInRole(userNameDN, groupDN, DirContext.ADD_ATTRIBUTE, searchBase);
+                                modifyUserInRoleWithRecursiveSearch(userNameDN, newRole, DirContext.ADD_ATTRIBUTE,
+                                        searchBase);
                             } else {
-                                errorMessage = "User: " + userName + " already belongs to role: " + groupDN;
+                                errorMessage = "User: " + userName + " already belongs to role: " + newRole;
                                 throw new UserStoreException(errorMessage);
                             }
 
@@ -1928,6 +1928,72 @@ public class UniqueIDReadWriteLDAPUserStoreManager extends UniqueIDReadOnlyLDAPU
         } catch (NamingException e) {
             String errorMessage =
                     "Error occurred while modifying user entry: " + userNameDN + " in LDAP role: " + groupRDN;
+            if (log.isDebugEnabled()) {
+                log.debug(errorMessage, e);
+            }
+            throw new UserStoreException(errorMessage);
+        } finally {
+            JNDIUtil.closeContext(groupContext);
+            JNDIUtil.closeContext(mainDirContext);
+        }
+    }
+
+    /**
+     * Either delete or add user from/to group while recursively checking in the sub-directory paths.
+     *
+     * @param userNameDN : distinguish name of user entry.
+     * @param groupRDN   : relative distinguish name of group entry
+     * @param modifyType : modify attribute type in DirCOntext.
+     * @throws UserStoreException
+     */
+    protected void modifyUserInRoleWithRecursiveSearch(String userNameDN, String groupRDN, int modifyType,
+                                                       String searchBase) throws UserStoreException {
+
+        if (log.isDebugEnabled()) {
+            logger.debug("Modifying role: " + groupRDN + " with type: " + modifyType + " user: " + userNameDN
+                    + " in search base: " + searchBase);
+        }
+        DirContext dirContext = this.connectionSource.getContext();
+        SearchControls searchControls = new SearchControls();
+        searchControls.setSearchScope(SearchControls.SUBTREE_SCOPE);
+        searchControls.setReturningAttributes(null);
+        String groupSearchFilter = realmConfig
+                .getUserStoreProperty(LDAPConstants.ROLE_NAME_FILTER);
+        groupSearchFilter = groupSearchFilter.replace("?", escapeSpecialCharactersForFilter(groupRDN));
+        NamingEnumeration<SearchResult> returnedResultList = null;
+        String returnedGroupEntry;
+        try {
+            returnedResultList = dirContext.search(escapeDNForSearch(groupSearchBase),
+                    groupSearchFilter, searchControls);
+            // Assume only one group is returned from the search.
+            returnedGroupEntry = returnedResultList.next().getName();
+        } catch (NamingException e) {
+            String errorMessage = "Results could not be retrieved from the directory context for group : " + groupRDN;
+            if (log.isDebugEnabled()) {
+                log.debug(errorMessage, e);
+            }
+            throw new UserStoreException(errorMessage, e);
+        } finally {
+            JNDIUtil.closeNamingEnumeration(returnedResultList);
+        }
+        DirContext mainDirContext = null;
+        DirContext groupContext = null;
+        try {
+            mainDirContext = this.connectionSource.getContext();
+            groupContext = (DirContext) mainDirContext.lookup(escapeDNForSearch(searchBase));
+            String memberAttributeName = realmConfig.getUserStoreProperty(LDAPConstants.MEMBERSHIP_ATTRIBUTE);
+            Attributes modifyingAttributes = new BasicAttributes(true);
+            Attribute memberAttribute = new BasicAttribute(memberAttributeName);
+            memberAttribute.add(userNameDN);
+            modifyingAttributes.put(memberAttribute);
+            groupContext.modifyAttributes(returnedGroupEntry, modifyType, modifyingAttributes);
+            if (log.isDebugEnabled()) {
+                logger.debug("User: " + userNameDN + " was successfully " + "modified in LDAP group: "
+                        + groupRDN);
+            }
+        } catch (NamingException e) {
+            String errorMessage = "Error occurred while modifying user entry: " + userNameDN
+                    + " in LDAP role: " + groupRDN;
             if (log.isDebugEnabled()) {
                 log.debug(errorMessage, e);
             }


### PR DESCRIPTION
Changes in this PR

- Resolved https://github.com/wso2/product-is/issues/15383 and https://github.com/wso2/product-is/issues/15373

Fixes for https://github.com/wso2/product-is/issues/15383
- Added the sub directory path to the modify method to identify the exact element that needs to be modified and to the search method to view the users of a role.

- The fix was done to both ActiveDirectoryUserStoreManager and UniqueIDActiveDirectoryUserStoreManager since the error could be reproduced in both userstores.

Fixes for https://github.com/wso2/product-is/issues/15373

- Sending userstore domain free username for authenticate when userid is null.

- Adding tenant domain to user object to resolve the tenant domain null when saving the cache.