### PR TITLE
Add Config to Enable Tenant Validation for Non SaaS Username

### DIFF
--- a/distribution/kernel/carbon-home/repository/resources/conf/default.json
+++ b/distribution/kernel/carbon-home/repository/resources/conf/default.json
@@ -219,6 +219,7 @@
   "versioning_configuration.enable_version_resources_on_change" : false,
   "sts.callback_handler" : "org.wso2.carbon.identity.sts.common.identity.provider.AttributeCallbackHandler",
   "tenant_mgt.enable_tenant_theme_mgt" : true,
+  "tenant_mgt.enable_tenant_validation_for_nonsaas_username" : true,
   "jce_provider.provider_name" : "BC",
   "signature_util.enable_sha256_algo" : true
 

--- a/distribution/kernel/carbon-home/repository/resources/conf/templates/repository/conf/carbon.xml.j2
+++ b/distribution/kernel/carbon-home/repository/resources/conf/templates/repository/conf/carbon.xml.j2
@@ -481,6 +481,7 @@
     {% if tenant_mgt.enable_tenant_validation_for_nonsaas_username is defined %}
       <EnableTenantValidationForNonSaaSUsername>{{tenant_mgt.enable_tenant_validation_for_nonsaas_username}}</EnableTenantValidationForNonSaaSUsername>
     {% endif %}
+
     <!--
       Security configurations
     -->

--- a/distribution/kernel/carbon-home/repository/resources/conf/templates/repository/conf/carbon.xml.j2
+++ b/distribution/kernel/carbon-home/repository/resources/conf/templates/repository/conf/carbon.xml.j2
@@ -478,7 +478,9 @@
     {% if tenant_mgt.disable_email_domain_validation is defined %}
       <DisableEmailUserNameValidation>{{tenant_mgt.disable_email_domain_validation}}</DisableEmailUserNameValidation>
     {% endif %}
-
+    {% if tenant_mgt.enable_tenant_validation_for_nonsaas_username is defined %}
+      <EnableTenantValidationForNonSaaSUsername>{{tenant_mgt.enable_tenant_validation_for_nonsaas_username}}</EnableTenantValidationForNonSaaSUsername>
+    {% endif %}
     <!--
       Security configurations
     -->


### PR DESCRIPTION
Adds deployment.toml config to preserve backward compatibility for the changes introduced to validate username tenant of non saas apps.

Related Issue: https://github.com/wso2/product-is/issues/16228