### PR TITLE
Fix NPE with userUniqueIDDomainResolver variable.

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
@@ -7627,7 +7627,7 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
         // First we have to check whether this user store is already resolved and we have it either in the cache or
         // in our local database. If so we can use that.
         String domainName = null;
-        if(userUniqueIDDomainResolver != null) {
+        if (userUniqueIDDomainResolver != null) {
             domainName = userUniqueIDDomainResolver.getDomainForUserId(userId, tenantId);
         }
 

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
@@ -7626,7 +7626,10 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
 
         // First we have to check whether this user store is already resolved and we have it either in the cache or
         // in our local database. If so we can use that.
-        String domainName = userUniqueIDDomainResolver.getDomainForUserId(userId, tenantId);
+        String domainName = null;
+        if(userUniqueIDDomainResolver != null) {
+            domainName = userUniqueIDDomainResolver.getDomainForUserId(userId, tenantId);
+        }
 
         // If we don't have the domain name in our side, then we have to iterate through each user store and find
         // where is this user id from and mark it as the user store domain.


### PR DESCRIPTION
## Purpose
The userUniqueIDDomainResolver variable throws NPE. This effort will add the null check for the variable as the rest of the logic handles the case where the domain is null.

## Related issues
- Detected the issue while fixing this.
    - https://github.com/wso2/product-is/issues/12503