### PR TITLE
Add error code validation for login event 

### DIFF
--- a/core/org.wso2.carbon.ui/src/main/resources/web/admin/login.jsp
+++ b/core/org.wso2.carbon.ui/src/main/resources/web/admin/login.jsp
@@ -113,11 +113,8 @@ String bannerContent = adminConfig.getBannerContent();
         String BUNDLE = "org.wso2.carbon.i18n.Resources";
 
         if (loginStatus != null && "false".equalsIgnoreCase(loginStatus)) {
-            if (StringUtils.isNotBlank(errorCode)) {
-                if (errorCode.equalsIgnoreCase(CarbonUIUtil.geti18nString(errorCode, BUNDLE, request.getLocale()))){
-                    errorCode = "login.fail.message";
-                }
-            }else{
+            if (StringUtils.isBlank(errorCode) ||
+                    errorCode.equalsIgnoreCase(CarbonUIUtil.geti18nString(errorCode, BUNDLE, request.getLocale()))) {
                 errorCode = "login.fail.message";
             }
     %>
@@ -131,11 +128,8 @@ String bannerContent = adminConfig.getBannerContent();
         }
 
         if (loginStatus != null && "failed".equalsIgnoreCase(loginStatus)) {
-            if (StringUtils.isNotBlank(errorCode)) {
-                if (errorCode.equalsIgnoreCase(CarbonUIUtil.geti18nString(errorCode, BUNDLE, request.getLocale()))){
-                    errorCode = "login.fail.message1";
-                }
-            }else{
+            if (StringUtils.isBlank(errorCode) ||
+                    errorCode.equalsIgnoreCase(CarbonUIUtil.geti18nString(errorCode, BUNDLE, request.getLocale()))) {
                 errorCode = "login.fail.message1";
             }
      %>

--- a/core/org.wso2.carbon.ui/src/main/resources/web/admin/login.jsp
+++ b/core/org.wso2.carbon.ui/src/main/resources/web/admin/login.jsp
@@ -27,6 +27,7 @@
 <%@ page import="org.owasp.encoder.Encode" %>
 <%@ page import="org.apache.commons.logging.Log" %>
 <%@ page import="org.apache.commons.logging.LogFactory" %>
+<%@ page import="org.apache.commons.lang.StringUtils" %>
 
 <%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
 <jsp:include page="../dialog/display_messages.jsp"/>

--- a/core/org.wso2.carbon.ui/src/main/resources/web/admin/login.jsp
+++ b/core/org.wso2.carbon.ui/src/main/resources/web/admin/login.jsp
@@ -109,9 +109,11 @@ String bannerContent = adminConfig.getBannerContent();
     <%
         String loginStatus = CharacterEncoder.getSafeText(request.getParameter("loginStatus"));
         String errorCode = CharacterEncoder.getSafeText(request.getParameter("errorCode"));
+        String BUNDLE = "org.wso2.carbon.i18n.Resources";
 
         if (loginStatus != null && "false".equalsIgnoreCase(loginStatus)) {
-            if (errorCode == null) {
+            if (errorCode == null || (!(StringUtils.isBlank(errorCode)) &&
+                    errorCode.equalsIgnoreCase(CarbonUIUtil.geti18nString(errorCode, BUNDLE, request.getLocale())))) {
                 errorCode = "login.fail.message";
             }
     %>
@@ -125,7 +127,8 @@ String bannerContent = adminConfig.getBannerContent();
         }
 
         if (loginStatus != null && "failed".equalsIgnoreCase(loginStatus)) {
-            if (errorCode == null) {
+            if (errorCode == null || (!(StringUtils.isBlank(errorCode)) &&
+                    errorCode.equalsIgnoreCase(CarbonUIUtil.geti18nString(errorCode, BUNDLE, request.getLocale())))) {
                 errorCode = "login.fail.message1";
             }
      %>

--- a/core/org.wso2.carbon.ui/src/main/resources/web/admin/login.jsp
+++ b/core/org.wso2.carbon.ui/src/main/resources/web/admin/login.jsp
@@ -113,8 +113,11 @@ String bannerContent = adminConfig.getBannerContent();
         String BUNDLE = "org.wso2.carbon.i18n.Resources";
 
         if (loginStatus != null && "false".equalsIgnoreCase(loginStatus)) {
-            if (errorCode == null || (!(StringUtils.isBlank(errorCode)) &&
-                    errorCode.equalsIgnoreCase(CarbonUIUtil.geti18nString(errorCode, BUNDLE, request.getLocale())))) {
+            if (StringUtils.isNotBlank(errorCode)) {
+                if (errorCode.equalsIgnoreCase(CarbonUIUtil.geti18nString(errorCode, BUNDLE, request.getLocale()))){
+                    errorCode = "login.fail.message";
+                }
+            }else{
                 errorCode = "login.fail.message";
             }
     %>
@@ -128,8 +131,11 @@ String bannerContent = adminConfig.getBannerContent();
         }
 
         if (loginStatus != null && "failed".equalsIgnoreCase(loginStatus)) {
-            if (errorCode == null || (!(StringUtils.isBlank(errorCode)) &&
-                    errorCode.equalsIgnoreCase(CarbonUIUtil.geti18nString(errorCode, BUNDLE, request.getLocale())))) {
+            if (StringUtils.isNotBlank(errorCode)) {
+                if (errorCode.equalsIgnoreCase(CarbonUIUtil.geti18nString(errorCode, BUNDLE, request.getLocale()))){
+                    errorCode = "login.fail.message1";
+                }
+            }else{
                 errorCode = "login.fail.message1";
             }
      %>


### PR DESCRIPTION
## Purpose
 Any string replaced in as the error code in the url will be displayed as the error message in the UI. This PR adds a validation on the error code where, if the submitted error code does not exist, that will return a generic error message.

