### PR TITLE
 Option to remove mounting configurations are not removable through the deployment.toml file 

### DIFF
--- a/distribution/kernel/carbon-home/repository/resources/conf/default.json
+++ b/distribution/kernel/carbon-home/repository/resources/conf/default.json
@@ -220,7 +220,5 @@
   "sts.callback_handler" : "org.wso2.carbon.identity.sts.common.identity.provider.AttributeCallbackHandler",
   "tenant_mgt.enable_tenant_theme_mgt" : true,
   "jce_provider.provider_name" : "BC",
-  "signature_util.enable_sha256_algo" : true,
-  "registry.mount_enabled": true,
-  "registry.local_carbon_db_enabled": true
+  "signature_util.enable_sha256_algo" : true
 }

--- a/distribution/kernel/carbon-home/repository/resources/conf/default.json
+++ b/distribution/kernel/carbon-home/repository/resources/conf/default.json
@@ -221,4 +221,5 @@
   "tenant_mgt.enable_tenant_theme_mgt" : true,
   "jce_provider.provider_name" : "BC",
   "signature_util.enable_sha256_algo" : true
+
 }

--- a/distribution/kernel/carbon-home/repository/resources/conf/default.json
+++ b/distribution/kernel/carbon-home/repository/resources/conf/default.json
@@ -220,6 +220,7 @@
   "sts.callback_handler" : "org.wso2.carbon.identity.sts.common.identity.provider.AttributeCallbackHandler",
   "tenant_mgt.enable_tenant_theme_mgt" : true,
   "jce_provider.provider_name" : "BC",
-  "signature_util.enable_sha256_algo" : true
-
+  "signature_util.enable_sha256_algo" : true,
+  "registry.mount_enabled": true,
+  "registry.local_carbon_db_enabled": true
 }

--- a/distribution/kernel/carbon-home/repository/resources/conf/templates/repository/conf/registry.xml.j2
+++ b/distribution/kernel/carbon-home/repository/resources/conf/templates/repository/conf/registry.xml.j2
@@ -27,13 +27,14 @@
     <enableCache>true</enableCache>
     <registryRoot>/</registryRoot>
 
-    {% if registry.local_carbon_db_enabled is sameas true %}
-        <dataSource>jdbc/WSO2CarbonDB</dataSource>
-    {% else %}
+    <dbConfig name="wso2registry">
+    {% if registry.carbon_db_disabled is sameas true %}
         <dataSource>jdbc/SHARED_DB</dataSource>
+    {% else %}
+        <dataSource>jdbc/WSO2CarbonDB</dataSource>
     {% endif %}
     </dbConfig>
-    {% if registry.mount_enabled is sameas true %}
+    {% if registry.mount_enabled is not defined or registry.mount_enabled is sameas true %}
     <dbConfig name="govregistry">
         <dataSource>jdbc/SHARED_DB</dataSource>
     </dbConfig>

--- a/distribution/kernel/carbon-home/repository/resources/conf/templates/repository/conf/registry.xml.j2
+++ b/distribution/kernel/carbon-home/repository/resources/conf/templates/repository/conf/registry.xml.j2
@@ -28,13 +28,13 @@
     <registryRoot>/</registryRoot>
 
     <dbConfig name="wso2registry">
-    {% if registry.carbon_db_disabled is sameas true %}
+    {% if registry.use_shared_db_as_datasource is sameas true %}
         <dataSource>jdbc/SHARED_DB</dataSource>
     {% else %}
         <dataSource>jdbc/WSO2CarbonDB</dataSource>
     {% endif %}
     </dbConfig>
-    {% if registry.mount_enabled is not defined or registry.mount_enabled is sameas true %}
+    {% if registry.enable_mount is not defined or registry.enable_mount is sameas true %}
     <dbConfig name="govregistry">
         <dataSource>jdbc/SHARED_DB</dataSource>
     </dbConfig>

--- a/distribution/kernel/carbon-home/repository/resources/conf/templates/repository/conf/registry.xml.j2
+++ b/distribution/kernel/carbon-home/repository/resources/conf/templates/repository/conf/registry.xml.j2
@@ -27,9 +27,13 @@
     <enableCache>true</enableCache>
     <registryRoot>/</registryRoot>
 
-    <dbConfig name="wso2registry">
+    {% if registry.local_carbon_db_enabled is sameas true %}
         <dataSource>jdbc/WSO2CarbonDB</dataSource>
+    {% else %}
+        <dataSource>jdbc/SHARED_DB</dataSource>
+    {% endif %}
     </dbConfig>
+    {% if registry.mount_enabled is sameas true %}
     <dbConfig name="govregistry">
         <dataSource>jdbc/SHARED_DB</dataSource>
     </dbConfig>
@@ -67,6 +71,7 @@
         <instanceId>conf</instanceId>
         <targetPath>{{config_data.path}}</targetPath>
     </mount>
+    {% endif %}
    <!--<handler class="org.wso2.carbon.registry.extensions.handlers.SynapseRepositoryHandler">
         <filter class="org.wso2.carbon.registry.core.jdbc.handlers.filters.MediaTypeMatcher">
             <property name="mediaType">application/vnd.apache.synapse</property>


### PR DESCRIPTION
## Purpose
Public Issue: https://github.com/wso2/product-is/issues/16095

## Approach
Introduce two configurations.
```
[registry]
use_shared_db_as_datasource = false // set true to change from carbon DB to shared DB for the wso2 registry
enable_mount = true // set false to disable mount configuration
```
These configurations are written in a way that these don't rely on default.json configuration.

