### PR TITLE
Add tenant domain validation for API requests

### DIFF
--- a/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/multitenancy/utils/TenantAxisUtils.java
+++ b/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/multitenancy/utils/TenantAxisUtils.java
@@ -81,6 +81,7 @@ public final class TenantAxisUtils {
     private static final Log log = LogFactory.getLog(TenantAxisUtils.class);
     private static final String TENANT_CONFIGURATION_CONTEXTS = "tenant.config.contexts";
     private static final String TENANT_CONFIGURATION_CONTEXTS_CREATED = "tenant.config.contexts.created";
+    private static final String ILLEGAL_CHARACTERS_FOR_TENANT_DOMAIN = ".*[^a-z0-9\\._\\-].*";
     private static CarbonCoreDataHolder dataHolder = CarbonCoreDataHolder.getInstance();
     private static Map<String, ReentrantReadWriteLock> tenantReadWriteLocks =
             new ConcurrentHashMap<String, ReentrantReadWriteLock>();
@@ -119,6 +120,12 @@ public final class TenantAxisUtils {
         ConfigurationContext tenantConfigCtx;
 
         Boolean isTenantActive;
+        if (tenantDomain != null && tenantDomain.matches(ILLEGAL_CHARACTERS_FOR_TENANT_DOMAIN)) {
+            String errorMsg = "The tenant domain ' " + tenantDomain +
+                    " ' contains one or more illegal characters. The valid characters are " +
+                    "lowercase letters, numbers, '.', '-' and '_'.";
+            throw new RuntimeException(errorMsg);
+        }
         try {
             isTenantActive = CarbonCoreDataHolder.getInstance().getRealmService().getTenantManager().
                     isTenantActive(getTenantId(tenantDomain));


### PR DESCRIPTION
## Purpose

When creating a tenant domain, we have a validation which allows only lowercase letters, numbers, '.', '-' and '_'. Since we are transforming the domain to lowercase when we store and query data from the database, compilations were observed when we send an API request with an uppercase tenant domain. Therefore the same validation is added for requests as well.

Fixes: https://github.com/wso2/api-manager/issues/1466