### PR TITLE
Fix deadlock for incoming concurrent user delete requests 

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCUserStoreManager.java
@@ -1491,10 +1491,12 @@ public class UniqueIDJDBCUserStoreManager extends JDBCUserStoreManager {
             if (sqlStmt1.contains(UserCoreConstants.UM_TENANT_COLUMN)) {
                 this.updateStringValuesToDatabase(dbConnection, sqlStmt1, userID, tenantId, tenantId);
                 this.updateStringValuesToDatabase(dbConnection, sqlStmt2, userID, tenantId, tenantId);
+                dbConnection.commit();
                 this.updateStringValuesToDatabase(dbConnection, sqlStmt3, userID, tenantId);
             } else {
                 this.updateStringValuesToDatabase(dbConnection, sqlStmt1, userID);
                 this.updateStringValuesToDatabase(dbConnection, sqlStmt2, userID);
+                dbConnection.commit();
                 this.updateStringValuesToDatabase(dbConnection, sqlStmt3, userID);
             }
             dbConnection.commit();


### PR DESCRIPTION
## Purpose
This PR fixes an intermittent deadlock issue when there are multiple concurrent scim2 user delete request to delete several users who belong to the same group

