### PR TITLE
Fix user retrieval on MySQL and Maria DB when there are multiple group and claim filters

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCUserStoreManager.java
@@ -3631,7 +3631,7 @@ public class UniqueIDJDBCUserStoreManager extends JDBCUserStoreManager {
             sqlBuilder.updateSql(" GROUP BY U.UM_USER_NAME, U.UM_USER_ID ");
             if (groupFilterCount > 0 && claimFilterCount > 0) {
                 sqlBuilder.updateSql(" HAVING (COUNT(DISTINCT R.UM_ROLE_NAME) = " + groupFilterCount +
-                        " AND COUNT(DISTINCT UA.UM_ATTR_VALUE) = " + claimFilterCount + ")");
+                        " AND COUNT(DISTINCT UA.UM_ATTR_NAME) = " + claimFilterCount + ")");
             } else if (groupFilterCount > 0) {
                 sqlBuilder.updateSql(" HAVING COUNT(DISTINCT R.UM_ROLE_NAME) = " + groupFilterCount);
             } else if (claimFilterCount > 0) {


### PR DESCRIPTION
## Purpose
Currently, when using MySQL or MariaDB as the secondary user stores and attempting to retrieve users (for example, by using the _/scim2/Users/.search_ endpoint), a particular user will be excluded from the response if the search request includes a group filter and the user has identical values for claims that matches the claim filters specified in the search request.

Ex: A user who is in the group  "Manager" and  has "test" as both given name and the family name, will be excluded from a SCIM2 search response if the filter is:

```
groups co Manager and name.givenName co t and name.familyName co t
``` 

This happens because the `COUNT(DISTINCT UA.UM_ATTR_VALUE)` in the `HAVING` clause takes the distinct count of the grouped values in the `UM_ATTR_VALUE` column which may cause the count to be less than the `claimFilterCount`.

To fix the issue `UM_ATTR_NAME` has been used instead of `UM_ATTR_VALUE` in the `HAVING` clause  because there will be no duplicate values in the `UM_ATTR_NAME` column for a particular `UM_USER_NAME`, `UM_USER_ID` combination.


## Related Issue

- https://github.com/wso2/product-is/issues/16192