### PR TITLE
Add ResponseHeaderSetFilter J2 mapping

### DIFF
--- a/distribution/kernel/carbon-home/repository/resources/conf/templates/repository/conf/tomcat/web.xml.j2
+++ b/distribution/kernel/carbon-home/repository/resources/conf/templates/repository/conf/tomcat/web.xml.j2
@@ -488,6 +488,23 @@
             </init-param>
         </filter>
     -->
+    {% for entry in tomcat.custom_response_header_filters %}
+        <filter>
+            <filter-name>ResponseHeaderSetFilter#{{loop.index}}</filter-name>
+            <filter-class>org.wso2.carbon.tomcat.ext.filter.ResponseHeaderSetFilter</filter-class>
+                <init-param>
+                    <param-name>headers</param-name>
+                    <param-value>{{entry.headers}}</param-value>
+                </init-param>
+        </filter>
+
+        <filter-mapping>
+            <filter-name>ResponseHeaderSetFilter#{{loop.index}}</filter-name>
+            <url-pattern>{{entry.filter_url_pattern}}</url-pattern>
+            <dispatcher>REQUEST</dispatcher>
+            <dispatcher>FORWARD</dispatcher>
+        </filter-mapping>
+    {% endfor %}
 
     {% if custom_header_filter.enable is sameas true %}
     <filter>


### PR DESCRIPTION
## Purpose
This PR aims to address the issue mentioned in https://github.com/wso2/api-manager/issues/1272

## Goals
Currently, we cannot set custom response headers for the web pages served in the APIM portals (publisher, dev and admin). The aim is to let users easily set custom response headers (ex: referrer policy, CSP ) for their specific usecases using deployment.toml as shown below. 
```
[[tomcat.custom_response_header_filters]]
headers = "X-WSO2-Test-Header:Test Value, X-WSO2-Test-Header-2:Test Value-2"
filter_url_pattern = "/*"
```