### PR TITLE
Add support for "AllowAll" hostname verification behaviour .

### DIFF
--- a/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/CarbonConstants.java
+++ b/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/CarbonConstants.java
@@ -451,4 +451,9 @@ public final class CarbonConstants {
         public static final String CORRELATION_ID = "correlationId";
         public static final String CORRELATION_ID_MDC = "Correlation-ID";
     }
+
+    // Constants related to hostname verification
+    public static final String DEFAULT_AND_LOCALHOST = "DefaultAndLocalhost";
+    public static final String ALLOW_ALL = "AllowAll";
+    public static final String HOST_NAME_VERIFIER = "httpclient.hostnameVerifier";
 }

--- a/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/HTTPClientUtils.java
+++ b/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/HTTPClientUtils.java
@@ -18,15 +18,18 @@
 package org.wso2.carbon.utils;
 
 import org.apache.http.conn.ssl.X509HostnameVerifier;
+import org.apache.http.conn.ssl.AllowAllHostnameVerifier;
 import org.apache.http.impl.client.HttpClientBuilder;
+
+import static org.wso2.carbon.CarbonConstants.ALLOW_ALL;
+import static org.wso2.carbon.CarbonConstants.DEFAULT_AND_LOCALHOST;
+import static org.wso2.carbon.CarbonConstants.HOST_NAME_VERIFIER;
 
 /**
  * Util methods for HTTP Client.
  */
 public class HTTPClientUtils {
 
-    public static final String DEFAULT_AND_LOCALHOST = "DefaultAndLocalhost";
-    public static final String HOST_NAME_VERIFIER = "httpclient.hostnameVerifier";
 
     private HTTPClientUtils() {
         //disable external instantiation
@@ -43,6 +46,8 @@ public class HTTPClientUtils {
         if (DEFAULT_AND_LOCALHOST.equals(System.getProperty(HOST_NAME_VERIFIER))) {
             X509HostnameVerifier hostnameVerifier = new CustomHostNameVerifier();
             httpClientBuilder.setHostnameVerifier(hostnameVerifier);
+        } else if (ALLOW_ALL.equals(System.getProperty(HOST_NAME_VERIFIER))) {
+            httpClientBuilder.setHostnameVerifier(new AllowAllHostnameVerifier());
         }
 
         return httpClientBuilder;

--- a/core/org.wso2.carbon.utils/src/test/java/org/wso2/carbon/utils/HTTPClientUtilsTest.java
+++ b/core/org.wso2.carbon.utils/src/test/java/org/wso2/carbon/utils/HTTPClientUtilsTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.utils;
+
+import org.apache.http.conn.ssl.AllowAllHostnameVerifier;
+import org.apache.http.conn.ssl.X509HostnameVerifier;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import org.wso2.carbon.BaseTest;
+
+import java.lang.reflect.Field;
+
+import static org.wso2.carbon.CarbonConstants.ALLOW_ALL;
+import static org.wso2.carbon.CarbonConstants.DEFAULT_AND_LOCALHOST;
+import static org.wso2.carbon.CarbonConstants.HOST_NAME_VERIFIER;
+
+public class HTTPClientUtilsTest extends BaseTest {
+
+    public static final String DUMMY_PROPERTY = "dummy";
+
+    @AfterMethod
+    public void tearDown() {
+    }
+
+    @DataProvider(name = "hostnameVerifierDataProvider")
+    public Object[][] hostnameVerifierDataProvider() {
+        return new Object[][]{
+                {DEFAULT_AND_LOCALHOST, CustomHostNameVerifier.class},
+                {ALLOW_ALL, AllowAllHostnameVerifier.class},
+                {DUMMY_PROPERTY, null}
+        };
+    }
+
+    @Test(dataProvider = "hostnameVerifierDataProvider")
+    public void testCreateClientWithCustomVerifierDefaultAndLocalHost(String hostnameVerifierType,
+          Class<? extends X509HostnameVerifier> expectedVerifier) throws NoSuchFieldException, IllegalAccessException {
+
+        System.setProperty(HOST_NAME_VERIFIER, hostnameVerifierType);
+
+        HttpClientBuilder httpClientBuilder = HTTPClientUtils.createClientWithCustomVerifier();
+
+        // Use reflection APIs to get the hostname verifier field value
+        Class<HttpClientBuilder> httpClientBuilderClass = HttpClientBuilder.class;
+        Field hostnameVerifierField = httpClientBuilderClass.getDeclaredField("hostnameVerifier");
+        hostnameVerifierField.setAccessible(true);
+
+        // If the hostname verifier property is set to "DEFAULT_AND_LOCALHOST" or "ALLOW_ALL", the hostname verifier
+        // field in the httpClientBuilder should be set with an instance of the expected verifier class.
+        // Otherwise, it should be null.
+        X509HostnameVerifier hostnameVerifier = (X509HostnameVerifier) hostnameVerifierField.get(httpClientBuilder);
+        if (expectedVerifier == null) {
+            Assert.assertNull(hostnameVerifier);
+        } else {
+            Assert.assertTrue(expectedVerifier.isInstance(hostnameVerifier));
+        }
+    }
+}


### PR DESCRIPTION
### Purpose
This PR:

- Adds AllowAll behavior for the custom hostname verification.
- Adds unit tests for the `createClientWithCustomVerifier()` method.

### Related Issue

- https://github.com/wso2/product-is/issues/12577

