### PR TITLE
Fix throwing null pointer exception after  enabling userstore preference order feature

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
@@ -11266,8 +11266,8 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
             // domain name provided with user name.
 
             try {
-                String preferredUserNameProperty = claimManager
-                        .getAttributeName(getMyDomainName(), preferredUserNameClaim);
+                String preferredUserNameProperty = abstractUserStoreManager.getClaimManager()
+                        .getAttributeName(abstractUserStoreManager.getMyDomainName(), preferredUserNameClaim);
                 // Let's authenticate with the primary UserStoreManager.
 
                 if (abstractUserStoreManager.isUniqueUserIdEnabled()) {


### PR DESCRIPTION
## Purpose
After unique userid feature from IS 6.0.0 onwards `userstore preference order` feature is not working. 
The reason is that at the authetication we are using `IterativeUserStoreManager` instaed of `AbstractUserStoreManager` and we don't have relamConfig & claimManager as properties of IterativeUserStoreManager. 
So we need to get AbstractUserStoreManager from `IterativeUserStoreManager` and use the relamConfig & `claimManger` in AbstractUserStoreManager.

- Related Issue: https://github.com/wso2/product-is/issues/16525
