### PR TITLE
Skip multi-valued attribute separation for specified attributes

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/UserStoreConfigConstants.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/UserStoreConfigConstants.java
@@ -182,4 +182,10 @@ public class UserStoreConfigConstants {
     // Property to bypass account locking for the userstore.
     public static final String BYPASS_ACCOUNT_LOCK = "BypassAccountLock";
     public static final String BYPASS_ACCOUNT_LOCK_DESCRIPTION = "Enable bypass account locking for the userstore";
+
+    // Property to specify attributes that need to skip multi-valued attribute separation.
+    public static final String singleValuedAttributes = "SingleValuedAttributes";
+    public static final String singleValuedAttributesDescription = "Comma-separated list of attributes that need to " +
+            "skip multi-valued attribute separation";
+    public static final String singleValuedAttributesDisplayName = "Single Valued Attributes";
 }

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/ActiveDirectoryUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/ActiveDirectoryUserStoreManager.java
@@ -263,6 +263,10 @@ public class ActiveDirectoryUserStoreManager extends ReadWriteLDAPUserStoreManag
 
             processAttributesBeforeUpdate(userName, attributeValueMap, null);
 
+            String singleValuedAttributesProperty = Optional.ofNullable(realmConfig
+                    .getUserStoreProperty(UserStoreConfigConstants.singleValuedAttributes)).orElse(StringUtils.EMPTY);
+            String[] singleValuedAttributes = StringUtils.split(singleValuedAttributesProperty, ",");
+
             attributeValueMap.forEach((attributeName, attributeValue) -> {
                 BasicAttribute claim = new BasicAttribute(attributeName);
                 if (attributeValue != null) {
@@ -270,7 +274,9 @@ public class ActiveDirectoryUserStoreManager extends ReadWriteLDAPUserStoreManag
                     if (claimSeparator != null && !claimSeparator.trim().isEmpty()) {
                         userAttributeSeparator = claimSeparator;
                     }
-                    if (attributeValue.contains(userAttributeSeparator)) {
+                    if (attributeValue.contains(userAttributeSeparator) &&
+                            !(ArrayUtils.isNotEmpty(singleValuedAttributes)
+                                    && (Arrays.stream(singleValuedAttributes).anyMatch(attributeName::equals)))) {
                         StringTokenizer st = new StringTokenizer(attributeValue, userAttributeSeparator);
                         while (st.hasMoreElements()) {
                             String newVal = st.nextElement().toString();
@@ -1021,6 +1027,9 @@ public class ActiveDirectoryUserStoreManager extends ReadWriteLDAPUserStoreManag
         setAdvancedProperty(UserStoreConfigConstants.timestampAttributes,
                 UserStoreConfigConstants.timestampAttributesDisplayName, " ",
                 UserStoreConfigConstants.timestampAttributesDescription);
+        setAdvancedProperty(UserStoreConfigConstants.singleValuedAttributes,
+                UserStoreConfigConstants.singleValuedAttributesDisplayName, " ",
+                UserStoreConfigConstants.singleValuedAttributesDescription);
     }
 
 

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/UniqueIDActiveDirectoryUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/UniqueIDActiveDirectoryUserStoreManager.java
@@ -308,6 +308,10 @@ public class UniqueIDActiveDirectoryUserStoreManager extends UniqueIDReadWriteLD
             attributeValueMap.put(realmConfig.getUserStoreProperty(LDAPConstants.USER_ID_ATTRIBUTE), userID);
             processAttributesBeforeUpdateWithID(userID, attributeValueMap, null);
 
+            String singleValuedAttributesProperty = Optional.ofNullable(realmConfig
+                    .getUserStoreProperty(UserStoreConfigConstants.singleValuedAttributes)).orElse(StringUtils.EMPTY);
+            String[] singleValuedAttributes = StringUtils.split(singleValuedAttributesProperty, ",");
+
             attributeValueMap.forEach((attributeName, attributeValue) -> {
                 BasicAttribute claim = new BasicAttribute(attributeName);
                 if (attributeValue != null) {
@@ -315,7 +319,9 @@ public class UniqueIDActiveDirectoryUserStoreManager extends UniqueIDReadWriteLD
                     if (claimSeparator != null && !claimSeparator.trim().isEmpty()) {
                         userAttributeSeparator = claimSeparator;
                     }
-                    if (attributeValue.contains(userAttributeSeparator)) {
+                    if (attributeValue.contains(userAttributeSeparator) &&
+                            !(ArrayUtils.isNotEmpty(singleValuedAttributes)
+                                    && (Arrays.stream(singleValuedAttributes).anyMatch(attributeName::equals)))) {
                         StringTokenizer st = new StringTokenizer(attributeValue, userAttributeSeparator);
                         while (st.hasMoreElements()) {
                             String newVal = st.nextElement().toString();
@@ -1099,6 +1105,9 @@ public class UniqueIDActiveDirectoryUserStoreManager extends UniqueIDReadWriteLD
         setAdvancedProperty(UserStoreConfigConstants.timestampAttributes,
                 UserStoreConfigConstants.timestampAttributesDisplayName, " ",
                 UserStoreConfigConstants.timestampAttributesDescription);
+        setAdvancedProperty(UserStoreConfigConstants.singleValuedAttributes,
+                UserStoreConfigConstants.singleValuedAttributesDisplayName, " ",
+                UserStoreConfigConstants.singleValuedAttributesDescription);
     }
 
     private static void setAdvancedProperty(String name, String displayName, String value, String description) {

--- a/distribution/kernel/carbon-home/repository/resources/conf/key-mappings.json
+++ b/distribution/kernel/carbon-home/repository/resources/conf/key-mappings.json
@@ -86,6 +86,7 @@
   "user_store.membership_attribute_range": "user_store.properties.MembershipAttributeRange",
   "user_store.ssl_certificate_validation_enabled": "user_store.properties.SSLCertificateValidationEnabled",
   "user_store.date_and_time_pattern": "user_store.properties.DateAndTimePattern",
+  "user_store.single_valued_attributes": "user_store.properties.SingleValuedAttributes",
 
   "transport.https.properties.certificate_verification": "transport.https.sslHostConfig.properties.certificateVerification",
   "transport.https.properties.protocols": "transport.https.sslHostConfig.properties.protocols",


### PR DESCRIPTION
## Purpose
> Multi-valued attribute separation will be skipped for the user-specified attributes in Single Valued Attributes define in advanced properties of the user store.
![Screenshot from 2023-02-14 16-32-23](https://user-images.githubusercontent.com/30428591/218717621-12f5c354-83a3-4d54-9cf5-3eb79fb0ff19.png)

### Related Git Issue

- [https://github.com/wso2/product-is/issues/15489](https://github.com/wso2/product-is/issues/15489)

### Doc Issue

- [https://github.com/wso2/product-is/issues/15506](https://github.com/wso2/product-is/issues/15506)