### PR TITLE
Fixing log overriding issue when running as a windows service

### DIFF
--- a/distribution/kernel/carbon-home/bin/yajsw/wrapper.conf
+++ b/distribution/kernel/carbon-home/bin/yajsw/wrapper.conf
@@ -106,3 +106,4 @@ wrapper.java.additional.25 = -Dfile.encoding=UTF8
 wrapper.java.additional.26 = -DworkerNode=false
 wrapper.java.additional.27 = -Dhttpclient.hostnameVerifier=DefaultAndLocalhost
 wrapper.java.additional.28 = -Dcarbon.new.config.dir.path=${carbon_home}/repository/resources/conf
+wrapper.java.additional.29 = -Djava.util.logging.manager=org.apache.juli.ClassLoaderLogManager


### PR DESCRIPTION
Adding fixes related to https://github.com/wso2/docs-apim/issues/6958 to the sample wrapper.conf file packed into the product