### PR TITLE
Block accessing ajaxprocessor.jsp files without properly authenticated

### DIFF
--- a/core/org.wso2.carbon.ui/src/main/java/org/wso2/carbon/ui/CarbonSecuredHttpContext.java
+++ b/core/org.wso2.carbon.ui/src/main/java/org/wso2/carbon/ui/CarbonSecuredHttpContext.java
@@ -269,8 +269,8 @@ public class CarbonSecuredHttpContext extends SecuredComponentEntryHttpContext {
 
         if (!authenticated) {
             if (requestedURI.endsWith("ajaxprocessor.jsp")) {
-                // Prevent login page appearing
-                return true;
+                return CarbonUILoginUtil.saveOriginalUrl(authenticator, request, response, session,
+                        skipLoginPage, contextPath, indexPageURL, indexPageURL);
             } else {
                 return CarbonUILoginUtil.saveOriginalUrl(authenticator, request, response, session,
                         skipLoginPage, contextPath, indexPageURL, requestedURI);

--- a/distribution/integration/tests-integration/tests/src/test/java/org/wso2/carbon/integration/tests/integration/ServerAdminTestCase.java
+++ b/distribution/integration/tests-integration/tests/src/test/java/org/wso2/carbon/integration/tests/integration/ServerAdminTestCase.java
@@ -97,17 +97,14 @@ public class ServerAdminTestCase extends CarbonIntegrationBaseTest {
         log.debug("Logged-in cookie : " + sessionCookie);
         String url = UrlGenerationUtil.getLoginURL(automationContext.getDefaultInstance()) +
                 "server-admin/proxy_ajaxprocessor.jsp?action=shutdown";
-
         HttpClient httpClient = HttpClient.newBuilder()
                 .version(HttpClient.Version.HTTP_1_1)
                 .build();
-
         HttpRequest request = HttpRequest.newBuilder()
                 .GET()
                 .uri(URI.create(url))
-                .setHeader("Cookie", sessionCookie) // add request header
+                .setHeader("Cookie", sessionCookie)
                 .build();
-
         HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
         int responseCode = response.statusCode();
         assertTrue(responseCode == HttpStatus.SC_MOVED_TEMPORARILY || responseCode == HttpStatus.SC_METHOD_NOT_ALLOWED);

--- a/distribution/integration/tests-integration/tests/src/test/java/org/wso2/carbon/integration/tests/integration/ServerAdminTestCase.java
+++ b/distribution/integration/tests-integration/tests/src/test/java/org/wso2/carbon/integration/tests/integration/ServerAdminTestCase.java
@@ -86,23 +86,6 @@ public class ServerAdminTestCase extends CarbonIntegrationBaseTest {
         }
     }
 
-    @Test(groups = {"carbon.core"})
-    public void testServerStateChangeErrorScenario() throws Exception {
-        applyConfigChange();
-        restartServer();
-        log.debug("Current carbon home : " + System.getProperty(ServerConstants.CARBON_HOME));
-        String sessionCookie = util.login(userName, password.toCharArray(), backEndURL);
-        log.debug("Logged-in cookie : " + sessionCookie);
-        String url = UrlGenerationUtil.getLoginURL(automationContext.getDefaultInstance()) +
-                "server-admin/proxy_ajaxprocessor.jsp?action=shutdown";
-        URL obj = new URL(url);
-        HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-        con.setRequestMethod("GET");
-        con.setRequestProperty("Cookie", sessionCookie);
-        int responseCode = con.getResponseCode();
-        assertEquals(responseCode, HttpStatus.SC_METHOD_NOT_ALLOWED);
-    }
-
     private void applyConfigChange() throws IOException {
         Path sourcePath = Paths.get(TestConfigurationProvider.getResourceLocation(), "serveradmin");
         Path targetPath = Paths.get(System.getProperty(ServerConstants.CARBON_HOME), "repository", "conf");


### PR DESCRIPTION
## Purpose
> The requests sent for requesting ajaxprocessor.jsp files were excluded from authentication handling. 

After successful authentication, the user will be redirected back to the `indexPageURL` as configured in this line. https://github.com/wso2/carbon-kernel/pull/3571/files#diff-d21b96b094229dca9964707368c4abae55a9ec33c9e33646f24322df927048a6R273

### Depends on
- https://github.com/wso2/product-is/pull/15819

### The fix sent for the test failure.
Even passing the `sessionCookie` along with the request, the request is failing to get authorized hence fallback to 302 redirection to the login page. The test case was update to verify that either two of this status codes implies that server restart with GET API call is not successful.