### PR TITLE
Set tenant domain of a user retrieved from UserUniqueIDManger.

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
@@ -11545,6 +11545,7 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
                 boolean status = ((AbstractUserStoreManager) abstractUserStoreManager)
                         .doAuthenticate(user.getUsername(), credential);
                 if (status) {
+                    user.setTenantDomain(getTenantDomain(tenantId));
                     authenticationResult.setAuthenticationStatus(AuthenticationResult.AuthenticationStatus.SUCCESS);
                     authenticationResult.setAuthenticatedUser(user);
                 } else {


### PR DESCRIPTION
#### Describe
When the user is retreived from UserUniqueIDManger the tenant domain has to be set manually. This effort will update the user retrieved, with the relavant tenant domain.

Fixes https://github.com/wso2/product-is/issues/16660