### PR TITLE
Opt out of stricter java rules for zip64 and dot entries

### DIFF
--- a/distribution/kernel/carbon-home/bin/wso2server.sh
+++ b/distribution/kernel/carbon-home/bin/wso2server.sh
@@ -324,6 +324,8 @@ do
     -Djava.security.egd=file:/dev/./urandom \
     -Dfile.encoding=UTF8 \
     -Djava.net.preferIPv4Stack=true \
+    -Djdk.util.zip.disableZip64ExtraFieldValidation=true \
+    -Djdk.nio.zipfs.allowDotZipEntry=true \
     -Dcom.ibm.cacheLocalHost=true \
     -DworkerNode=false \
     -DenableCorrelationLogs=false \


### PR DESCRIPTION
## Purpose

Fix https://github.com/wso2/product-is/issues/16315

This PR addresses the issue of server startup failure when using JDK version 11.0.20. In this version, new rules regarding ZIP64 extra fields and dot entries in JAR files were introduced. 

https://www.oracle.com/java/technologies/javase/11-0-20-relnotes.html

We have added -Djdk.util.zip.disableZip64ExtraFieldValidation=true to turn off the ZIP64 extra fields validation and -Djdk.nio.zipfs.allowDotZipEntry=true to allow dot entries in ZIP files.