### PR TITLE
Add backward compatibility for configured sql for case insensitive attributes

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/JDBCUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/JDBCUserStoreManager.java
@@ -4634,13 +4634,29 @@ public class JDBCUserStoreManager extends AbstractUserStoreManager {
         sqlBuilder.where("UA.UM_ATTR_NAME = ?", attributeName);
 
         if (ExpressionOperation.EQ.toString().equals(operation)) {
-            sqlBuilder.where("UA.UM_ATTR_VALUE = ?", attributeValue);
+            if (isCaseSensitiveUsername()) {
+                sqlBuilder.where("UA.UM_ATTR_VALUE = ?", attributeValue);
+            } else {
+                sqlBuilder.where("LOWER(UA.UM_ATTR_VALUE) = LOWER(?)", attributeValue);
+            }
         } else if (ExpressionOperation.EW.toString().equals(operation)) {
-            sqlBuilder.where("UA.UM_ATTR_VALUE LIKE ?", "%" + attributeValue);
+            if (isCaseSensitiveUsername()) {
+                sqlBuilder.where("UA.UM_ATTR_VALUE LIKE ?", "%" + attributeValue);
+            } else {
+                sqlBuilder.where("LOWER(UA.UM_ATTR_VALUE) LIKE LOWER(?)", "%" + attributeValue);
+            }
         } else if (ExpressionOperation.CO.toString().equals(operation)) {
-            sqlBuilder.where("UA.UM_ATTR_VALUE LIKE ?", "%" + attributeValue + "%");
+            if (isCaseSensitiveUsername()) {
+                sqlBuilder.where("UA.UM_ATTR_VALUE LIKE ?", "%" + attributeValue + "%");
+            } else {
+                sqlBuilder.where("LOWER(UA.UM_ATTR_VALUE) LIKE LOWER(?)", "%" + attributeValue + "%");
+            }
         } else if (ExpressionOperation.SW.toString().equals(operation)) {
-            sqlBuilder.where("UA.UM_ATTR_VALUE LIKE ?", attributeValue + "%");
+            if (isCaseSensitiveUsername()) {
+                sqlBuilder.where("UA.UM_ATTR_VALUE LIKE ?", attributeValue + "%");
+            } else {
+                sqlBuilder.where("LOWER(UA.UM_ATTR_VALUE) LIKE LOWER(?)", attributeValue + "%");
+            }
         }
     }
 
@@ -4662,13 +4678,29 @@ public class JDBCUserStoreManager extends AbstractUserStoreManager {
         sqlBuilder.updateSqlWithOROperation("UA.UM_ATTR_NAME = ?", attributeName);
 
         if (ExpressionOperation.EQ.toString().equals(operation)) {
-            sqlBuilder.where("UA.UM_ATTR_VALUE = ?", attributeValue);
+            if (isCaseSensitiveUsername()) {
+                sqlBuilder.where("UA.UM_ATTR_VALUE = ?", attributeValue);
+            } else {
+                sqlBuilder.where("LOWER(UA.UM_ATTR_VALUE) = LOWER(?)", attributeValue);
+            }
         } else if (ExpressionOperation.EW.toString().equals(operation)) {
-            sqlBuilder.where("UA.UM_ATTR_VALUE LIKE ?", "%" + attributeValue);
+            if (isCaseSensitiveUsername()) {
+                sqlBuilder.where("UA.UM_ATTR_VALUE LIKE ?", "%" + attributeValue);
+            } else {
+                sqlBuilder.where("LOWER(UA.UM_ATTR_VALUE) LIKE LOWER(?)", "%" + attributeValue);
+            }
         } else if (ExpressionOperation.CO.toString().equals(operation)) {
-            sqlBuilder.where("UA.UM_ATTR_VALUE LIKE ?", "%" + attributeValue + "%");
+            if (isCaseSensitiveUsername()) {
+                sqlBuilder.where("UA.UM_ATTR_VALUE LIKE ?", "%" + attributeValue + "%");
+            } else {
+                sqlBuilder.where("LOWER(UA.UM_ATTR_VALUE) LIKE LOWER(?)", "%" + attributeValue + "%");
+            }
         } else if (ExpressionOperation.SW.toString().equals(operation)) {
-            sqlBuilder.where("UA.UM_ATTR_VALUE LIKE ?", attributeValue + "%");
+            if (isCaseSensitiveUsername()) {
+                sqlBuilder.where("UA.UM_ATTR_VALUE LIKE ?", attributeValue + "%");
+            } else {
+                sqlBuilder.where("LOWER(UA.UM_ATTR_VALUE) LIKE LOWER(?)", attributeValue + "%");
+            }
         }
     }
 

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCUserStoreManager.java
@@ -3767,25 +3767,25 @@ public class UniqueIDJDBCUserStoreManager extends JDBCUserStoreManager {
             if (isCaseSensitiveUsername()) {
                 sqlBuilder.where("UA.UM_ATTR_VALUE = ?", attributeValue);
             } else {
-                sqlBuilder.where("LOWER(UA.UM_ATTR_VALUE) = ?", attributeValue.toLowerCase());
+                sqlBuilder.where("LOWER(UA.UM_ATTR_VALUE) = LOWER(?)", attributeValue);
             }
         } else if (ExpressionOperation.EW.toString().equals(operation)) {
             if (isCaseSensitiveUsername()) {
                 sqlBuilder.where("UA.UM_ATTR_VALUE LIKE ?", "%" + attributeValue);
             } else {
-                sqlBuilder.where("LOWER(UA.UM_ATTR_VALUE) LIKE ?", "%" + attributeValue.toLowerCase());
+                sqlBuilder.where("LOWER(UA.UM_ATTR_VALUE) LIKE LOWER(?)", "%" + attributeValue);
             }
         } else if (ExpressionOperation.CO.toString().equals(operation)) {
             if (isCaseSensitiveUsername()) {
                 sqlBuilder.where("UA.UM_ATTR_VALUE LIKE ?", "%" + attributeValue + "%");
             } else {
-                sqlBuilder.where("LOWER(UA.UM_ATTR_VALUE) LIKE ?", "%" + attributeValue.toLowerCase() + "%");
+                sqlBuilder.where("LOWER(UA.UM_ATTR_VALUE) LIKE LOWER(?)", "%" + attributeValue + "%");
             }
         } else if (ExpressionOperation.SW.toString().equals(operation)) {
             if (isCaseSensitiveUsername()) {
                 sqlBuilder.where("UA.UM_ATTR_VALUE LIKE ?", attributeValue + "%");
             } else {
-                sqlBuilder.where("LOWER(UA.UM_ATTR_VALUE) LIKE ?", attributeValue.toLowerCase() + "%");
+                sqlBuilder.where("LOWER(UA.UM_ATTR_VALUE) LIKE LOWER(?)", attributeValue + "%");
             }
         }
     }
@@ -3811,25 +3811,25 @@ public class UniqueIDJDBCUserStoreManager extends JDBCUserStoreManager {
             if (isCaseSensitiveUsername()) {
                 sqlBuilder.where("UA.UM_ATTR_VALUE = ?", attributeValue);
             } else {
-                sqlBuilder.where("LOWER(UA.UM_ATTR_VALUE) = ?", attributeValue.toLowerCase());
+                sqlBuilder.where("LOWER(UA.UM_ATTR_VALUE) = LOWER(?)", attributeValue);
             }
         } else if (ExpressionOperation.EW.toString().equals(operation)) {
             if (isCaseSensitiveUsername()) {
                 sqlBuilder.where("UA.UM_ATTR_VALUE LIKE ?", "%" + attributeValue);
             } else {
-                sqlBuilder.where("LOWER(UA.UM_ATTR_VALUE) LIKE ?", "%" + attributeValue.toLowerCase());
+                sqlBuilder.where("LOWER(UA.UM_ATTR_VALUE) LIKE LOWER(?)", "%" + attributeValue);
             }
         } else if (ExpressionOperation.CO.toString().equals(operation)) {
             if (isCaseSensitiveUsername()) {
                 sqlBuilder.where("UA.UM_ATTR_VALUE LIKE ?", "%" + attributeValue + "%");
             } else {
-                sqlBuilder.where("LOWER(UA.UM_ATTR_VALUE) LIKE ?", "%" + attributeValue.toLowerCase() + "%");
+                sqlBuilder.where("LOWER(UA.UM_ATTR_VALUE) LIKE LOWER(?)", "%" + attributeValue + "%");
             }
         } else if (ExpressionOperation.SW.toString().equals(operation)) {
             if (isCaseSensitiveUsername()) {
                 sqlBuilder.where("UA.UM_ATTR_VALUE LIKE ?", attributeValue + "%");
             } else {
-                sqlBuilder.where("LOWER(UA.UM_ATTR_VALUE) LIKE ?", attributeValue.toLowerCase() + "%");
+                sqlBuilder.where("LOWER(UA.UM_ATTR_VALUE) LIKE LOWER(?)", attributeValue + "%");
             }
         }
     }

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCUserStoreManager.java
@@ -3764,13 +3764,29 @@ public class UniqueIDJDBCUserStoreManager extends JDBCUserStoreManager {
         sqlBuilder.where("UA.UM_ATTR_NAME = ?", attributeName);
 
         if (ExpressionOperation.EQ.toString().equals(operation)) {
-            sqlBuilder.where("UA.UM_ATTR_VALUE = ?", attributeValue);
+            if (isCaseSensitiveUsername()) {
+                sqlBuilder.where("UA.UM_ATTR_VALUE = ?", attributeValue);
+            } else {
+                sqlBuilder.where("LOWER(UA.UM_ATTR_VALUE) = ?", attributeValue.toLowerCase());
+            }
         } else if (ExpressionOperation.EW.toString().equals(operation)) {
-            sqlBuilder.where("UA.UM_ATTR_VALUE LIKE ?", "%" + attributeValue);
+            if (isCaseSensitiveUsername()) {
+                sqlBuilder.where("UA.UM_ATTR_VALUE LIKE ?", "%" + attributeValue);
+            } else {
+                sqlBuilder.where("LOWER(UA.UM_ATTR_VALUE) LIKE ?", "%" + attributeValue.toLowerCase());
+            }
         } else if (ExpressionOperation.CO.toString().equals(operation)) {
-            sqlBuilder.where("UA.UM_ATTR_VALUE LIKE ?", "%" + attributeValue + "%");
+            if (isCaseSensitiveUsername()) {
+                sqlBuilder.where("UA.UM_ATTR_VALUE LIKE ?", "%" + attributeValue + "%");
+            } else {
+                sqlBuilder.where("LOWER(UA.UM_ATTR_VALUE) LIKE ?", "%" + attributeValue.toLowerCase() + "%");
+            }
         } else if (ExpressionOperation.SW.toString().equals(operation)) {
-            sqlBuilder.where("UA.UM_ATTR_VALUE LIKE ?", attributeValue + "%");
+            if (isCaseSensitiveUsername()) {
+                sqlBuilder.where("UA.UM_ATTR_VALUE LIKE ?", attributeValue + "%");
+            } else {
+                sqlBuilder.where("LOWER(UA.UM_ATTR_VALUE) LIKE ?", attributeValue.toLowerCase() + "%");
+            }
         }
     }
 
@@ -3792,13 +3808,29 @@ public class UniqueIDJDBCUserStoreManager extends JDBCUserStoreManager {
         sqlBuilder.updateSqlWithOROperation("UA.UM_ATTR_NAME = ?", attributeName);
 
         if (ExpressionOperation.EQ.toString().equals(operation)) {
-            sqlBuilder.where("UA.UM_ATTR_VALUE = ?", attributeValue);
+            if (isCaseSensitiveUsername()) {
+                sqlBuilder.where("UA.UM_ATTR_VALUE = ?", attributeValue);
+            } else {
+                sqlBuilder.where("LOWER(UA.UM_ATTR_VALUE) = ?", attributeValue.toLowerCase());
+            }
         } else if (ExpressionOperation.EW.toString().equals(operation)) {
-            sqlBuilder.where("UA.UM_ATTR_VALUE LIKE ?", "%" + attributeValue);
+            if (isCaseSensitiveUsername()) {
+                sqlBuilder.where("UA.UM_ATTR_VALUE LIKE ?", "%" + attributeValue);
+            } else {
+                sqlBuilder.where("LOWER(UA.UM_ATTR_VALUE) LIKE ?", "%" + attributeValue.toLowerCase());
+            }
         } else if (ExpressionOperation.CO.toString().equals(operation)) {
-            sqlBuilder.where("UA.UM_ATTR_VALUE LIKE ?", "%" + attributeValue + "%");
+            if (isCaseSensitiveUsername()) {
+                sqlBuilder.where("UA.UM_ATTR_VALUE LIKE ?", "%" + attributeValue + "%");
+            } else {
+                sqlBuilder.where("LOWER(UA.UM_ATTR_VALUE) LIKE ?", "%" + attributeValue.toLowerCase() + "%");
+            }
         } else if (ExpressionOperation.SW.toString().equals(operation)) {
-            sqlBuilder.where("UA.UM_ATTR_VALUE LIKE ?", attributeValue + "%");
+            if (isCaseSensitiveUsername()) {
+                sqlBuilder.where("UA.UM_ATTR_VALUE LIKE ?", attributeValue + "%");
+            } else {
+                sqlBuilder.where("LOWER(UA.UM_ATTR_VALUE) LIKE ?", attributeValue.toLowerCase() + "%");
+            }
         }
     }
 


### PR DESCRIPTION
Issue: https://github.com/wso2/product-is/issues/15963

Fix:
Found that isCaseSensitiveUsername] method is used to differentiate case sensitive and insensitive attributes and user names. We also decided to use this approach as a solution.

I have changed two methods in both classes

    buildClaimWhereConditions
    buildClaimConditionWithOROperator - currently this method is used by MySQL which is case-insensitive by default, but I still fix this method cause... from the method context it should look for the isCaseSensitiveUsername when building the query irrespect of the database.