### PR TITLE
Make "OverrideUsernameClaimFromInternalUsername" property on the user-mgt.xml configurable.

### DIFF
--- a/distribution/kernel/carbon-home/repository/resources/conf/default.json
+++ b/distribution/kernel/carbon-home/repository/resources/conf/default.json
@@ -220,6 +220,7 @@
   "sts.callback_handler" : "org.wso2.carbon.identity.sts.common.identity.provider.AttributeCallbackHandler",
   "tenant_mgt.enable_tenant_theme_mgt" : true,
   "jce_provider.provider_name" : "BC",
-  "signature_util.enable_sha256_algo" : true
+  "signature_util.enable_sha256_algo" : true,
+  "user_mgt.override_username_claim_from_internal_username": false
 
 }

--- a/distribution/kernel/carbon-home/repository/resources/conf/templates/repository/conf/user-mgt.xml.j2
+++ b/distribution/kernel/carbon-home/repository/resources/conf/templates/repository/conf/user-mgt.xml.j2
@@ -25,7 +25,7 @@
             </AdminUser>
             <EveryOneRoleName>{{everyone.rolename}}</EveryOneRoleName>
 
-            <OverrideUsernameClaimFromInternalUsername>true</OverrideUsernameClaimFromInternalUsername>
+            <OverrideUsernameClaimFromInternalUsername>{{user_mgt.override_username_claim_from_internal_username}}</OverrideUsernameClaimFromInternalUsername>
             <!-- By default users in this role sees the registry root -->
             {% for property_name,property_value in realm_manager.properties.items() %}
             <Property name="{{property_name}}">{{property_value}}</Property>


### PR DESCRIPTION
### Purpose
This PR adds support for configuring the `OverrideUsernameClaimFromInternalUsername` on the *user-mgt.xml* through the *deployment.toml* file.

Ex:
```toml
[user_mgt]
override_username_claim_from_internal_username = false
``` 

### Related Issues

- https://github.com/wso2/product-is/issues/16310

