### PR TITLE
Remove SHA1 default usage

### DIFF
--- a/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/util/SignatureUtil.java
+++ b/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/util/SignatureUtil.java
@@ -35,9 +35,11 @@ import static org.wso2.carbon.core.util.CryptoUtil.getJCEProvider;
 
 public class SignatureUtil {
 
-    private static final String THUMB_DIGEST_ALGORITHM = "SHA-1";
+    private static final String THUMB_DIGEST_ALGORITHM_SHA1 = "SHA-1";
+    private static final String THUMB_DIGEST_ALGORITHM_SHA256 = "SHA-256";
+    private static final String signatureAlgorithmSHA1 = "SHA1withRSA";
+    private static final String signatureAlgorithmSHA256 = "SHA256withRSA";
 
-    private static String signatureAlgorithm = "SHA1withRSA";
 
     private SignatureUtil() {
         // hide default constructor for utility class
@@ -69,7 +71,14 @@ public class SignatureUtil {
      * @throws Exception
      */
     public static byte[] getThumbPrintForAlias(String alias) throws Exception {
-        MessageDigest sha = MessageDigest.getInstance(THUMB_DIGEST_ALGORITHM);
+
+        MessageDigest sha;
+        if (Boolean.parseBoolean(ServerConfiguration.getInstance().getFirstProperty(
+                ServerConstants.SIGNATURE_UTIL_ENABLE_SHA256_ALGO))) {
+            sha = MessageDigest.getInstance(THUMB_DIGEST_ALGORITHM_SHA256);
+        } else {
+            sha = MessageDigest.getInstance(THUMB_DIGEST_ALGORITHM_SHA1);
+        }
         sha.reset();
         Certificate cert = getCertificate(alias);
         sha.update(cert.getEncoded());
@@ -86,7 +95,14 @@ public class SignatureUtil {
      * @throws Exception
      */
     public static boolean validateSignature(byte[] thumb, String data, byte[] signature) throws Exception {
-        Signature signer = Signature.getInstance(signatureAlgorithm, getJCEProvider());
+
+        Signature signer;
+        if (Boolean.parseBoolean(ServerConfiguration.getInstance().getFirstProperty(
+                ServerConstants.SIGNATURE_UTIL_ENABLE_SHA256_ALGO))) {
+            signer = Signature.getInstance(signatureAlgorithmSHA256, getJCEProvider());
+        } else {
+            signer = Signature.getInstance(signatureAlgorithmSHA1, getJCEProvider());
+        }
         signer.initVerify(getPublicKey(thumb));
         signer.update(data.getBytes());
         return signer.verify(signature);
@@ -101,7 +117,14 @@ public class SignatureUtil {
      * @throws Exception
      */
     public static boolean validateSignature(String data, byte[] signature) throws Exception {
-        Signature signer = Signature.getInstance(signatureAlgorithm, getJCEProvider());
+
+        Signature signer;
+        if (Boolean.parseBoolean(ServerConfiguration.getInstance().getFirstProperty(
+                ServerConstants.SIGNATURE_UTIL_ENABLE_SHA256_ALGO))) {
+            signer = Signature.getInstance(signatureAlgorithmSHA256, getJCEProvider());
+        } else {
+            signer = Signature.getInstance(signatureAlgorithmSHA1, getJCEProvider());
+        }
         signer.initVerify(getDefaultPublicKey());
         signer.update(data.getBytes());
         return signer.verify(signature);
@@ -115,7 +138,14 @@ public class SignatureUtil {
      * @throws Exception
      */
     public static byte[] doSignature(String data) throws Exception {
-        Signature signer = Signature.getInstance(signatureAlgorithm, getJCEProvider());
+
+        Signature signer;
+        if (Boolean.parseBoolean(ServerConfiguration.getInstance().getFirstProperty(
+                ServerConstants.SIGNATURE_UTIL_ENABLE_SHA256_ALGO))) {
+            signer = Signature.getInstance(signatureAlgorithmSHA256, getJCEProvider());
+        } else {
+            signer = Signature.getInstance(signatureAlgorithmSHA1, getJCEProvider());
+        }
         signer.initSign(getDefaultPrivateKey());
         signer.update(data.getBytes());
         return signer.sign();
@@ -149,7 +179,13 @@ public class SignatureUtil {
         KeyStore keyStore = keyStoreMan.getPrimaryKeyStore();
         PublicKey pubKey = null;
         Certificate cert = null;
-        MessageDigest sha = MessageDigest.getInstance(THUMB_DIGEST_ALGORITHM);
+        MessageDigest sha;
+        if (Boolean.parseBoolean(ServerConfiguration.getInstance().getFirstProperty(
+                ServerConstants.SIGNATURE_UTIL_ENABLE_SHA256_ALGO))) {
+            sha = MessageDigest.getInstance(THUMB_DIGEST_ALGORITHM_SHA256);
+        } else {
+            sha = MessageDigest.getInstance(THUMB_DIGEST_ALGORITHM_SHA1);
+        }
         sha.reset();
         for (Enumeration<String> e = keyStore.aliases(); e.hasMoreElements(); ) {
             String alias = e.nextElement();

--- a/core/org.wso2.carbon.ui/src/main/java/org/wso2/carbon/ui/filters/csrf/CSRFConstants.java
+++ b/core/org.wso2.carbon.ui/src/main/java/org/wso2/carbon/ui/filters/csrf/CSRFConstants.java
@@ -22,7 +22,7 @@ import java.util.regex.Pattern;
 
 public class CSRFConstants {
     public static final String CSRF_TOKEN = "csrftoken";
-    public static final String CSRF_TOKEN_PRNG = "SHA1PRNG";
+    public static final String CSRF_TOKEN_PRNG = "DRBG";
 
     public static final String METHOD_POST = "POST";
 

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/JDBCUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/JDBCUserStoreManager.java
@@ -102,7 +102,7 @@ public class JDBCUserStoreManager extends AbstractUserStoreManager {
     private static final String SQL_FILTER_CHAR_ESCAPE = "\\";
     public static final String QUERY_BINDING_SYMBOL = "?";
     private static final String CASE_INSENSITIVE_USERNAME = "CaseInsensitiveUsername";
-    private static final String SHA_1_PRNG = "SHA1PRNG";
+    private static final String RANDOM_ALG_DRBG = "DRBG";
 
     protected DataSource jdbcds = null;
     protected Random random = new Random();
@@ -2641,13 +2641,13 @@ public class JDBCUserStoreManager extends AbstractUserStoreManager {
     private String generateSaltValue() {
         String saltValue = null;
         try {
-            SecureRandom secureRandom = SecureRandom.getInstance(SHA_1_PRNG);
+            SecureRandom secureRandom = SecureRandom.getInstance(RANDOM_ALG_DRBG);
             byte[] bytes = new byte[16];
             //secureRandom is automatically seeded by calling nextBytes
             secureRandom.nextBytes(bytes);
             saltValue = Base64.encode(bytes);
         } catch (NoSuchAlgorithmException e) {
-            throw new RuntimeException("SHA1PRNG algorithm could not be found.");
+            throw new RuntimeException("DRBG algorithm could not be found.");
         }
         return saltValue;
     }

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCUserStoreManager.java
@@ -91,7 +91,7 @@ public class UniqueIDJDBCUserStoreManager extends JDBCUserStoreManager {
     private static final String SQL_FILTER_STRING_ANY = "%";
     private static final String SQL_FILTER_CHAR_ESCAPE = "\\";
     private static final String CASE_INSENSITIVE_USERNAME = "CaseInsensitiveUsername";
-    private static final String SHA_1_PRNG = "SHA1PRNG";
+    private static final String RANDOM_ALG_DRBG = "DRBG";
     private static final String DB2 = "db2";
     private static final String H2 = "h2";
     private static final String MSSQL = "mssql";
@@ -2136,13 +2136,13 @@ public class UniqueIDJDBCUserStoreManager extends JDBCUserStoreManager {
 
         String saltValue;
         try {
-            SecureRandom secureRandom = SecureRandom.getInstance(SHA_1_PRNG);
+            SecureRandom secureRandom = SecureRandom.getInstance(RANDOM_ALG_DRBG);
             byte[] bytes = new byte[16];
             //secureRandom is automatically seeded by calling nextBytes
             secureRandom.nextBytes(bytes);
             saltValue = Base64.encode(bytes);
         } catch (NoSuchAlgorithmException e) {
-            throw new RuntimeException("SHA1PRNG algorithm could not be found.");
+            throw new RuntimeException("DRBG algorithm could not be found.");
         }
         return saltValue;
     }

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/system/SystemUserRoleManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/system/SystemUserRoleManager.java
@@ -52,7 +52,7 @@ public class SystemUserRoleManager {
     private static Log log = LogFactory.getLog(SystemUserRoleManager.class);
     int tenantId;
     private DataSource dataSource;
-    private static final String SHA_1_PRNG = "SHA1PRNG";
+    private static final String RANDOM_ALG_DRBG = "DRBG";
 
     public SystemUserRoleManager(DataSource dataSource, int tenantId) throws UserStoreException {
         super();
@@ -373,13 +373,13 @@ public class SystemUserRoleManager {
 
             String saltValue = null;
             try {
-                SecureRandom secureRandom = SecureRandom.getInstance(SHA_1_PRNG);
+                SecureRandom secureRandom = SecureRandom.getInstance(RANDOM_ALG_DRBG);
                 byte[] bytes = new byte[16];
                 //secureRandom is automatically seeded by calling nextBytes
                 secureRandom.nextBytes(bytes);
                 saltValue = Base64.encode(bytes);
             } catch (NoSuchAlgorithmException e) {
-                throw new RuntimeException("SHA1PRNG algorithm could not be found.");
+                throw new RuntimeException("DRBG algorithm could not be found.");
             }
 
             String password = this.preparePassword(credentialObj, saltValue);

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/util/UserCoreUtil.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/util/UserCoreUtil.java
@@ -402,7 +402,7 @@ public final class UserCoreUtil {
 
         try {
             // the secure random
-            SecureRandom prng = SecureRandom.getInstance("SHA1PRNG");
+            SecureRandom prng = SecureRandom.getInstance("DRBG");
             for (int i = 0; i < length; i++) {
                 password[i] = passwordChars.charAt(prng.nextInt(passwordFeed.length()));
             }

--- a/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/ServerConstants.java
+++ b/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/ServerConstants.java
@@ -158,6 +158,7 @@ public final class ServerConstants {
     public static final String JCE_PROVIDER = "JCEProvider";
     public static final String JCE_PROVIDER_BC = "BC";
     public static final String JCE_PROVIDER_BCFIPS = "BCFIPS";
+    public static final String SIGNATURE_UTIL_ENABLE_SHA256_ALGO = "SignatureUtil.EnableSHA256Algo";
 
     public static class Axis2ParameterNames {
         public static final String CONTEXT_ROOT = "contextRoot";

--- a/distribution/kernel/carbon-home/repository/conf/carbon.xml
+++ b/distribution/kernel/carbon-home/repository/conf/carbon.xml
@@ -718,4 +718,9 @@
     <!-- Configure JCE provider -->
     <JCEProvider>BC</JCEProvider>
 
+    <!-- Configure SignatureUtil algorithms -->
+    <SignatureUtil>
+        <EnableSHA256Algo>true</EnableSHA256Algo>
+    </SignatureUtil>
+
 </Server>

--- a/distribution/kernel/carbon-home/repository/conf/security/Owasp.CsrfGuard.Carbon.properties
+++ b/distribution/kernel/carbon-home/repository/conf/security/Owasp.CsrfGuard.Carbon.properties
@@ -321,10 +321,10 @@ org.owasp.csrfguard.TokenLength=32
 # The pseudo-random number generator property (org.owasp.csrfguard.PRNG) defines what PRNG should be used
 # to generate the OWASP CSRFGuard token. Always ensure this value references a cryptographically strong
 # pseudo-random number generator algorithm. The following configuration snippet sets the pseudo-random number
-# generator to SHA1PRNG:
+# generator to DRBG:
 #
-# org.owasp.csrfguard.PRNG=SHA1PRNG
-org.owasp.csrfguard.PRNG=SHA1PRNG
+# org.owasp.csrfguard.PRNG=DRBG
+org.owasp.csrfguard.PRNG=DRBG
 
 # Pseudo-random Number Generator Provider
 

--- a/distribution/kernel/carbon-home/repository/resources/conf/default.json
+++ b/distribution/kernel/carbon-home/repository/resources/conf/default.json
@@ -154,7 +154,7 @@
   "admin_console.authenticator.mutual_ssl_authenticator.config.WhiteListEnabled": false,
   "owasp.csrfguard.create_token_per_page": false,
   "owasp.csrfguard.token_length": "32",
-  "owasp.csrfguard.random_number_generator_algo": "SHA1PRNG",
+  "owasp.csrfguard.random_number_generator_algo": "DRBG",
   "owasp.csrfguard.js_servlet.x_request_with_header": "WSO2 CSRF Protection",
   "tomcat.global.session_timeout": "30m",
   "tomcat.management_console.session_timeout": "15m",

--- a/distribution/kernel/carbon-home/repository/resources/conf/default.json
+++ b/distribution/kernel/carbon-home/repository/resources/conf/default.json
@@ -219,6 +219,7 @@
   "versioning_configuration.enable_version_resources_on_change" : false,
   "sts.callback_handler" : "org.wso2.carbon.identity.sts.common.identity.provider.AttributeCallbackHandler",
   "tenant_mgt.enable_tenant_theme_mgt" : true,
-  "jce_provider.provider_name" : "BC"
+  "jce_provider.provider_name" : "BC",
+  "signature_util.enable_sha256_algo" : true
 
 }

--- a/distribution/kernel/carbon-home/repository/resources/conf/templates/repository/conf/carbon.xml.j2
+++ b/distribution/kernel/carbon-home/repository/resources/conf/templates/repository/conf/carbon.xml.j2
@@ -793,4 +793,9 @@
     {% if jce_provider.provider_name is defined %}
         <JCEProvider>{{jce_provider.provider_name}}</JCEProvider>
     {% endif %}
+
+    <!-- Configure SignatureUtil algorithms -->
+    <SignatureUtil>
+        <EnableSHA256Algo>{{signature_util.enable_sha256_algo}}</EnableSHA256Algo>
+    </SignatureUtil>
 </Server>

--- a/distribution/kernel/carbon-home/repository/resources/conf/templates/repository/conf/security/Owasp.CsrfGuard.Carbon.properties.j2
+++ b/distribution/kernel/carbon-home/repository/resources/conf/templates/repository/conf/security/Owasp.CsrfGuard.Carbon.properties.j2
@@ -326,9 +326,9 @@ org.owasp.csrfguard.TokenLength={{owasp.csrfguard.token_length}}
 # The pseudo-random number generator property (org.owasp.csrfguard.PRNG) defines what PRNG should be used
 # to generate the OWASP CSRFGuard token. Always ensure this value references a cryptographically strong
 # pseudo-random number generator algorithm. The following configuration snippet sets the pseudo-random number
-# generator to SHA1PRNG:
+# generator to DRBG:
 #
-# org.owasp.csrfguard.PRNG=SHA1PRNG
+# org.owasp.csrfguard.PRNG=DRBG
 org.owasp.csrfguard.PRNG={{owasp.csrfguard.random_number_generator_algo}}
 
 # Pseudo-random Number Generator Provider


### PR DESCRIPTION
### Proposed changes in this pull request

The default behavior of our products uses SHA1 which is no longer considered as secure. This PR changes the default usage to SHA256 in the following flows.
- CSRF token will be generated using DRBG algorithm instead of SHA1PRNG.
- Password salts will be generated using DRBG algorithm
- SignatureUtil signing and validation will be done using RSA SHA256.
- Certificate thumbprint generation in getThumbPrintForAlias() method will be done using SHA-256

### Migration impact
Thumbprint generation, signing and signature validation will be defaulted to using SHA-256. To revert this behavior, use the following deployment.toml configuration.
```
[signature_util]
enable_sha256_algo= false
```

### Related issues
 
- Issue https://github.com/wso2/product-is/issues/15793

### Related PRs

- PR https://github.com/wso2/carbon-identity-framework/pull/4567
- PR https://github.com/wso2-extensions/identity-outbound-auth-samlsso/pull/162
- PR https://github.com/wso2-extensions/identity-inbound-auth-sts/pull/136
- PR https://github.com/wso2-extensions/identity-metadata-saml2/pull/85
- PR https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/2076
- PR https://github.com/wso2/cipher-tool/pull/78
- PR https://github.com/wso2-extensions/identity-user-account-association/pull/47
- PR https://github.com/wso2-enterprise/asgardeo-website/pull/639
- PR https://github.com/wso2-extensions/identity-governance/pull/707
- PR https://github.com/wso2-extensions/identity-inbound-auth-openid/pull/92
- PR https://github.com/wso2-extensions/identity-outbound-auth-sms-otp/pull/173
- PR https://github.com/wso2-extensions/identity-outbound-auth-email-otp/pull/157

### Documentation

- PR https://github.com/wso2/docs-is/pull/3717


