### PR TITLE
Show admin-banner ui in super tenant only

### DIFF
--- a/core/admin-advisory-mgt/org.wso2.carbon.admin.advisory.mgt.ui/src/main/resources/META-INF/component.xml
+++ b/core/admin-advisory-mgt/org.wso2.carbon.admin.advisory.mgt.ui/src/main/resources/META-INF/component.xml
@@ -29,6 +29,7 @@
             <style-class>manage</style-class>
             <icon>../admin-advisory-mgt/images/admin-adv.png</icon>
             <require-permission>/permission/admin/login</require-permission>
+            <require-super-tenant>true</require-super-tenant>
         </menu>
     </menus>
 </component>

--- a/core/admin-advisory-mgt/org.wso2.carbon.admin.advisory.mgt.ui/src/main/resources/META-INF/component.xml
+++ b/core/admin-advisory-mgt/org.wso2.carbon.admin.advisory.mgt.ui/src/main/resources/META-INF/component.xml
@@ -28,7 +28,7 @@
             <order>1</order>
             <style-class>manage</style-class>
             <icon>../admin-advisory-mgt/images/admin-adv.png</icon>
-            <require-permission>/permission/admin/login</require-permission>
+            <require-permission>/permission/admin</require-permission>
             <require-super-tenant>true</require-super-tenant>
         </menu>
     </menus>

--- a/core/admin-advisory-mgt/org.wso2.carbon.admin.advisory.mgt/src/main/resources/META-INF/services.xml
+++ b/core/admin-advisory-mgt/org.wso2.carbon.admin.advisory.mgt/src/main/resources/META-INF/services.xml
@@ -27,7 +27,7 @@
             org.wso2.carbon.admin.advisory.mgt.service.AdminAdvisoryManagementService
         </parameter>
         <operation name="saveAdminAdvisoryConfig">
-            <parameter name="AuthorizationAction" locked="true">/permission/admin/login</parameter>
+            <parameter name="AuthorizationAction" locked="true">/permission/admin</parameter>
         </operation>
         <operation name="getAdminAdvisoryConfig">
             <parameter name="DoAuthentication" locked="true">false</parameter>
@@ -36,7 +36,7 @@
         <parameter name="adminService" locked="true">true</parameter>
     </service>
 
-    <parameter name="AuthorizationAction" locked="false">/permission/admin/login</parameter>
+    <parameter name="AuthorizationAction" locked="false">/permission/admin</parameter>
     <parameter name="hiddenService" locked="false">false</parameter>
 
 </serviceGroup>


### PR DESCRIPTION
## Purpose
The admin advisory banner configured by the super admin is applied to all tenants. Therefore, we should not show the configuration UI component to other tenants. This PR makes the configuration UI component visible to super tenant only.

The PR also changes the permission level to all admin permissions (`/permission/admin`) to be able to configure the admin banner.

## Related Issues
- Issue https://github.com/wso2/product-is/issues/15521