### PR TITLE
Fix case-sensitive username filtering issue in LDAP searches via SCIM APIs

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/ReadOnlyLDAPUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/ReadOnlyLDAPUserStoreManager.java
@@ -3484,20 +3484,26 @@ public class ReadOnlyLDAPUserStoreManager extends AbstractUserStoreManager {
     private List<String> getMatchUserNames(ExpressionCondition expressionCondition, List<String> users) {
 
         List<String> newUserNameList = new ArrayList<>();
+        String attributeValue = (expressionCondition.getAttributeValue() != null) ?
+                expressionCondition.getAttributeValue().toLowerCase() : expressionCondition.getAttributeValue();
 
         for (String user : users) {
-            if (ExpressionOperation.SW.toString().equals(expressionCondition.getOperation())
-                    && user.startsWith(expressionCondition.getAttributeValue()) && !newUserNameList.contains(user)) {
-                newUserNameList.add(user);
-            } else if (ExpressionOperation.EQ.toString().equals(expressionCondition.getOperation())
-                    && user.equals(expressionCondition.getAttributeValue()) && !newUserNameList.contains(user)) {
-                newUserNameList.add(user);
-            } else if (ExpressionOperation.CO.toString().equals(expressionCondition.getOperation())
-                    && user.contains(expressionCondition.getAttributeValue()) && !newUserNameList.contains(user)) {
-                newUserNameList.add(user);
-            } else if (ExpressionOperation.EW.toString().equals(expressionCondition.getOperation())
-                    && user.endsWith(expressionCondition.getAttributeValue()) && !newUserNameList.contains(user)) {
-                newUserNameList.add(user);
+            String username = user;
+            if (StringUtils.isNotBlank(username)) {
+                username = username.toLowerCase();
+                if (ExpressionOperation.SW.toString().equals(expressionCondition.getOperation())
+                        && username.startsWith(attributeValue) && !newUserNameList.contains(user)) {
+                    newUserNameList.add(user);
+                } else if (ExpressionOperation.EQ.toString().equals(expressionCondition.getOperation())
+                        && username.equals(attributeValue) && !newUserNameList.contains(user)) {
+                    newUserNameList.add(user);
+                } else if (ExpressionOperation.CO.toString().equals(expressionCondition.getOperation())
+                        && username.contains(attributeValue) && !newUserNameList.contains(user)) {
+                    newUserNameList.add(user);
+                } else if (ExpressionOperation.EW.toString().equals(expressionCondition.getOperation())
+                        && username.endsWith(attributeValue) && !newUserNameList.contains(user)) {
+                    newUserNameList.add(user);
+                }
             }
         }
         return newUserNameList;

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/UniqueIDReadOnlyLDAPUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/UniqueIDReadOnlyLDAPUserStoreManager.java
@@ -3475,19 +3475,25 @@ public class UniqueIDReadOnlyLDAPUserStoreManager extends ReadOnlyLDAPUserStoreM
     private List<User> getMatchUsers(ExpressionCondition expressionCondition, List<User> users) {
 
         List<User> newUsersList = new ArrayList<>();
+        String attributeValue = (expressionCondition.getAttributeValue() != null) ?
+                expressionCondition.getAttributeValue().toLowerCase() : expressionCondition.getAttributeValue();
+
         for (User user : users) {
-            if (ExpressionOperation.SW.toString().equals(expressionCondition.getOperation())
-                    && user.getUsername().startsWith(expressionCondition.getAttributeValue()) && !newUsersList.contains(user)) {
-                newUsersList.add(user);
-            } else if (ExpressionOperation.EQ.toString().equals(expressionCondition.getOperation())
-                    && user.getUsername().equals(expressionCondition.getAttributeValue()) && !newUsersList.contains(user)) {
-                newUsersList.add(user);
-            } else if (ExpressionOperation.CO.toString().equals(expressionCondition.getOperation())
-                    && user.getUsername().contains(expressionCondition.getAttributeValue()) && !newUsersList.contains(user)) {
-                newUsersList.add(user);
-            } else if (ExpressionOperation.EW.toString().equals(expressionCondition.getOperation())
-                    && user.getUsername().endsWith(expressionCondition.getAttributeValue()) && !newUsersList.contains(user)) {
-                newUsersList.add(user);
+            if (StringUtils.isNotBlank(user.getUsername())) {
+                String username = user.getUsername().toLowerCase();
+                if (ExpressionOperation.SW.toString().equals(expressionCondition.getOperation())
+                        && username.startsWith(attributeValue) && !newUsersList.contains(user)) {
+                    newUsersList.add(user);
+                } else if (ExpressionOperation.EQ.toString().equals(expressionCondition.getOperation())
+                        && username.equals(attributeValue) && !newUsersList.contains(user)) {
+                    newUsersList.add(user);
+                } else if (ExpressionOperation.CO.toString().equals(expressionCondition.getOperation())
+                        && username.contains(attributeValue) && !newUsersList.contains(user)) {
+                    newUsersList.add(user);
+                } else if (ExpressionOperation.EW.toString().equals(expressionCondition.getOperation())
+                        && username.endsWith(attributeValue) && !newUsersList.contains(user)) {
+                    newUsersList.add(user);
+                }
             }
         }
         return newUsersList;


### PR DESCRIPTION
## Purpose
 LDAP searches are by default case-insensitive. However, when group membership is included in search criteria, username search has been case sensitive. With this PR case-insensitive username filtering will be enabled for LDAP userstores via SCIM APIs.

### Related Issues

- https://github.com/wso2/product-is/issues/16254

### Migration Issue

- https://github.com/wso2/product-is/issues/16418