### PR TITLE
Add dao implementation for keystores

### DIFF
--- a/core/org.wso2.carbon.core/pom.xml
+++ b/core/org.wso2.carbon.core/pom.xml
@@ -95,6 +95,10 @@
             <artifactId>org.wso2.carbon.utils</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.wso2.carbon.security.mgt</groupId>
+            <artifactId>org.wso2.carbon.security.mgt</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.wso2.carbon.crypto</groupId>
             <artifactId>org.wso2.carbon.crypto.api</artifactId>
         </dependency>
@@ -247,6 +251,7 @@
                             javax.xml.stream.*; version=1.0.1,
                             org.wso2.carbon.registry.core.service,
                             org.wso2.carbon.user.core.*; version=0.0.0,
+                            org.wso2.carbon.security.mgt.*; version=${carbon.security.mgt.imp.version.range},
                             org.bouncycastle.*; version="${imp.pkg.version.bcp}",
                             *;resolution:=optional
                         </Import-Package>

--- a/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/util/KeyStoreManager.java
+++ b/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/util/KeyStoreManager.java
@@ -27,6 +27,10 @@ import org.wso2.carbon.registry.api.Registry;
 import org.wso2.carbon.registry.core.Resource;
 import org.wso2.carbon.registry.core.exceptions.RegistryException;
 import org.wso2.carbon.registry.core.service.RegistryService;
+import org.wso2.carbon.security.SecurityConfigException;
+import org.wso2.carbon.security.keystore.dao.KeyStoreDAO;
+import org.wso2.carbon.security.keystore.dao.impl.KeyStoreDAOImpl;
+import org.wso2.carbon.security.keystore.model.KeyStoreModel;
 import org.wso2.carbon.utils.CarbonUtils;
 import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 
@@ -37,6 +41,7 @@ import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.security.cert.X509Certificate;
 import java.util.Date;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
@@ -54,6 +59,8 @@ public class KeyStoreManager {
     private static Log log = LogFactory.getLog(KeyStoreManager.class);
 
     private Registry registry = null;
+    private KeyStoreDAO keyStoreDAO = null;
+
     private ConcurrentHashMap<String, KeyStoreBean> loadedKeyStores = null;
     private int tenantId = MultitenantConstants.SUPER_TENANT_ID;
 
@@ -76,8 +83,13 @@ public class KeyStoreManager {
         this.tenantId = tenantId;
         try {
             registry = registryService.getGovernanceSystemRegistry(tenantId);
+            keyStoreDAO = new KeyStoreDAOImpl(tenantId);
         } catch (RegistryException e) {
             String message = "Error when retrieving the system governance registry";
+            log.error(message, e);
+            throw new SecurityException(message, e);
+        } catch (SecurityConfigException e) {
+            String message = "Error when retrieving the key store DAO";
             log.error(message, e);
             throw new SecurityException(message, e);
         }
@@ -134,19 +146,20 @@ public class KeyStoreManager {
         }
 
         String path = RegistryResources.SecurityManagement.KEY_STORES + "/" + keyStoreName;
-        if (registry.resourceExists(path)) {
-            org.wso2.carbon.registry.api.Resource resource = registry.get(path);
-            byte[] bytes = (byte[]) resource.getContent();
-            KeyStore keyStore = KeyStore.getInstance(resource
-                    .getProperty(RegistryResources.SecurityManagement.PROP_TYPE));
+
+        Optional<KeyStoreModel> optionalKeyStoreModel = keyStoreDAO.getKeyStore(keyStoreName);
+        if (optionalKeyStoreModel.isPresent()) {
+            KeyStoreModel keyStoreModel = optionalKeyStoreModel.get();
+
+            byte[] bytes = keyStoreModel.getContent();
+            KeyStore keyStore = KeyStore.getInstance(keyStoreModel.getType());
             CryptoUtil cryptoUtil = CryptoUtil.getDefaultCryptoUtil();
-            String encryptedPassword = resource
-                    .getProperty(RegistryResources.SecurityManagement.PROP_PASSWORD);
+            String encryptedPassword = keyStoreModel.getPassword();
             String password = new String(cryptoUtil.base64DecodeAndDecrypt(encryptedPassword));
             ByteArrayInputStream stream = new ByteArrayInputStream(bytes);
             keyStore.load(stream, password.toCharArray());
-            KeyStoreBean keyStoreBean = new KeyStoreBean(keyStore, resource.getLastModified());
-            resource.discard();
+
+            KeyStoreBean keyStoreBean = new KeyStoreBean(keyStore, keyStoreModel.getLastUpdated());
 
             if (loadedKeyStores.containsKey(keyStoreName)) {
                 loadedKeyStores.replace(keyStoreName, keyStoreBean);
@@ -172,37 +185,33 @@ public class KeyStoreManager {
                 return getDefaultPrivateKey();
             }
 
-            String path = RegistryResources.SecurityManagement.KEY_STORES + "/" + keyStoreName;
-            org.wso2.carbon.registry.api.Resource resource;
+            KeyStoreModel keyStoreModel;
             KeyStore keyStore;
 
-            if (registry.resourceExists(path)) {
-                resource = registry.get(path);
+            Optional<KeyStoreModel> optionalKeyStoreModel = keyStoreDAO.getKeyStore(keyStoreName);
+            if (optionalKeyStoreModel.isPresent()) {
+                keyStoreModel = optionalKeyStoreModel.get();
             } else {
-                throw new SecurityException("Given Key store is not available in registry : " + keyStoreName);
+                throw new SecurityException("Given Key store is not available in Database : " + keyStoreName);
             }
 
             CryptoUtil cryptoUtil = CryptoUtil.getDefaultCryptoUtil();
-            String encryptedPassword = resource
-                    .getProperty(RegistryResources.SecurityManagement.PROP_PRIVATE_KEY_PASS);
+            String encryptedPassword = keyStoreModel.getPrivateKeyPass();
             String privateKeyPasswd = new String(cryptoUtil.base64DecodeAndDecrypt(encryptedPassword));
 
             if (isCachedKeyStoreValid(keyStoreName)) {
                 keyStore = loadedKeyStores.get(keyStoreName).getKeyStore();
                 return keyStore.getKey(alias, privateKeyPasswd.toCharArray());
-            } else {
-                byte[] bytes = (byte[]) resource.getContent();
-                String keyStorePassword = new String(cryptoUtil.base64DecodeAndDecrypt(resource.getProperty(
-                        RegistryResources.SecurityManagement.PROP_PASSWORD)));
-                keyStore = KeyStore.getInstance(resource
-                        .getProperty(RegistryResources.SecurityManagement.PROP_TYPE));
-                ByteArrayInputStream stream = new ByteArrayInputStream(bytes);
-                keyStore.load(stream, keyStorePassword.toCharArray());
-
-                KeyStoreBean keyStoreBean = new KeyStoreBean(keyStore, resource.getLastModified());
-                updateKeyStoreCache(keyStoreName, keyStoreBean);
-                return keyStore.getKey(alias, privateKeyPasswd.toCharArray());
             }
+            byte[] bytes = keyStoreModel.getContent();
+            String keyStorePassword = new String(cryptoUtil.base64DecodeAndDecrypt(keyStoreModel.getPassword()));
+            keyStore = KeyStore.getInstance(keyStoreModel.getType());
+            ByteArrayInputStream stream = new ByteArrayInputStream(bytes);
+            keyStore.load(stream, keyStorePassword.toCharArray());
+
+            KeyStoreBean keyStoreBean = new KeyStoreBean(keyStore, keyStoreModel.getLastUpdated());
+            updateKeyStoreCache(keyStoreName, keyStoreBean);
+            return keyStore.getKey(alias, privateKeyPasswd.toCharArray());
         } catch (Exception e) {
             log.error("Error loading the private key from the key store : " + keyStoreName);
             throw new SecurityException("Error loading the private key from the key store : " +
@@ -217,6 +226,7 @@ public class KeyStoreManager {
      * @return password of the key store
      * @throws Exception Error when reading the registry resource of decrypting the password
      */
+    // TODO: deprecate this method in the future since we are no longer using registry for key store management.
     public String getPassword(Resource resource) throws Exception {
         CryptoUtil cryptoUtil = CryptoUtil.getDefaultCryptoUtil();
         String encryptedPassword = resource
@@ -236,12 +246,11 @@ public class KeyStoreManager {
      */
     public String getKeyStorePassword(String keyStoreName) throws Exception {
 
-        String path = RegistryResources.SecurityManagement.KEY_STORES + "/" + keyStoreName;
-        if (registry.resourceExists(path)) {
-            org.wso2.carbon.registry.api.Resource resource = registry.get(path);
+        Optional<KeyStoreModel> optionalKeyStoreModel = keyStoreDAO.getKeyStore(keyStoreName);
+        if (optionalKeyStoreModel.isPresent()) {
+            KeyStoreModel keyStoreModel = optionalKeyStoreModel.get();
             CryptoUtil cryptoUtil = CryptoUtil.getDefaultCryptoUtil();
-            String encryptedPassword = resource
-                    .getProperty(RegistryResources.SecurityManagement.PROP_PASSWORD);
+            String encryptedPassword = keyStoreModel.getPassword();
             if(encryptedPassword != null){
                 return new String(cryptoUtil.base64DecodeAndDecrypt(encryptedPassword));
             } else {
@@ -281,24 +290,25 @@ public class KeyStoreManager {
             return;
         }
 
-        String path = RegistryResources.SecurityManagement.KEY_STORES + "/" + name;
+        Optional<KeyStoreModel> optionalKeyStoreModel = keyStoreDAO.getKeyStore(name);
+        if (optionalKeyStoreModel.isPresent()) {
+            KeyStoreModel keyStoreModel = optionalKeyStoreModel.get();
+            ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+            CryptoUtil cryptoUtil = CryptoUtil.getDefaultCryptoUtil();
+            String encryptedPassword = keyStoreModel.getPassword();
+            String password = new String(cryptoUtil.base64DecodeAndDecrypt(encryptedPassword));
+            keyStore.store(outputStream, password.toCharArray());
+            outputStream.flush();
+            outputStream.close();
 
-        org.wso2.carbon.registry.api.Resource resource = registry.get(path);
+            keyStoreModel.setContent(outputStream.toByteArray());
+            keyStoreDAO.updateKeyStore(keyStoreModel);
 
-        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-        CryptoUtil cryptoUtil = CryptoUtil.getDefaultCryptoUtil();
-        String encryptedPassword = resource
-                .getProperty(RegistryResources.SecurityManagement.PROP_PASSWORD);
-        String password = new String(cryptoUtil.base64DecodeAndDecrypt(encryptedPassword));
-        keyStore.store(outputStream, password.toCharArray());
-        outputStream.flush();
-        outputStream.close();
-
-        resource.setContent(outputStream.toByteArray());
-
-        registry.put(path, resource);
-        resource.discard();
-        updateKeyStoreCache(name, new KeyStoreBean(keyStore, new Date()));
+            // TODO: is it correct to use new Date() here? The value stored in DB might be different.
+            updateKeyStoreCache(name, new KeyStoreBean(keyStore, new Date()));
+        } else {
+            throw new SecurityException("Key Store with a name : " + name + " does not exist.");
+        }
     }
 
     /**
@@ -487,18 +497,20 @@ public class KeyStoreManager {
     }
 
     private boolean isCachedKeyStoreValid(String keyStoreName) {
-        String path = RegistryResources.SecurityManagement.KEY_STORES + "/" + keyStoreName;
         boolean cachedKeyStoreValid = false;
         try {
             if (loadedKeyStores.containsKey(keyStoreName)) {
-                org.wso2.carbon.registry.api.Resource metaDataResource = registry.get(path);
-                KeyStoreBean keyStoreBean = loadedKeyStores.get(keyStoreName);
-                if (keyStoreBean.getLastModifiedDate().equals(metaDataResource.getLastModified())) {
-                    cachedKeyStoreValid = true;
+                Optional<KeyStoreModel> optionalKeyStoreModel = keyStoreDAO.getKeyStore(keyStoreName);
+                if (optionalKeyStoreModel.isPresent()) {
+                    KeyStoreModel keyStoreModel = optionalKeyStoreModel.get();
+                    KeyStoreBean keyStoreBean = loadedKeyStores.get(keyStoreName);
+                    if (keyStoreBean.getLastModifiedDate().equals(keyStoreModel.getLastUpdated())) {
+                        cachedKeyStoreValid = true;
+                    }
                 }
             }
-        } catch (org.wso2.carbon.registry.api.RegistryException e) {
-            String errorMsg = "Error reading key store meta data from registry.";
+        } catch (SecurityConfigException e) {
+            String errorMsg = "Error reading key store meta data from Database.";
             log.error(errorMsg, e);
             throw new SecurityException(errorMsg, e);
         }

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -606,6 +606,10 @@
 
         <jdbc-pool.version>9.0.65.wso2v1</jdbc-pool.version>
 
+        <!-- Carbon Security Management -->
+        <carbon.security.mgt.version>1.0.0</carbon.security.mgt.version>
+        <carbon.security.mgt.imp.version.range>[1.0.0,2.0.0)</carbon.security.mgt.imp.version.range>
+
         <!-- Test integration -->
         <slf4j.version>1.5.10</slf4j.version>
         <woden.api.version>1.0M9</woden.api.version>
@@ -1705,6 +1709,12 @@
                 <type>zip</type>
             </dependency>
 
+            <!--Other Dependencies-->
+            <dependency>
+                <groupId>org.wso2.carbon.security.mgt</groupId>
+                <artifactId>org.wso2.carbon.security.mgt</artifactId>
+                <version>${carbon.security.mgt.version}</version>
+            </dependency>
 
             <!-- Test integration dependencies -->
             <dependency>


### PR DESCRIPTION
## Purpose
> With this [1] effort, the keystore related data will be stored in a related data table. This PR will contains changes made to bring effort to this component.

## Related PRs
- [1] https://github.com/wso2/carbon-security-mgt/pull/4 

## Related Issues
- https://github.com/wso2/product-is/issues/16422