### PR TITLE
Fix incorrect if condition

### DIFF
--- a/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/init/CarbonServerManager.java
+++ b/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/init/CarbonServerManager.java
@@ -670,7 +670,7 @@ public final class CarbonServerManager implements Controllable {
 
             if (!(exServicePath != null && exServicePath.equals(servicePath) &&
                     exContext != null && exContext.equals(contextRoot) &&
-                    exHost != null && exHost.equals(contextRoot))) {
+                    exHost != null && exHost.equals(requestIP))) {
                 resource.setProperty(SERVICE_PATH, servicePath);
                 resource.setProperty(BUNDLE_CONTEXT_ROOT, contextRoot);
                 resource.setProperty(HOST_NAME, requestIP);


### PR DESCRIPTION
## Purpose
At the server startup, connection props resource (path: /_system/config/repository/connection, name: props) is written to the registry regardless of its availability in the database already (if it is already available, it will be deleted and added again).

While observing the reason for this, we noticed this is happening due to a incorrect if condition, which is fixed in this PR.