### PR TITLE
 Fixing log overriding issue when running as a windows service

### DIFF
--- a/distribution/kernel/carbon-home/bin/yajsw/wrapper.conf
+++ b/distribution/kernel/carbon-home/bin/yajsw/wrapper.conf
@@ -107,3 +107,4 @@ wrapper.java.additional.26 = -Dfile.encoding=UTF8
 wrapper.java.additional.27 = -DworkerNode=false
 wrapper.java.additional.28 = -Dhttpclient.hostnameVerifier=DefaultAndLocalhost
 wrapper.java.additional.29 = -Dcarbon.new.config.dir.path=${carbon_home}/repository/resources/conf
+wrapper.java.additional.30 = -Djava.util.logging.manager=org.apache.juli.ClassLoaderLogManager


### PR DESCRIPTION
Adding fixes related to https://github.com/wso2/docs-apim/issues/6958 to the sample wrapper.conf file packed into the product