### PR TITLE
Fix target path is null

### DIFF
--- a/core/org.wso2.carbon.registry.core/src/main/java/org/wso2/carbon/registry/core/utils/RegistryUtils.java
+++ b/core/org.wso2.carbon.registry.core/src/main/java/org/wso2/carbon/registry/core/utils/RegistryUtils.java
@@ -1125,9 +1125,14 @@ public final class RegistryUtils {
                 if (targetSubPath != null) {
                     registerHandlerForRemoteLinks(systemRegistry.getRegistryContext(), path,
                             target, targetSubPath, author);
-                } else {
+                } else if (target != null) {
                     registerHandlerForSymbolicLinks(systemRegistry.getRegistryContext(),
                             path, target, author);
+                } else {
+                    if(log.isDebugEnabled()) {
+                        log.debug("Unable to add mount. The mount point " + mountPointString +
+                                " has no target or target sub path.");
+                    }
                 }
             } catch (RegistryException e) {
                 log.warn("Couldn't mount " + target + ".");

--- a/core/org.wso2.carbon.registry.core/src/main/java/org/wso2/carbon/registry/core/utils/RegistryUtils.java
+++ b/core/org.wso2.carbon.registry.core/src/main/java/org/wso2/carbon/registry/core/utils/RegistryUtils.java
@@ -1129,10 +1129,8 @@ public final class RegistryUtils {
                     registerHandlerForSymbolicLinks(systemRegistry.getRegistryContext(),
                             path, target, author);
                 } else {
-                    if(log.isDebugEnabled()) {
-                        log.debug("Unable to add mount. The mount point " + mountPointString +
-                                " has no target or target sub path.");
-                    }
+                    log.warn("Unable to add mount. The mount point " + mountPointString + " has no target or " +
+                            "target sub path.");
                 }
             } catch (RegistryException e) {
                 log.warn("Couldn't mount " + target + ".");


### PR DESCRIPTION
## Purpose
Even though, the version property is disabled by default. In some migration process when enabling this property cause NPE.
`ERROR {org.wso2.carbon.registry.core.internal.RegistryCoreServiceComponent} - Failed to activate Registry Core bundle java.lang.NullPointerException
	at org.wso2.carbon.registry.core.jdbc.handlers.builtin.SymLinkHandler.setTargetPoint(SymLinkHandler.java:481)
	at org.wso2.carbon.registry.core.utils.RegistryUtils.registerHandlerForSymbolicLinks(RegistryUtils.java:1602)
	at org.wso2.carbon.registry.core.utils.RegistryUtils.registerMountPoints(RegistryUtils.java:1129)
	at org.wso2.carbon.registry.core.jdbc.EmbeddedRegistryService.configure(EmbeddedRegistryService.java:222)
	at org.wso2.carbon.registry.core.jdbc.EmbeddedRegistryService.<init>(EmbeddedRegistryService.java:99)
    ....`

## Approach
If the target path is null, its impossible to mount the resource. Hence with this fix, we avoid creating symbolic link.
Since this is caused by misconfiguration, it will be a warn log.

```
[2023-06-28 10:08:42,827] []  WARN {org.wso2.carbon.registry.core.utils.RegistryUtils} - Unable to add mount. The mount point /_system/local/repository/components/org.wso2.carbon.registry/mount/-_system-config has no target or target sub path.
[2023-06-28 10:08:44,937] []  WARN {org.wso2.carbon.registry.core.utils.RegistryUtils} - Unable to add mount. The mount point /_system/local/repository/components/org.wso2.carbon.registry/mount/-_system-governance has no target or target sub path.
```