### PR TITLE
Localising tenant retrival from username and getting tenant from session while authorising the admin

### DIFF
--- a/core/org.wso2.carbon.core.services/src/main/java/org/wso2/carbon/core/services/authentication/AuthenticationAdmin.java
+++ b/core/org.wso2.carbon.core.services/src/main/java/org/wso2/carbon/core/services/authentication/AuthenticationAdmin.java
@@ -92,7 +92,7 @@ public class AuthenticationAdmin implements CarbonServerAuthenticator {
             PrivilegedCarbonContext carbonContext = PrivilegedCarbonContext.getThreadLocalCarbonContext();
             carbonContext.setTenantDomain(tenantDomain);
             carbonContext.setTenantId(tenantId);
-            username = MultitenantUtils.getTenantAwareUsername(username);
+            username = getTenantAwareUsername(username);
             UserRealm realm = AnonymousSessionUtil.getRealmByTenantDomain(registryService,
                     realmService, tenantDomain);
 
@@ -144,6 +144,14 @@ public class AuthenticationAdmin implements CarbonServerAuthenticator {
         }
     }
 
+    private String getTenantAwareUsername(String username) {
+
+        if (username.contains("@")) {
+            username = username.substring(0, username.lastIndexOf('@'));
+        }
+        return username;
+    }
+
 
     public RememberMeData loginWithRememberMeOption(String username, String password, String remoteAddress)
             throws AuthenticationException {
@@ -159,7 +167,7 @@ public class AuthenticationAdmin implements CarbonServerAuthenticator {
                 String tenantDomain = MultitenantUtils.getTenantDomain(username);
                 int tenantId = realmService.getTenantManager().getTenantId(tenantDomain);
                 UserRealm realm = realmService.getTenantUserRealm(tenantId);
-                realm.getUserStoreManager().addRememberMe(MultitenantUtils.getTenantAwareUsername(username), uuid);
+                realm.getUserStoreManager().addRememberMe(getTenantAwareUsername(username), uuid);
                 data.setAuthenticated(true);
             }
         } catch (Exception e) {
@@ -332,7 +340,7 @@ public class AuthenticationAdmin implements CarbonServerAuthenticator {
             int tenantId = realmService.getTenantManager().getTenantId(tenantDomain);
             handleAuthenticationStarted(tenantId);
 
-            String userName = MultitenantUtils.getTenantAwareUsername(userNameWithTenant);
+            String userName = getTenantAwareUsername(userNameWithTenant);
             String uuid = cookie.substring(index + 1);
             UserRealm realm = realmService.getTenantUserRealm(tenantId);
             

--- a/core/org.wso2.carbon.core.services/src/main/java/org/wso2/carbon/core/services/authentication/AuthenticationAdmin.java
+++ b/core/org.wso2.carbon.core.services/src/main/java/org/wso2/carbon/core/services/authentication/AuthenticationAdmin.java
@@ -153,27 +153,23 @@ public class AuthenticationAdmin implements CarbonServerAuthenticator {
                 username = username.substring(0, username.lastIndexOf('@'));
             }
             return username;
-        } else {
-            return MultitenantUtils.getTenantAwareUsername(username);
         }
+        return MultitenantUtils.getTenantAwareUsername(username);
     }
 
     private String getTenantDomain(String username) {
 
         if (isInputValidationEnabled()) {
-            String tenantDomain = org.wso2.carbon.utils.multitenancy.MultitenantConstants.SUPER_TENANT_DOMAIN_NAME;
             if (!username.contains("@")) {
                 // Should be super tenant alphanumeric username.
-                return tenantDomain;
-            } else {
-                // If input validation is enabled, email type username should be tenant qualified username.
-                // Hence sub string after "@" will be tenant domain.
-                tenantDomain = username.substring(username.lastIndexOf('@') + 1);
+                return MultitenantConstants.SUPER_TENANT_DOMAIN_NAME;
             }
-            return tenantDomain;
-        } else {
-            return MultitenantUtils.getTenantDomain(username);
+            // If input validation is enabled, email type username should be tenant qualified username.
+            // sub tenant alpha numeric user names also tenant qualified username.
+            // Hence sub string after "@" will be tenant domain.
+            return username.substring(username.lastIndexOf('@') + 1);
         }
+        return MultitenantUtils.getTenantDomain(username);
     }
 
 

--- a/core/org.wso2.carbon.ui/src/main/java/org/wso2/carbon/ui/AbstractCarbonUIAuthenticator.java
+++ b/core/org.wso2.carbon.ui/src/main/java/org/wso2/carbon/ui/AbstractCarbonUIAuthenticator.java
@@ -274,8 +274,8 @@ public abstract class AbstractCarbonUIAuthenticator implements CarbonUIAuthentic
 
 		HttpSession session = request.getSession();
         String tenantDomain;
-        if (session.getAttribute("tenantDomain") != null) {
-            tenantDomain = session.getAttribute("tenantDomain").toString();
+        if (session.getAttribute(MultitenantConstants.TENANT_DOMAIN) != null) {
+            tenantDomain = session.getAttribute(MultitenantConstants.TENANT_DOMAIN).toString();
         } else {
             tenantDomain = MultitenantUtils.getTenantDomain(userName);
         }

--- a/core/org.wso2.carbon.ui/src/main/java/org/wso2/carbon/ui/AbstractCarbonUIAuthenticator.java
+++ b/core/org.wso2.carbon.ui/src/main/java/org/wso2/carbon/ui/AbstractCarbonUIAuthenticator.java
@@ -274,7 +274,7 @@ public abstract class AbstractCarbonUIAuthenticator implements CarbonUIAuthentic
 
 		HttpSession session = request.getSession();
         String tenantDomain;
-        if (session.getAttribute("tenantDomain") != null){
+        if (session.getAttribute("tenantDomain") != null) {
             tenantDomain = session.getAttribute("tenantDomain").toString();
         } else {
             tenantDomain = MultitenantUtils.getTenantDomain(userName);

--- a/core/org.wso2.carbon.ui/src/main/java/org/wso2/carbon/ui/AbstractCarbonUIAuthenticator.java
+++ b/core/org.wso2.carbon.ui/src/main/java/org/wso2/carbon/ui/AbstractCarbonUIAuthenticator.java
@@ -273,8 +273,13 @@ public abstract class AbstractCarbonUIAuthenticator implements CarbonUIAuthentic
     public void onSuccessAdminLogin(HttpServletRequest request, String userName) throws Exception {
 
 		HttpSession session = request.getSession();
-		
-    	String tenantDomain = MultitenantUtils.getTenantDomain(userName);
+        String tenantDomain;
+        if (session.getAttribute("tenantDomain") != null){
+            tenantDomain = session.getAttribute("tenantDomain").toString();
+        } else {
+            tenantDomain = MultitenantUtils.getTenantDomain(userName);
+        }
+
         if (tenantDomain != null && tenantDomain.trim().length() > 0) {
             session.setAttribute(MultitenantConstants.TENANT_DOMAIN, tenantDomain);
             // we will make it an attribute on request as well

--- a/core/org.wso2.carbon.utils/src/test/resources/carbon-utils/carbon.xml
+++ b/core/org.wso2.carbon.utils/src/test/resources/carbon-utils/carbon.xml
@@ -352,7 +352,7 @@
     <!--
         Enable following config to flag input validation configuration.
     -->
-    <isInputValidationEnabled>true</isInputValidationEnabled>
+    <InputValidationEnabled>true</InputValidationEnabled>
 
     <!--
       Security configurations

--- a/distribution/kernel/carbon-home/repository/conf/carbon.xml
+++ b/distribution/kernel/carbon-home/repository/conf/carbon.xml
@@ -430,7 +430,7 @@
     <!--
        Enable following config to flag input validation configuration.
     -->
-    <isInputValidationEnabled>true</isInputValidationEnabled>
+    <InputValidationEnabled>true</InputValidationEnabled>
     <!--EnablePasswordTrim>false</EnablePasswordTrim-->
     <!--
       Security configurations

--- a/distribution/kernel/carbon-home/repository/resources/conf/default.json
+++ b/distribution/kernel/carbon-home/repository/resources/conf/default.json
@@ -222,5 +222,5 @@
   "tenant_mgt.enable_tenant_validation_for_nonsaas_username" : true,
   "jce_provider.provider_name" : "BC",
   "signature_util.enable_sha256_algo" : true,
-  "tenant_mgt.enable_input_validation" : true
+  "tenant_mgt.enable_input_validation" : false
 }

--- a/distribution/kernel/carbon-home/repository/resources/conf/templates/repository/conf/carbon.xml.j2
+++ b/distribution/kernel/carbon-home/repository/resources/conf/templates/repository/conf/carbon.xml.j2
@@ -475,7 +475,7 @@
     <!--
       Enable following config to flag input validation configuration.
     -->
-    <isInputValidationEnabled>{{tenant_mgt.enable_input_validation}}</isInputValidationEnabled>
+    <InputValidationEnabled>{{tenant_mgt.enable_input_validation}}</InputValidationEnabled>
     {% if password_trim.enable is defined %}
       <EnablePasswordTrim>{{password_trim.enable}}</EnablePasswordTrim>
     {% endif %}


### PR DESCRIPTION
With https://github.com/wso2/product-is/issues/16357, we need to modify the carbon console login as $. With that change, if the user name is email type then the username should append the tenant domain.

This change on can enabled with a configuration from https://github.com/wso2/carbon-kernel/pull/3667


Mail: [Unification] Bring new tenant level Password/username validation feature to IS
