### PR TITLE
Template STSHostName config

### DIFF
--- a/distribution/kernel/carbon-home/repository/resources/conf/templates/repository/conf/carbon.xml.j2
+++ b/distribution/kernel/carbon-home/repository/resources/conf/templates/repository/conf/carbon.xml.j2
@@ -771,9 +771,13 @@
 
 	<LoadAPIContextsInServerStartup>true</LoadAPIContextsInServerStartup>
    </APIManagement>
-      {% if sts.time_to_live is defined %}
-      <STSTimeToLive>{{sts.time_to_live}}</STSTimeToLive>
-      {% endif %}
+
+    {% if sts.time_to_live is defined %}
+    <STSTimeToLive>{{sts.time_to_live}}</STSTimeToLive>
+    {% endif %}
+    {% if sts.host_name is defined %}
+    <STSHostName>{{sts.host_name}}</STSHostName>
+    {% endif %}
 
 
     <!-- Configure disable/enable shutdown and restart from the Management Console UI -->


### PR DESCRIPTION
## Purpose
- $subject

With this new template, we can add the STSHostName in the `deployment.toml` as follows,

```
[sts]
host_name="STSHostName"
```

### Related Issue(s)
- https://github.com/wso2/product-is/issues/16661