### PR TITLE
Handle user not exist cases in the user stores when resolving user by name and id

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
@@ -12728,8 +12728,7 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
                 userID = doGetUserIDFromUserNameWithID(userName);
                 if (StringUtils.isEmpty(userID)) {
                     if (log.isDebugEnabled()) {
-                        log.debug(String.format("User with userName %s is not available in cache or database.",
-                                userName));
+                        log.debug("User with username " + userName + " is not available in cache or database.");
                     }
                     return null;
                 }

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
@@ -16238,7 +16238,6 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
                         log.debug("Could not resolve the user for user id: " + userID);
                     }
                 }
-
             }
         }
 

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
@@ -12648,6 +12648,11 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
         if (userName == null) {
             userName = getUserNameFromUserID(userID);
         }
+
+        if (StringUtils.isEmpty(userID) || StringUtils.isEmpty(userName)) {
+            throw new UserStoreClientException("User not found in the cache or database");
+        }
+
         if (StringUtils.isNotEmpty(userName) && userName.contains(UserCoreConstants.DOMAIN_SEPARATOR)) {
             domain = UserCoreUtil.extractDomainFromName(userName);
             userName = UserCoreUtil.removeDomainFromName(userName);
@@ -12721,6 +12726,13 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
         if (StringUtils.isEmpty(userID)) {
             if (isUniqueUserIdEnabledInUserStore(userStore)) {
                 userID = doGetUserIDFromUserNameWithID(userName);
+                if (StringUtils.isEmpty(userID)) {
+                    if (log.isDebugEnabled()) {
+                        log.debug(String.format("User with userName %s is not available in cache or database.",
+                                userName));
+                    }
+                    return null;
+                }
                 addToUserIDCache(userID, userName, userStore);
                 addToUserNameCache(userID, userName, userStore);
                 return userID;
@@ -16212,14 +16224,21 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
         Map<String, List<String>> domainAwareUsers = new HashMap<>();
         if (!userIDs.isEmpty()) {
             for (String userID : userIDs) {
-                User user = getUser(userID, null);
-                String domainName = user.getUserStoreDomain();
-                List<String> users = domainAwareUsers.get(domainName);
-                if (users == null) {
-                    users = new ArrayList<>();
-                    domainAwareUsers.put(domainName.toUpperCase(), users);
+                try {
+                    User user = getUser(userID, null);
+                    String domainName = user.getUserStoreDomain();
+                    List<String> users = domainAwareUsers.get(domainName);
+                    if (users == null) {
+                        users = new ArrayList<>();
+                        domainAwareUsers.put(domainName.toUpperCase(), users);
+                    }
+                    users.add(UserCoreUtil.removeDomainFromName(userID));
+                } catch (UserStoreClientException e) {
+                    if (log.isDebugEnabled()) {
+                        log.debug("Could not resolve the user for user id: " + userID);
+                    }
                 }
-                users.add(UserCoreUtil.removeDomainFromName(userID));
+
             }
         }
 


### PR DESCRIPTION
## Purpose

The `getUser(username, userId)` logic is intended to be executed for already existing user and it doesn't handle the cases where the external user store users getting deleted manually. 

### Related issues
- https://github.com/wso2/product-is/issues/15878