### PR TITLE
Add custom verifier to hostname verification by HTTP client

### DIFF
--- a/core/org.wso2.carbon.utils/pom.xml
+++ b/core/org.wso2.carbon.utils/pom.xml
@@ -229,6 +229,14 @@
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.orbit.org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.orbit.org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+        </dependency>
     </dependencies>
 
     <properties>

--- a/core/org.wso2.carbon.utils/pom.xml
+++ b/core/org.wso2.carbon.utils/pom.xml
@@ -233,10 +233,6 @@
             <groupId>org.wso2.orbit.org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.wso2.orbit.org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-        </dependency>
     </dependencies>
 
     <properties>

--- a/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/CustomHostNameVerifier.java
+++ b/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/CustomHostNameVerifier.java
@@ -1,9 +1,26 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.wso2.carbon.utils;
 
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.http.conn.ssl.AbstractVerifier;
-
 import javax.net.ssl.SSLException;
+import java.util.Optional;
 
 /**
  * Custom hostname verifier class.
@@ -13,16 +30,17 @@ public class CustomHostNameVerifier extends AbstractVerifier {
     private final static String[] LOCALHOSTS = {"::1", "127.0.0.1", "localhost", "localhost.localdomain"};
 
     @Override
-    public void verify(String s, String[] strings, String[] subjectAlts) throws SSLException {
+    public void verify(String hostname, String[] commonNames, String[] subjectAlternativeNames) throws SSLException {
 
-        String[] subjectAltsWithLocalhosts = ArrayUtils.addAll(subjectAlts, LOCALHOSTS);
+        String[] subjectAltsWithLocalhosts = ArrayUtils.addAll(subjectAlternativeNames, LOCALHOSTS);
 
-        if (strings != null && strings.length > 0 && strings[0] != null) {
-
-            String[] subjectAltsWithLocalhostsAndCN = ArrayUtils.add(subjectAltsWithLocalhosts, strings[0]);
-            this.verify(s, strings, subjectAltsWithLocalhostsAndCN, false);
-        } else {
-            this.verify(s, strings, subjectAltsWithLocalhosts, false);
+        boolean isValidCommonNames = Optional.ofNullable(commonNames)
+                .filter(names -> names.length > 0)
+                .map(names -> names[0])
+                .isPresent();
+        if (isValidCommonNames && !ArrayUtils.contains(subjectAlternativeNames, commonNames[0])) {
+            subjectAltsWithLocalhosts = ArrayUtils.add(subjectAltsWithLocalhosts, commonNames[0]);
         }
+        this.verify(hostname, commonNames, subjectAltsWithLocalhosts, false);
     }
 }

--- a/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/CustomHostNameVerifier.java
+++ b/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/CustomHostNameVerifier.java
@@ -1,0 +1,28 @@
+package org.wso2.carbon.utils;
+
+import org.apache.commons.lang3.ArrayUtils;
+import org.apache.http.conn.ssl.AbstractVerifier;
+
+import javax.net.ssl.SSLException;
+
+/**
+ * Custom hostname verifier class.
+ */
+public class CustomHostNameVerifier extends AbstractVerifier {
+
+    private final static String[] LOCALHOSTS = {"::1", "127.0.0.1", "localhost", "localhost.localdomain"};
+
+    @Override
+    public void verify(String s, String[] strings, String[] subjectAlts) throws SSLException {
+
+        String[] subjectAltsWithLocalhosts = ArrayUtils.addAll(subjectAlts, LOCALHOSTS);
+
+        if (strings != null && strings.length > 0 && strings[0] != null) {
+
+            String[] subjectAltsWithLocalhostsAndCN = ArrayUtils.add(subjectAltsWithLocalhosts, strings[0]);
+            this.verify(s, strings, subjectAltsWithLocalhostsAndCN, false);
+        } else {
+            this.verify(s, strings, subjectAltsWithLocalhosts, false);
+        }
+    }
+}

--- a/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/CustomHostNameVerifier.java
+++ b/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/CustomHostNameVerifier.java
@@ -17,7 +17,7 @@
  */
 package org.wso2.carbon.utils;
 
-import org.apache.commons.lang3.ArrayUtils;
+import org.apache.commons.lang.ArrayUtils;
 import org.apache.http.conn.ssl.AbstractVerifier;
 import javax.net.ssl.SSLException;
 import java.util.Optional;
@@ -32,15 +32,15 @@ public class CustomHostNameVerifier extends AbstractVerifier {
     @Override
     public void verify(String hostname, String[] commonNames, String[] subjectAlternativeNames) throws SSLException {
 
-        String[] subjectAltsWithLocalhosts = ArrayUtils.addAll(subjectAlternativeNames, LOCALHOSTS);
+        String[] subjectAltsWithLocalhosts = (String[]) ArrayUtils.addAll(subjectAlternativeNames, LOCALHOSTS);
 
-        boolean isValidCommonNames = Optional.ofNullable(commonNames)
+        boolean hasValidCommonNames = Optional.ofNullable(commonNames)
                 .filter(names -> names.length > 0)
                 .map(names -> names[0])
                 .isPresent();
-        if (isValidCommonNames && !ArrayUtils.contains(subjectAlternativeNames, commonNames[0])) {
-            subjectAltsWithLocalhosts = ArrayUtils.add(subjectAltsWithLocalhosts, commonNames[0]);
+        if (hasValidCommonNames && !ArrayUtils.contains(subjectAlternativeNames, commonNames[0])) {
+            subjectAltsWithLocalhosts = (String[]) ArrayUtils.add(subjectAltsWithLocalhosts, commonNames[0]);
         }
-        this.verify(hostname, commonNames, subjectAltsWithLocalhosts, false);
+        super.verify(hostname, commonNames, subjectAltsWithLocalhosts, false);
     }
 }

--- a/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/HTTPClientUtils.java
+++ b/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/HTTPClientUtils.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.wso2.carbon.utils;
 
 import org.apache.http.conn.ssl.X509HostnameVerifier;
@@ -20,7 +37,7 @@ public class HTTPClientUtils {
      *
      * @return HttpClientBuilder.
      */
-    public static HttpClientBuilder getHTTPClientWithCustomHostNameVerifier() {
+    public static HttpClientBuilder createClientWithCustomVerifier() {
 
         HttpClientBuilder httpClientBuilder = HttpClientBuilder.create().useSystemProperties();
         if (DEFAULT_AND_LOCALHOST.equals(System.getProperty(HOST_NAME_VERIFIER))) {

--- a/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/HTTPClientUtils.java
+++ b/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/HTTPClientUtils.java
@@ -10,6 +10,7 @@ public class HTTPClientUtils {
 
     public static final String DEFAULT_AND_LOCALHOST = "DefaultAndLocalhost";
     public static final String HOST_NAME_VERIFIER = "httpclient.hostnameVerifier";
+
     private HTTPClientUtils() {
         //disable external instantiation
     }

--- a/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/HTTPClientUtils.java
+++ b/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/HTTPClientUtils.java
@@ -1,0 +1,32 @@
+package org.wso2.carbon.utils;
+
+import org.apache.http.conn.ssl.X509HostnameVerifier;
+import org.apache.http.impl.client.HttpClientBuilder;
+
+/**
+ * Util methods for HTTP Client.
+ */
+public class HTTPClientUtils {
+
+    public static final String DEFAULT_AND_LOCALHOST = "DefaultAndLocalhost";
+    public static final String HOST_NAME_VERIFIER = "httpclient.hostnameVerifier";
+    private HTTPClientUtils() {
+        //disable external instantiation
+    }
+
+    /**
+     * Get the httpclient builder with custom hostname verifier.
+     *
+     * @return HttpClientBuilder.
+     */
+    public static HttpClientBuilder getHTTPClientWithCustomHostNameVerifier() {
+
+        HttpClientBuilder httpClientBuilder = HttpClientBuilder.create().useSystemProperties();
+        if (DEFAULT_AND_LOCALHOST.equals(System.getProperty(HOST_NAME_VERIFIER))) {
+            X509HostnameVerifier hostnameVerifier = new CustomHostNameVerifier();
+            httpClientBuilder.setHostnameVerifier(hostnameVerifier);
+        }
+
+        return httpClientBuilder;
+    }
+}

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -1925,11 +1925,6 @@
                 <artifactId>httpclient</artifactId>
                 <version>${httpcomponents-httpclient.wso2.version}</version>
             </dependency>
-            <dependency>
-                <groupId>org.wso2.orbit.org.apache.commons</groupId>
-                <artifactId>commons-lang3</artifactId>
-                <version>${commons-lang3.orbit.version}</version>
-            </dependency>
         </dependencies>
     </dependencyManagement>
 </project>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -654,6 +654,9 @@
         <config.mapper.version>1.0.13</config.mapper.version>
         <version.stax.ex>1.8.3</version.stax.ex>
         <version.saaj.impl>1.5.0</version.saaj.impl>
+
+        <httpcomponents-httpclient.wso2.version>4.5.13.wso2v1</httpcomponents-httpclient.wso2.version>
+        <httpcomponents-httpclient.imp.pkg.version.range>[4.3.1.wso2v2,5.0.0)</httpcomponents-httpclient.imp.pkg.version.range>
     </properties>
 
     <dependencyManagement>
@@ -1916,6 +1919,16 @@
                 <groupId>org.jvnet.staxex</groupId>
                 <artifactId>stax-ex</artifactId>
                 <version>${version.stax.ex}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.orbit.org.apache.httpcomponents</groupId>
+                <artifactId>httpclient</artifactId>
+                <version>${httpcomponents-httpclient.wso2.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.orbit.org.apache.commons</groupId>
+                <artifactId>commons-lang3</artifactId>
+                <version>${commons-lang3.orbit.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
## Purpose
As explained in https://github.com/wso2/product-is/issues/16181 `localhost` is not required to be added as a SAN in the certificate even in the flows which use `localhost` as the internal hostname ( eg: Self registration flow). But currently when `localhost` is not available as a SAN, some internal API calls fail. Sometimes back a fix has been implemented to ignore `localhost` verification in https://github.com/wso2/carbon-identity-framework/pull/4262 by introducing a custom verifier to the HTTP client. But in two places this customized HTTP client is not used and therefore self-registration gets failed. As these places are in two different modules, the HTTP client with custom hostname verification has been moved to the kernel as a util method through this PR. Further, we expect to use the same HTTP client for any internal API calls to avoid such issues in the future.

## Goals
Resolves the issue of self-registration flow does not work when `localhost` is removed from the SAN.

## Approach
From this PR, an HTTP client creation with customized hostname verification (introduced in https://github.com/wso2/carbon-identity-framework/pull/4262) logic is moved to the Kernal. 

Further as per the issue https://github.com/wso2/product-is/issues/16182 when hostname and internal hostname are changed according to option 2 in https://is.docs.wso2.com/en/latest/deploy/change-the-hostname/  an error is observed. This is because even when the hostname and CN are equal when we give a list of subject alternative names, the hostname is validated against the SAN. A fix is added to resolve that issue as well.

## Documentation
https://github.com/wso2/product-is/issues/16255

## Related PRs
https://github.com/wso2/carbon-identity-framework/pull/4794 

