### PR TITLE
Fix issue in initializing IterativeUserStoreManager.

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
@@ -189,7 +189,7 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
     private boolean userRolesCacheEnabled = true;
     private String cacheIdentifier;
     private boolean replaceEscapeCharactersAtUserLogin = true;
-    private Map<String, UserStoreManager> userStoreManagerHolder = new HashMap<String, UserStoreManager>();
+    protected Map<String, UserStoreManager> userStoreManagerHolder = new HashMap<String, UserStoreManager>();
     private Map<String, Integer> maxUserListCount = null;
     private Map<String, Integer> maxRoleListCount = null;
     private List<UserStoreManagerConfigurationListener> listener = new ArrayList<UserStoreManagerConfigurationListener>();
@@ -201,7 +201,7 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
     };
 
     private UserUniqueIDManger userUniqueIDManger = new UserUniqueIDManger();
-    private UserUniqueIDDomainResolver userUniqueIDDomainResolver;
+    protected UserUniqueIDDomainResolver userUniqueIDDomainResolver;
     private GroupUniqueIDDomainResolver groupUniqueIDDomainResolver;
 
     private void setClaimManager(ClaimManager claimManager) throws IllegalAccessException {
@@ -17984,5 +17984,25 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
             return Integer.parseInt(pwValidityTimeoutStr);
         }
         return DEFAULT_PASSWORD_VALIDITY_PERIOD_VALUE;
+    }
+
+    /**
+     * Getter for the user store manager holder.
+     *
+     * @return Map of user store managers.
+     */
+    public Map<String, UserStoreManager> getUserStoreManagerHolder() {
+
+        return userStoreManagerHolder;
+    }
+
+    /**
+     * Getter for the user unique ID domain resolver.
+     *
+     * @return UserUniqueIDDomainResolver.
+     */
+    public UserUniqueIDDomainResolver getUserUniqueIDDomainResolver() {
+
+        return userUniqueIDDomainResolver;
     }
 }

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/IterativeUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/IterativeUserStoreManager.java
@@ -40,6 +40,8 @@ public class IterativeUserStoreManager extends AbstractUserStoreManager {
         this.claimManager = abstractUserStoreManager.getClaimManager();
         this.realmConfig = abstractUserStoreManager.getRealmConfiguration();
         this.tenantId = abstractUserStoreManager.getTenantId();
+        this.userStoreManagerHolder = abstractUserStoreManager.getUserStoreManagerHolder();
+        this.userUniqueIDDomainResolver = abstractUserStoreManager.getUserUniqueIDDomainResolver();
     }
 
     /**


### PR DESCRIPTION
## Purpose
> Fix issue in initializing IterativeUserStoreManager using AbstractUserStoreManager. In the multi attribute login flow when user store preference order is configured, as the initialization doesn't involve transferring `userStoreManagerHolder` and `UserUniqueIDDomainResolver` field to IterativeUserStoreManager from AbstractUserStoreManager. This effort will fix this issue.

## Context
When the multi attribute login is not enabled, [1] is used to resolve the relavant userstore of the user which uses realm configs to resolve the userstore. The releam config is getting transferred from AbstractUserStoreManager to IterativeUserStoreManager [2]. 

In the case of multi attribute login is enabled, [3] is used to resolve the relavant userstore of the user which uses either userStoreManagerHolder or userUniqueIDDomainResolver to resolve the userstore. Before this effort its not getting transferred. Therefore always recieved PRIMARY as the userstore, hence the authentication failed.

[1] https://github.com/wso2/carbon-kernel/blob/f2e32feedcbd144b50ed4c7931828a78250d02b7/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java#L7616

[2] https://github.com/wso2/carbon-kernel/blob/f2e32feedcbd144b50ed4c7931828a78250d02b7/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/IterativeUserStoreManager.java#L41

[3] https://github.com/wso2/carbon-kernel/blob/f2e32feedcbd144b50ed4c7931828a78250d02b7/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java#L7384

## Related PR
- https://github.com/wso2/carbon-kernel/pull/3682