### PR TITLE
Improve getUserListWithID to set domain name from userId

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
@@ -3101,6 +3101,11 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
             extractedDomain = names[0].trim();
         }
 
+        // Extracting the domain using user id.
+        if (StringUtils.isBlank(extractedDomain) && UserCoreClaimConstants.USER_ID_CLAIM_URI.equalsIgnoreCase(claim)) {
+            extractedDomain = getDomainWithUserID(claimValue);
+        }
+
         UserStoreManager userManager = this;
         /*
         * This method("getUserListWithID") can be called for secondary userstore managers.
@@ -17958,5 +17963,21 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
             return Integer.parseInt(pwValidityTimeoutStr);
         }
         return DEFAULT_PASSWORD_VALIDITY_PERIOD_VALUE;
+    }
+
+    /**
+     * Get the domain name using the user ID.
+     *
+     * @param userId User ID.
+     * @throws UserStoreException Exception when the user does not exist.
+     */
+    private String getDomainWithUserID(String userId) throws UserStoreException {
+
+        UserStore userStore = getUserStoreWithID(userId);
+        String domain = null;
+        if (userStore != null && StringUtils.isNotBlank(userStore.getDomainName())) {
+            domain = userStore.getDomainName();
+        }
+        return domain;
     }
 }


### PR DESCRIPTION
## Purpose
Scim2/Me endpoint with DELETE operation fails when there are multiple userstores and a userstore added prior to the userstore in which the current authenticated user resides fails. To fix this, inside getUserListWithID() method the domain name is set using the userId so that the userstores need not be iterated later in the method to find the domain, which will throw an error if a userstore has failed.

## Related Issues
- Issue https://github.com/wso2/product-is/issues/15465