### PR TITLE
Change the logic of persisting user id vs domain mapping

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
@@ -12660,6 +12660,11 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
         User user = new User(userID, userName, userName);
         user.setTenantDomain(getTenantDomain(tenantId));
         user.setUserStoreDomain(domain);
+
+        if (StringUtils.isNotEmpty(userID) &&
+                StringUtils.isEmpty(userUniqueIDDomainResolver.getDomainForUserId(userID, tenantId))) {
+            userUniqueIDDomainResolver.setDomainForUserId(userID, domain, tenantId);
+        }
         return user;
     }
 


### PR DESCRIPTION
When creating a new user, we do not persist the `UM_UUID_DOMAIN_MAPPER` table at the point of user creation because if an external userstore is plugged to the IS, this table will not be populated for such users. Persisting this mapping is done by the `userUniqueIDDomainResolver.setDomainForUserId` method inside `AbstractUserStoreManager#getUserStoreInternalWithId` method. But at this point only the userId is known and therefore the domain is found out by iterating through every userstore searching for that userId.

With this PR, we are adding a performance improvement by persisting this mapping at a point where the domain of a user is known, thereby preventing the iteration through all userstores in search of that user's domain.

Fixes: https://github.com/wso2/product-is/issues/15203#issuecomment-1689667154