### PR TITLE
Append escape character along with underscore when filtering users by name

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/JDBCRealmConstants.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/JDBCRealmConstants.java
@@ -34,6 +34,7 @@ public final class JDBCRealmConstants {
     public static final String GET_SHARED_ROLE_LIST_H2 = "GetSharedRoleListSQLH2";
     public static final String GET_USER_FILTER = "UserFilterSQL";
     public static final String GET_USER_FILTER_WITH_ID = "UserFilterWithIDSQL";
+    public static final String GET_USER_FILTER_WITH_ID_WITH_ESCAPE = "UserFilterWithIDWithEscapeSQL";
     public static final String GET_USER_FILTER_WITH_ESCAPE = "UserFilterSQLWithEscape";
     public static final String GET_USER_FILTER_PAGINATED = "UserFilterPaginatedSQL";
     public static final String GET_USER_FILTER_PAGINATED_WITH_ID = "UserFilterPaginatedWithIDSQL";
@@ -168,6 +169,8 @@ public final class JDBCRealmConstants {
     public static final String GET_USER_FILTER_SQL = "SELECT UM_USER_NAME FROM UM_USER WHERE UM_USER_NAME LIKE ? AND UM_TENANT_ID=? ORDER BY UM_USER_NAME";
     public static final String GET_USER_FILTER_WITH_ID_SQL = "SELECT UM_USER_ID, UM_USER_NAME FROM UM_USER WHERE "
             + "UM_USER_NAME LIKE ? AND UM_TENANT_ID=? ORDER BY UM_USER_NAME";
+    public static final String GET_USER_FILTER_WITH_ID_WITH_ESCAPE_SQL = "SELECT UM_USER_ID, UM_USER_NAME FROM UM_USER WHERE "
+            + "UM_USER_NAME LIKE ? ESCAPE ? AND UM_TENANT_ID=? ORDER BY UM_USER_NAME";
     public static final String GET_USER_FILTER_SQL_WITH_ESCAPE = "SELECT UM_USER_NAME FROM UM_USER WHERE UM_USER_NAME "
             + "LIKE ? ESCAPE ? AND UM_TENANT_ID=? ORDER BY UM_USER_NAME";
     public static final String GET_USER_FILTER_PAGINATED_SQL = "SELECT UM_USER_NAME FROM UM_USER WHERE UM_USER_NAME " +

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/JDBCUserStoreConstants.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/JDBCUserStoreConstants.java
@@ -333,6 +333,9 @@ public class JDBCUserStoreConstants {
         setAdvancedProperty(JDBCRealmConstants.GET_USER_FILTER_WITH_ID, "User ID Filter SQL",
                 JDBCRealmConstants.GET_USER_FILTER_WITH_ID_SQL, "",
                 new Property[] { USER.getProperty(), SQL.getProperty(), FALSE.getProperty() });
+        setAdvancedProperty(JDBCRealmConstants.GET_USER_FILTER_WITH_ID_WITH_ESCAPE, "User ID Filter SQL With Escape",
+                JDBCRealmConstants.GET_USER_FILTER_WITH_ID_WITH_ESCAPE_SQL, "",
+                new Property[] { USER.getProperty(), SQL.getProperty(), FALSE.getProperty() });
         setAdvancedProperty(JDBCRealmConstants.GET_USER_FILTER_WITH_ESCAPE, "User Filter SQL With Escape",
                 JDBCRealmConstants.GET_USER_FILTER_SQL_WITH_ESCAPE, "",
                 new Property[] { USER.getProperty(), SQL.getProperty(), FALSE.getProperty() });
@@ -343,6 +346,10 @@ public class JDBCUserStoreConstants {
         setAdvancedProperty(JDBCCaseInsensitiveConstants.GET_USER_FILTER_WITH_ID_CASE_INSENSITIVE,
                 "User Filter With ID SQL With Case Insensitive Username",
                 JDBCCaseInsensitiveConstants.GET_USER_FILTER_WITH_ID_SQL_CASE_INSENSITIVE, "",
+                new Property[] { USER.getProperty(), SQL.getProperty(), FALSE.getProperty() });
+        setAdvancedProperty(JDBCCaseInsensitiveConstants.GET_USER_FILTER_WITH_ID_CASE_INSENSITIVE_WITH_ESCAPE,
+                "User Filter With ID SQL Case Insensitive Username With Escape",
+                JDBCCaseInsensitiveConstants.GET_USER_FILTER_WITH_ID_SQL_CASE_INSENSITIVE_WITH_ESCAPE, "",
                 new Property[] { USER.getProperty(), SQL.getProperty(), FALSE.getProperty() });
         setAdvancedProperty(JDBCCaseInsensitiveConstants.GET_USER_FILTER_CASE_INSENSITIVE_WITH_ESCAPE,
                 "User Filter SQL With Case Insensitive Username With Escape",

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCUserStoreManager.java
@@ -89,6 +89,7 @@ public class UniqueIDJDBCUserStoreManager extends JDBCUserStoreManager {
 
     private static final String QUERY_FILTER_STRING_ANY = "*";
     private static final String SQL_FILTER_STRING_ANY = "%";
+    private static final String SQL_FILTER_CHAR_ESCAPE = "\\";
     private static final String CASE_INSENSITIVE_USERNAME = "CaseInsensitiveUsername";
     private static final String SHA_1_PRNG = "SHA1PRNG";
     private static final String DB2 = "db2";
@@ -178,7 +179,6 @@ public class UniqueIDJDBCUserStoreManager extends JDBCUserStoreManager {
             if (filter != null && filter.trim().length() != 0) {
                 filter = filter.trim();
                 filter = filter.replace("*", "%");
-                filter = filter.replace("?", "_");
             } else {
                 filter = "%";
             }
@@ -191,17 +191,27 @@ public class UniqueIDJDBCUserStoreManager extends JDBCUserStoreManager {
                 throw new UserStoreException("Attempts to establish a connection with the data source has failed.");
             }
 
-            if (isCaseSensitiveUsername()) {
-                sqlStmt = realmConfig.getUserStoreProperty(JDBCRealmConstants.GET_USER_FILTER_WITH_ID);
+            if (filter.contains("_")) {
+                filter = filter.replaceAll("_", "\\\\_");
+                sqlStmt = getUserFilterQuery(JDBCRealmConstants.GET_USER_FILTER_WITH_ID_WITH_ESCAPE,
+                        JDBCCaseInsensitiveConstants.GET_USER_FILTER_WITH_ID_CASE_INSENSITIVE_WITH_ESCAPE);
             } else {
-                sqlStmt = realmConfig
-                        .getUserStoreProperty(JDBCCaseInsensitiveConstants.GET_USER_FILTER_WITH_ID_CASE_INSENSITIVE);
+                sqlStmt = getUserFilterQuery(JDBCRealmConstants.GET_USER_FILTER_WITH_ID,
+                        JDBCCaseInsensitiveConstants.GET_USER_FILTER_WITH_ID_CASE_INSENSITIVE);
             }
 
+            filter = filter.replace("?", "_");
             prepStmt = dbConnection.prepareStatement(sqlStmt);
             prepStmt.setString(1, filter);
-            if (sqlStmt.contains(UserCoreConstants.UM_TENANT_COLUMN)) {
-                prepStmt.setInt(2, tenantId);
+            if (sqlStmt.toUpperCase().contains(UserCoreConstants.SQL_ESCAPE_KEYWORD)) {
+                prepStmt.setString(2, SQL_FILTER_CHAR_ESCAPE);
+                if (sqlStmt.contains(UserCoreConstants.UM_TENANT_COLUMN)) {
+                    prepStmt.setInt(3, tenantId);
+                }
+            } else {
+                if (sqlStmt.contains(UserCoreConstants.UM_TENANT_COLUMN)) {
+                    prepStmt.setInt(2, tenantId);
+                }
             }
 
             prepStmt.setMaxRows(maxItemLimit);
@@ -276,6 +286,14 @@ public class UniqueIDJDBCUserStoreManager extends JDBCUserStoreManager {
         }
         return users;
 
+    }
+
+    private String getUserFilterQuery(String caseSensitiveQueryPropertyName, String caseInsensitiveQueryPropertyName) {
+
+        if (isCaseSensitiveUsername()) {
+            return realmConfig.getUserStoreProperty(caseSensitiveQueryPropertyName);
+        }
+        return realmConfig.getUserStoreProperty(caseInsensitiveQueryPropertyName);
     }
 
     @Override

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/caseinsensitive/JDBCCaseInsensitiveConstants.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/caseinsensitive/JDBCCaseInsensitiveConstants.java
@@ -26,6 +26,8 @@ public class JDBCCaseInsensitiveConstants {
             "SelectUserIDFromUserNameSQLCaseInsensitive";
     public static final String GET_USER_FILTER_CASE_INSENSITIVE = "UserFilterSQLCaseInsensitive";
     public static final String GET_USER_FILTER_WITH_ID_CASE_INSENSITIVE = "UserFilterWithIDSQLCaseInsensitive";
+    public static final String GET_USER_FILTER_WITH_ID_CASE_INSENSITIVE_WITH_ESCAPE =
+            "UserFilterWithIDSQLCaseInsensitiveWithEscape";
     public static final String GET_USER_FILTER_CASE_INSENSITIVE_WITH_ESCAPE = "UserFilterSQLCaseInsensitiveWithEscape";
     public static final String GET_USER_FILTER_CASE_INSENSITIVE_PAGINATED = "UserFilterPaginatedSQLCaseInsensitive";
     public static final String GET_USER_FILTER_WITH_ID_CASE_INSENSITIVE_PAGINATED =
@@ -93,6 +95,9 @@ public class JDBCCaseInsensitiveConstants {
             "(UM_USER_NAME) LIKE LOWER(?) AND UM_TENANT_ID=? ORDER BY UM_USER_NAME";
     public static final String GET_USER_FILTER_WITH_ID_SQL_CASE_INSENSITIVE = "SELECT UM_USER_ID, UM_USER_NAME FROM "
             + "UM_USER WHERE LOWER(UM_USER_NAME) LIKE LOWER(?) AND UM_TENANT_ID=? ORDER BY UM_USER_NAME";
+    public static final String GET_USER_FILTER_WITH_ID_SQL_CASE_INSENSITIVE_WITH_ESCAPE = "SELECT UM_USER_ID, " +
+            "UM_USER_NAME FROM UM_USER WHERE LOWER(UM_USER_NAME) LIKE LOWER(?) ESCAPE ? AND UM_TENANT_ID=? ORDER BY " +
+            "UM_USER_NAME";
     public static final String GET_USER_FILTER_SQL_CASE_INSENSITIVE_WITH_ESCAPE = "SELECT UM_USER_NAME FROM UM_USER "
             + "WHERE LOWER(UM_USER_NAME) LIKE LOWER(?) ESCAPE ? AND UM_TENANT_ID=? ORDER BY UM_USER_NAME";
     public static final String GET_USER_FILTER_CASE_INSENSITIVE_PAGINATED_SQL = "SELECT UM_USER_NAME FROM UM_USER " +

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/util/JDBCRealmUtil.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/util/JDBCRealmUtil.java
@@ -125,6 +125,10 @@ public class JDBCRealmUtil {
             properties.put(JDBCRealmConstants.GET_USER_FILTER_WITH_ID,
                     JDBCRealmConstants.GET_USER_FILTER_WITH_ID_SQL);
         }
+        if (!properties.containsKey(JDBCRealmConstants.GET_USER_FILTER_WITH_ID_WITH_ESCAPE)) {
+            properties.put(JDBCRealmConstants.GET_USER_FILTER_WITH_ID_WITH_ESCAPE,
+                    JDBCRealmConstants.GET_USER_FILTER_WITH_ID_WITH_ESCAPE_SQL);
+        }
         if (!properties.containsKey(JDBCRealmConstants.GET_USER_FILTER_WITH_ESCAPE)) {
             properties.put(JDBCRealmConstants.GET_USER_FILTER_WITH_ESCAPE,
                     JDBCRealmConstants.GET_USER_FILTER_SQL_WITH_ESCAPE);
@@ -570,6 +574,10 @@ public class JDBCRealmUtil {
         if (!properties.containsKey(JDBCCaseInsensitiveConstants.GET_USER_FILTER_WITH_ID_CASE_INSENSITIVE)) {
             properties.put(JDBCCaseInsensitiveConstants.GET_USER_FILTER_WITH_ID_CASE_INSENSITIVE,
                     JDBCCaseInsensitiveConstants.GET_USER_FILTER_WITH_ID_SQL_CASE_INSENSITIVE);
+        }
+        if (!properties.containsKey(JDBCCaseInsensitiveConstants.GET_USER_FILTER_WITH_ID_CASE_INSENSITIVE_WITH_ESCAPE)) {
+            properties.put(JDBCCaseInsensitiveConstants.GET_USER_FILTER_WITH_ID_CASE_INSENSITIVE_WITH_ESCAPE,
+                    JDBCCaseInsensitiveConstants.GET_USER_FILTER_WITH_ID_SQL_CASE_INSENSITIVE_WITH_ESCAPE);
         }
         if (!properties.containsKey(JDBCCaseInsensitiveConstants.GET_USER_FILTER_CASE_INSENSITIVE_WITH_ESCAPE)) {
             properties.put(JDBCCaseInsensitiveConstants.GET_USER_FILTER_CASE_INSENSITIVE_WITH_ESCAPE,


### PR DESCRIPTION
## Purpose
> Most of the databases use the `_` character as a wild card operator when matching patterns. Due to that  we have to manually add escape character `\` in case of checking in order to avoid the issue of username having `_` characters when executing the filter operations (filter based on patterns).

## Related Issues

- https://github.com/wso2/product-is/issues/15638

## Approach

The affected user store manager was `UniqueIDJDBCUserStoreManager` and it's implementations.
The LDAP based user store managers doesn't impacted by this issue.

Similar work done for the `JDBCUserStoreManager` was referenced. 
- https://github.com/wso2/carbon-kernel/pull/2288

Should test will following database types.
- [x] H2
- [x] PostgreSQL
- [x] SQL Server
- [x] MySQL
- [x] ORACLE
- [x] DB2 
