### PR TITLE
Make JCE provider configurable

### DIFF
--- a/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/internal/CarbonCoreActivator.java
+++ b/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/internal/CarbonCoreActivator.java
@@ -100,13 +100,13 @@ public class CarbonCoreActivator implements BundleActivator {
      *
      * @return jce provider identifier name
      */
-    private static String getPreferredJceProviderClass(String providerIdentifier) throws Exception {
+    private static String getPreferredJceProviderClass(String providerIdentifier) {
         if (ServerConstants.BOUNCY_CASTLE_PROVIDER_IDENTIFIER.equalsIgnoreCase(providerIdentifier)) {
             return ServerConstants.BOUNCY_CASTLE_PROVIDER_CLASS;
         } else if (ServerConstants.BOUNCY_CASTLE_FIPS_PROVIDER_IDENTIFIER.equalsIgnoreCase(providerIdentifier)) {
             return ServerConstants.BOUNCY_CASTLE_FIPS_PROVIDER_CLASS;
         } else {
-            throw new Exception("Unsupported JCE provider: " + providerIdentifier);
+            throw new IllegalArgumentException("Unsupported JCE provider: " + providerIdentifier);
         }
     }
 }

--- a/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/internal/CarbonCoreActivator.java
+++ b/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/internal/CarbonCoreActivator.java
@@ -17,14 +17,15 @@ package org.wso2.carbon.core.internal;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.osgi.framework.BundleActivator;
 import org.osgi.framework.BundleContext;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
+import org.wso2.carbon.utils.ServerConstants;
 import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 
 import java.io.File;
 import java.lang.management.ManagementPermission;
+import java.security.Provider;
 import java.security.Security;
 
 /**
@@ -69,13 +70,43 @@ public class CarbonCoreActivator implements BundleActivator {
                  System.getProperty("user.language") + "-" + System.getProperty("user.country") +
                  ", " + System.getProperty("user.timezone"));
 
-        Security.addProvider(new BouncyCastleProvider());
+        String cryptoProviderIdentifier = getPreferredJceProviderIdentifier();
+        String cryptoProviderClass = getPreferredJceProviderClass(cryptoProviderIdentifier);
+        Security.addProvider((Provider) Class.forName(cryptoProviderClass).getDeclaredConstructor().newInstance());
         if(log.isDebugEnabled()){
-            log.debug("BouncyCastle security provider is successfully registered in JVM.");
+            log.debug(cryptoProviderClass + " security provider is successfully registered in JVM.");
         }
     }
 
     public void stop(BundleContext context) throws Exception {
         dataHolder.setBundleContext(null);
+    }
+
+    /**
+     * This method returns the preferred JCE provider identifier to be used.
+     *
+     * @return jce provider identifier name
+     */
+    private static String getPreferredJceProviderIdentifier() {
+        String provider = System.getProperty("security.jce.provider");
+        if (provider != null && provider.equalsIgnoreCase(ServerConstants.BOUNCY_CASTLE_FIPS_PROVIDER_IDENTIFIER)) {
+            return ServerConstants.BOUNCY_CASTLE_FIPS_PROVIDER_IDENTIFIER;
+        }
+        return ServerConstants.BOUNCY_CASTLE_PROVIDER_IDENTIFIER;
+    }
+
+    /**
+     * This method returns the preferred JCE provider class to be used.
+     *
+     * @return jce provider identifier name
+     */
+    private static String getPreferredJceProviderClass(String providerIdentifier) throws Exception {
+        if (ServerConstants.BOUNCY_CASTLE_PROVIDER_IDENTIFIER.equalsIgnoreCase(providerIdentifier)) {
+            return ServerConstants.BOUNCY_CASTLE_PROVIDER_CLASS;
+        } else if (ServerConstants.BOUNCY_CASTLE_FIPS_PROVIDER_IDENTIFIER.equalsIgnoreCase(providerIdentifier)) {
+            return ServerConstants.BOUNCY_CASTLE_FIPS_PROVIDER_CLASS;
+        } else {
+            throw new Exception("Unsupported JCE provider: " + providerIdentifier);
+        }
     }
 }

--- a/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/internal/CarbonCoreActivator.java
+++ b/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/internal/CarbonCoreActivator.java
@@ -88,7 +88,7 @@ public class CarbonCoreActivator implements BundleActivator {
      * @return jce provider identifier name
      */
     private static String getPreferredJceProviderIdentifier() {
-        String provider = System.getProperty("security.jce.provider");
+        String provider = System.getProperty(ServerConstants.JCE_PROVIDER_PARAMETER);
         if (provider != null && provider.equalsIgnoreCase(ServerConstants.BOUNCY_CASTLE_FIPS_PROVIDER_IDENTIFIER)) {
             return ServerConstants.BOUNCY_CASTLE_FIPS_PROVIDER_IDENTIFIER;
         }

--- a/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/internal/CarbonCoreActivator.java
+++ b/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/internal/CarbonCoreActivator.java
@@ -89,7 +89,7 @@ public class CarbonCoreActivator implements BundleActivator {
      */
     private static String getPreferredJceProviderIdentifier() {
         String provider = System.getProperty(ServerConstants.JCE_PROVIDER_PARAMETER);
-        if (provider != null && provider.equalsIgnoreCase(ServerConstants.BOUNCY_CASTLE_FIPS_PROVIDER_IDENTIFIER)) {
+        if (ServerConstants.BOUNCY_CASTLE_FIPS_PROVIDER_IDENTIFIER.equalsIgnoreCase(provider)) {
             return ServerConstants.BOUNCY_CASTLE_FIPS_PROVIDER_IDENTIFIER;
         }
         return ServerConstants.BOUNCY_CASTLE_PROVIDER_IDENTIFIER;

--- a/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/util/CryptoUtil.java
+++ b/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/util/CryptoUtil.java
@@ -607,7 +607,7 @@ public class CryptoUtil {
      * @return jce provider identifier name
      */
     private String getPreferredJceProviderIdentifier() {
-        String provider = System.getProperty("security.jce.provider");
+        String provider = System.getProperty(ServerConstants.JCE_PROVIDER_PARAMETER);
         if (provider != null && provider.equalsIgnoreCase(ServerConstants.BOUNCY_CASTLE_FIPS_PROVIDER_IDENTIFIER)) {
             return ServerConstants.BOUNCY_CASTLE_FIPS_PROVIDER_IDENTIFIER;
         }

--- a/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/util/CryptoUtil.java
+++ b/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/util/CryptoUtil.java
@@ -608,7 +608,7 @@ public class CryptoUtil {
      */
     private String getPreferredJceProviderIdentifier() {
         String provider = System.getProperty(ServerConstants.JCE_PROVIDER_PARAMETER);
-        if (provider != null && provider.equalsIgnoreCase(ServerConstants.BOUNCY_CASTLE_FIPS_PROVIDER_IDENTIFIER)) {
+        if (ServerConstants.BOUNCY_CASTLE_FIPS_PROVIDER_IDENTIFIER.equalsIgnoreCase(provider)) {
             return ServerConstants.BOUNCY_CASTLE_FIPS_PROVIDER_IDENTIFIER;
         }
         return ServerConstants.BOUNCY_CASTLE_PROVIDER_IDENTIFIER;

--- a/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/util/SignatureUtil.java
+++ b/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/util/SignatureUtil.java
@@ -185,13 +185,13 @@ public class SignatureUtil {
      *
      * @return jce provider identifier name
      */
-    private static String getPreferredJceProviderClass(String providerIdentifier) throws Exception {
+    private static String getPreferredJceProviderClass(String providerIdentifier) {
          if (ServerConstants.BOUNCY_CASTLE_FIPS_PROVIDER_IDENTIFIER.equalsIgnoreCase(providerIdentifier)) {
             return ServerConstants.BOUNCY_CASTLE_FIPS_PROVIDER_CLASS;
         } else if (ServerConstants.BOUNCY_CASTLE_PROVIDER_IDENTIFIER.equalsIgnoreCase(providerIdentifier)) {
              return ServerConstants.BOUNCY_CASTLE_PROVIDER_CLASS;
          } else {
-            throw new Exception("Unsupported JCE provider: " + providerIdentifier);
+            throw new IllegalArgumentException("Unsupported JCE provider: " + providerIdentifier);
         }
     }
 

--- a/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/util/SignatureUtil.java
+++ b/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/util/SignatureUtil.java
@@ -174,7 +174,7 @@ public class SignatureUtil {
      */
     private static String getPreferredJceProviderIdentifier() {
         String provider = System.getProperty(ServerConstants.JCE_PROVIDER_PARAMETER);
-        if (provider != null && provider.equalsIgnoreCase(ServerConstants.BOUNCY_CASTLE_FIPS_PROVIDER_IDENTIFIER)) {
+        if (ServerConstants.BOUNCY_CASTLE_FIPS_PROVIDER_IDENTIFIER.equalsIgnoreCase(provider)) {
             return ServerConstants.BOUNCY_CASTLE_FIPS_PROVIDER_IDENTIFIER;
         }
         return ServerConstants.BOUNCY_CASTLE_PROVIDER_IDENTIFIER;

--- a/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/util/SignatureUtil.java
+++ b/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/util/SignatureUtil.java
@@ -173,7 +173,7 @@ public class SignatureUtil {
      * @return jce provider identifier name
      */
     private static String getPreferredJceProviderIdentifier() {
-        String provider = System.getProperty("security.jce.provider");
+        String provider = System.getProperty(ServerConstants.JCE_PROVIDER_PARAMETER);
         if (provider != null && provider.equalsIgnoreCase(ServerConstants.BOUNCY_CASTLE_FIPS_PROVIDER_IDENTIFIER)) {
             return ServerConstants.BOUNCY_CASTLE_FIPS_PROVIDER_IDENTIFIER;
         }

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/config/UserStoreConfigXMLProcessor.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/config/UserStoreConfigXMLProcessor.java
@@ -585,7 +585,7 @@ public class UserStoreConfigXMLProcessor {
      */
     private String getPreferredJceProviderIdentifier() {
         String provider = System.getProperty(ServerConstants.JCE_PROVIDER_PARAMETER);
-        if (provider != null && provider.equalsIgnoreCase(ServerConstants.BOUNCY_CASTLE_FIPS_PROVIDER_IDENTIFIER)) {
+        if (ServerConstants.BOUNCY_CASTLE_FIPS_PROVIDER_IDENTIFIER.equalsIgnoreCase(provider)) {
             return ServerConstants.BOUNCY_CASTLE_FIPS_PROVIDER_IDENTIFIER;
         }
         return ServerConstants.BOUNCY_CASTLE_PROVIDER_IDENTIFIER;

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/config/UserStoreConfigXMLProcessor.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/config/UserStoreConfigXMLProcessor.java
@@ -584,7 +584,7 @@ public class UserStoreConfigXMLProcessor {
      * @return jce provider identifier name
      */
     private String getPreferredJceProviderIdentifier() {
-        String provider = System.getProperty("security.jce.provider");
+        String provider = System.getProperty(ServerConstants.JCE_PROVIDER_PARAMETER);
         if (provider != null && provider.equalsIgnoreCase(ServerConstants.BOUNCY_CASTLE_FIPS_PROVIDER_IDENTIFIER)) {
             return ServerConstants.BOUNCY_CASTLE_FIPS_PROVIDER_IDENTIFIER;
         }

--- a/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/ServerConstants.java
+++ b/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/ServerConstants.java
@@ -155,6 +155,11 @@ public final class ServerConstants {
     public static final String STS_NAME = "wso2carbon-sts";
     public static final String DEFAULT_PASSWORD_VALIDITY_PERIOD = "DefaultPasswordValidityPeriod";
 
+    // crypto provider related constants
+    public static final String BOUNCY_CASTLE_PROVIDER_IDENTIFIER = "BC";
+    public static final String BOUNCY_CASTLE_PROVIDER_CLASS = "org.bouncycastle.jce.provider.BouncyCastleProvider";
+    public static final String BOUNCY_CASTLE_FIPS_PROVIDER_IDENTIFIER = "BCFIPS";
+    public static final String BOUNCY_CASTLE_FIPS_PROVIDER_CLASS = "org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider";
 
     public static class Axis2ParameterNames {
         public static final String CONTEXT_ROOT = "contextRoot";

--- a/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/ServerConstants.java
+++ b/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/ServerConstants.java
@@ -160,6 +160,7 @@ public final class ServerConstants {
     public static final String BOUNCY_CASTLE_PROVIDER_CLASS = "org.bouncycastle.jce.provider.BouncyCastleProvider";
     public static final String BOUNCY_CASTLE_FIPS_PROVIDER_IDENTIFIER = "BCFIPS";
     public static final String BOUNCY_CASTLE_FIPS_PROVIDER_CLASS = "org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider";
+    public static final String JCE_PROVIDER_PARAMETER = "security.jce.provider";
 
     public static class Axis2ParameterNames {
         public static final String CONTEXT_ROOT = "contextRoot";

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -506,7 +506,7 @@
 
         <!-- bouncycastle -->
         <bouncycastle.version>1.70.0.wso2v1</bouncycastle.version>
-        <imp.pkg.version.bcp>[1.52.0, 2.0.0)</imp.pkg.version.bcp>
+        <imp.pkg.version.bcp>[1.0.0, 2.0.0)</imp.pkg.version.bcp>
 
         <!--BPS specific-->
         <saxon-bps.wso2.version.human-task>9.0.0.x-wso2v1</saxon-bps.wso2.version.human-task>


### PR DESCRIPTION
## Purpose
This PR makes the JCE provider configurable which was hardcoded to BouncyCastle non-fips provider in order to achieve FIPS compliance.

Resolves https://github.com/wso2/api-manager/issues/1616