### PR TITLE
Skiping throwing error when the resource is already available.

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/util/DatabaseUtil.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/util/DatabaseUtil.java
@@ -1007,6 +1007,13 @@ public class DatabaseUtil {
             }
             dbConnection.commit();
         } catch (SQLException e) {
+            if (e.getMessage().contains("Cannot insert duplicate key in object")) {
+                if (log.isDebugEnabled()) {
+                    // Refer https://www.rfc-editor.org/rfc/rfc7644#section-3.5.2.1
+                    log.debug("The resource is already added. Hence, skipping the error.", e);
+                }
+                return;
+            }
             String errorMessage = "Using sql : " + sqlStmt + " " + e.getMessage();
             if (log.isDebugEnabled()) {
                 log.debug(errorMessage, e);

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/util/DatabaseUtil.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/util/DatabaseUtil.java
@@ -1007,7 +1007,7 @@ public class DatabaseUtil {
             }
             dbConnection.commit();
         } catch (SQLException e) {
-            if (e.getMessage().contains("Cannot insert duplicate key in object")) {
+            if (e.getErrorCode() == 2627) { // SQL Server error code for duplicate entry.
                 if (log.isDebugEnabled()) {
                     // Refer https://www.rfc-editor.org/rfc/rfc7644#section-3.5.2.1
                     log.debug("The resource is already added. Hence, skipping the error.", e);


### PR DESCRIPTION
## Purpose
* According to the https://www.rfc-editor.org/rfc/rfc7644#section-3.5.2.1, we should not return any error when the resource is already available when using the add operation.