### PR TITLE
[4.8.x] Upgrade Jettison to 1.5.4

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -470,8 +470,8 @@
         <antlr.wso2.version>3.2.0.wso2v1</antlr.wso2.version>
 
         <!-- Jettison Version -->
-        <version.jettison>1.5.3</version.jettison>
-        <orbit.version.jettison>1.5.3.wso2v1</orbit.version.jettison>
+        <version.jettison>1.5.4</version.jettison>
+        <orbit.version.jettison>1.5.4.wso2v1</orbit.version.jettison>
 
         <orbit.version.hsqldb>1.8.0.7wso2v1</orbit.version.hsqldb>
         <orbit.version.commons.beanutils>1.8.0.wso2v1</orbit.version.commons.beanutils>


### PR DESCRIPTION
Jettison 1.5.3 has been identified with a vulnerability