### PR TITLE
Fix NPE due to duplicate username for remote userstore

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
@@ -250,7 +250,7 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
                 String errorMessage = e.getCause().getCause().getMessage();
                 if (isClientException) {
                     if (StringUtils.isBlank(errorCode)) {
-                        throw new UserStoreClientException(errorCode, e);
+                        throw new UserStoreClientException(errorMessage, e);
                     }
                     throw new UserStoreClientException(errorMessage, errorCode, e);
                 } else {


### PR DESCRIPTION
## Purpose
> When there are duplicate users for same email in the remote userstore, errors are not properly handled as the error messages are not properly passed.

