### PR TITLE
Improve Error Logs in DBSFileUploadExecutor.java to filter sensitive information

### DIFF
--- a/core/org.wso2.carbon.ui/src/main/java/org/wso2/carbon/ui/transports/fileupload/DBSFileUploadExecutor.java
+++ b/core/org.wso2.carbon.ui/src/main/java/org/wso2/carbon/ui/transports/fileupload/DBSFileUploadExecutor.java
@@ -105,8 +105,7 @@ public class DBSFileUploadExecutor extends org.wso2.carbon.ui.transports.fileupl
                 log.error("File upload failed", e);                
                 out.write("<script type=\"text/javascript\" src=\"../ds/extensions/core/js/data_service.js\"></script>");                
                 out.write("<script type=\"text/javascript\">" +
-                          "alert('Service file upload FAILED. You will be redirected to file upload screen. Reason :" +
-                          e.getMessage().replaceFirst(",","") + "');" +
+                          "alert('Service file upload FAILED. You will be redirected to file upload screen.');" +
                           "loadDBSFileUploadPage();"+ //available in data_service.js
                           "</script>");
             }


### PR DESCRIPTION
## Purpose
To fix the application call the java.io.PrintWriter.write() function, which may expose information about the application logic or other details such as the names and versions of the application container and associated components.

## Goals
To sanitize all messages of any sensitive information that is not absolutely necessary.

## Approach
In DBSFileUploadExecutor.java class it prints an error via the java.io.PrintWriter.write() function.

This can be fixed by printing only the error description.