### PR TITLE
Stop handling requests when request context is null

### DIFF
--- a/core/org.wso2.carbon.tomcat.ext/src/main/java/org/wso2/carbon/tomcat/ext/valves/CompositeValve.java
+++ b/core/org.wso2.carbon.tomcat.ext/src/main/java/org/wso2/carbon/tomcat/ext/valves/CompositeValve.java
@@ -41,10 +41,17 @@ public class CompositeValve extends ValveBase {
     @Override
     public void invoke(Request request, Response response) throws IOException, ServletException {
         try {
-
-            String enableSaaSParam =
-                    request.getContext().findParameter(ENABLE_SAAS);
-            Realm realm = request.getContext().getRealm();
+            String enableSaaSParam;
+            Realm realm;
+            if (request.getContext() != null) {
+                enableSaaSParam = request.getContext().findParameter(ENABLE_SAAS);
+                realm = request.getContext().getRealm();
+            } else {
+                log.error("Could not handle the request: " + request.getRequestURI() +
+                        ", since the request context is null. This could be due to the maxHttpHeaderSize limitation, " +
+                        "or the request having no context.");
+                return;
+            }
 
             // deprecation notice since Carbon 4.4. Users should configure SaaS mode by adding the CarbonTomcatRealm to the
             // META-INF/context.xml. See javadocs at @org.wso2.carbon.tomcat.ext.realms.CarbonTomcatRealm.
@@ -63,8 +70,6 @@ public class CompositeValve extends ValveBase {
             // ------------ Absolutely no code below this line -----------------------
             // --------- Valve chaining happens from here onwards --------------------
 
-        } catch (NullPointerException e) {
-            log.error("Could not handle the request, could be due to the maxHttpHeaderSize limitation. ", e);
         } catch (Exception e) {
             log.error("Could not handle the request: " + request.getRequestURI(), e);
         }


### PR DESCRIPTION
## Purpose
$subject. Fixes https://github.com/wso2/api-manager/issues/2121

`request.getContext()` can become `null` during following cases:
- Request context is not present in the request (As reported in https://github.com/wso2/api-manager/issues/2121)
- Too long context/header value, i.e: maxHttpHeaderSize limitation, (As reported in https://github.com/wso2/api-manager/issues/907)

This fix performs a null check for `request.getContext()`, and stops handling the request further - after logging about the above two possibilities.

Sample logs during above cases are as follows:

**No context in the request**
```
[2023-08-28 23:33:23,107] ERROR - CompositeValve Could not handle the request: HTTP/1.1, since the request context is null. This could be due to the maxHttpHeaderSize limitation, or the request having no context.
```

**Long context (8000 characters)**
```
[2023-08-28 23:32:54,858] ERROR - CompositeValve Could not handle the request: /0fsaF.....1P4Gj4A/1.0.0/, since the request context is null. This could be due to the maxHttpHeaderSize limitation, or the request having no context.
```

