### PR TITLE
Fix Getting 500 error response for client errors in SCIM/Groups PATCH 

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/UniqueIDReadWriteLDAPUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/UniqueIDReadWriteLDAPUserStoreManager.java
@@ -35,6 +35,7 @@ import org.wso2.carbon.user.core.UserStoreException;
 import org.wso2.carbon.user.core.claim.ClaimManager;
 import org.wso2.carbon.user.core.common.RoleContext;
 import org.wso2.carbon.user.core.common.User;
+import org.wso2.carbon.user.core.constants.UserCoreErrorConstants;
 import org.wso2.carbon.user.core.hybrid.HybridRoleManager;
 import org.wso2.carbon.user.core.profile.ProfileConfigurationManager;
 import org.wso2.carbon.user.core.tenant.Tenant;
@@ -1931,7 +1932,8 @@ public class UniqueIDReadWriteLDAPUserStoreManager extends UniqueIDReadOnlyLDAPU
             if (log.isDebugEnabled()) {
                 log.debug(errorMessage, e);
             }
-            throw new UserStoreException(errorMessage);
+            throw new UserStoreException(errorMessage,
+                    UserCoreErrorConstants.ErrorMessages.ERROR_CODE_NON_EXISTING_USER.getCode());
         } finally {
             JNDIUtil.closeContext(groupContext);
             JNDIUtil.closeContext(mainDirContext);


### PR DESCRIPTION
## Purpose
This PR aims to address the issues mentioned in [https://github.com/wso2/product-is/issues/16097](https://github.com/wso2/product-is/issues/16097).

Related PRs:
https://github.com/wso2/charon/pull/387
https://github.com/wso2-extensions/identity-inbound-provisioning-scim2/pull/478

## Goals
The goals of this PR are to:
- Change the error responses when removing a non-existent member from a group in LDAP user stores.