### PR TITLE
[4.9.x] Add isInputValidationEnabled configuration at kernel Utils

### DIFF
--- a/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/CarbonUtils.java
+++ b/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/CarbonUtils.java
@@ -1491,4 +1491,26 @@ public class CarbonUtils {
         builder.append(StringUtils.join(inputs.iterator(), ", ")).append(" }");
         return builder.toString();
     }
+
+    /**
+     * Function to extract InputValidationEnabled configuration from carbon.xml.
+     * <pre>
+     * {@code
+     * <xml>
+     *   <InputValidationEnabled>true</InputValidationEnabled>
+     * </xml>
+     * }
+     * </pre>
+     *
+     * @return isInputValidationEnabled.
+     */
+    public static boolean isInputValidationEnabled() {
+        boolean isInputValidationEnabled = true;
+        String isInputValidationEnabledConfig = ServerConfiguration.getInstance().
+                getFirstProperty("InputValidationEnabled");
+        if (isInputValidationEnabledConfig != null) {
+            isInputValidationEnabled = Boolean.parseBoolean(isInputValidationEnabledConfig);
+        }
+        return isInputValidationEnabled;
+    }
 }

--- a/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/CarbonUtils.java
+++ b/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/CarbonUtils.java
@@ -1503,12 +1503,9 @@ public class CarbonUtils {
      * @return isInputValidationEnabled.
      */
     public static boolean isInputValidationEnabled() {
-        boolean isInputValidationEnabled = true;
         String isInputValidationEnabledConfig = ServerConfiguration.getInstance().
                 getFirstProperty("InputValidationEnabled");
-        if (isInputValidationEnabledConfig != null) {
-            isInputValidationEnabled = Boolean.parseBoolean(isInputValidationEnabledConfig);
-        }
-        return isInputValidationEnabled;
+
+        return isInputValidationEnabledConfig == null || Boolean.parseBoolean(isInputValidationEnabledConfig);
     }
 }

--- a/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/CarbonUtils.java
+++ b/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/CarbonUtils.java
@@ -1496,9 +1496,7 @@ public class CarbonUtils {
      * Function to extract InputValidationEnabled configuration from carbon.xml.
      * <pre>
      * {@code
-     * <xml>
      *   <InputValidationEnabled>true</InputValidationEnabled>
-     * </xml>
      * }
      * </pre>
      *

--- a/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/CarbonUtils.java
+++ b/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/CarbonUtils.java
@@ -1503,6 +1503,7 @@ public class CarbonUtils {
      * @return isInputValidationEnabled.
      */
     public static boolean isInputValidationEnabled() {
+
         String isInputValidationEnabledConfig = ServerConfiguration.getInstance().
                 getFirstProperty("InputValidationEnabled");
 

--- a/core/org.wso2.carbon.utils/src/test/java/org/wso2/carbon/utils/CarbonUtilsTest.java
+++ b/core/org.wso2.carbon.utils/src/test/java/org/wso2/carbon/utils/CarbonUtilsTest.java
@@ -470,5 +470,17 @@ public class CarbonUtilsTest extends BaseTest {
         Integer[] numbers = {1, 2, 3, 4, 5, 6, 7, 8, 9};
         Assert.assertEquals(CarbonUtils.arrayCopyOf(numbers), numbers);
     }
+
+    @Test(groups = {"org.wso2.carbon.utils.base"}, dependsOnMethods = "testGetServerConfiguration")
+    public void testIsInputValidationEnabledDefault() {
+        ServerConfiguration.getInstance().overrideConfigurationProperty("InputValidationEnabled", null);
+        Assert.assertTrue(CarbonUtils.isInputValidationEnabled());
+    }
+
+    @Test(groups = {"org.wso2.carbon.utils.base"}, dependsOnMethods = "testGetServerConfiguration")
+    public void testIsInputValidationEnabled() {
+        ServerConfiguration.getInstance().overrideConfigurationProperty("InputValidationEnabled", "false");
+        Assert.assertFalse(CarbonUtils.isInputValidationEnabled());
+    }
 }
 

--- a/core/org.wso2.carbon.utils/src/test/resources/carbon-utils/carbon.xml
+++ b/core/org.wso2.carbon.utils/src/test/resources/carbon-utils/carbon.xml
@@ -349,6 +349,10 @@
       Enable following config to allow Emails as usernames. 	
     -->
     <!--EnableEmailUserName>true</EnableEmailUserName-->
+    <!--
+        Enable following config to flag input validation configuration.
+    -->
+    <isInputValidationEnabled>true</isInputValidationEnabled>
 
     <!--
       Security configurations

--- a/distribution/kernel/carbon-home/repository/conf/carbon.xml
+++ b/distribution/kernel/carbon-home/repository/conf/carbon.xml
@@ -427,6 +427,10 @@
       Enable following config to allow Emails as usernames. 	
     -->
     <EnableEmailUserName>false</EnableEmailUserName>
+    <!--
+       Enable following config to flag input validation configuration.
+    -->
+    <isInputValidationEnabled>true</isInputValidationEnabled>
     <!--EnablePasswordTrim>false</EnablePasswordTrim-->
     <!--
       Security configurations

--- a/distribution/kernel/carbon-home/repository/resources/conf/default.json
+++ b/distribution/kernel/carbon-home/repository/resources/conf/default.json
@@ -221,6 +221,6 @@
   "tenant_mgt.enable_tenant_theme_mgt" : true,
   "tenant_mgt.enable_tenant_validation_for_nonsaas_username" : true,
   "jce_provider.provider_name" : "BC",
-  "signature_util.enable_sha256_algo" : true
-
+  "signature_util.enable_sha256_algo" : true,
+  "tenant_mgt.enable_input_validation" : true
 }

--- a/distribution/kernel/carbon-home/repository/resources/conf/templates/repository/conf/carbon.xml.j2
+++ b/distribution/kernel/carbon-home/repository/resources/conf/templates/repository/conf/carbon.xml.j2
@@ -472,6 +472,10 @@
       Enable following config to allow Emails as usernames.
     -->
     <EnableEmailUserName>{{tenant_mgt.enable_email_domain | default('false')}}</EnableEmailUserName>
+    <!--
+      Enable following config to flag input validation configuration.
+    -->
+    <isInputValidationEnabled>{{tenant_mgt.enable_input_validation}}</isInputValidationEnabled>
     {% if password_trim.enable is defined %}
       <EnablePasswordTrim>{{password_trim.enable}}</EnablePasswordTrim>
     {% endif %}


### PR DESCRIPTION
## Purpose
With https://github.com/wso2/product-is/issues/16357, there will be a behavioural change for carbon console login.
By adding this config, any can falg the carbon to revert previous behaviour for legacy reasons.

Java doc
<img width="559" alt="Screenshot 2023-09-13 at 10 10 31" src="https://github.com/wso2/carbon-kernel/assets/25488962/0109967e-89ae-4261-95ca-a2854aa62b38">
