### PR TITLE
Implementation to store user attribute values as unicode characters

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/JDBCUserStoreConstants.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/JDBCUserStoreConstants.java
@@ -52,7 +52,7 @@ public class JDBCUserStoreConstants {
     private static final String DISPLAY_NAME_ATTRIBUTE_DESCRIPTION = "This is the attribute name to display as the " +
             "display name of the user";
     public static final String DISPLAY_NAME_ATTRIBUTE = "DisplayNameAttribute";
-    public static final String STORE_USER_ATTRIBUTE_VALUE_AS_UNICODE = "storeUserAttributeValueAsUnicode";
+    public static final String STORE_USER_ATTRIBUTE_VALUE_AS_UNICODE = "StoreUserAttributeValueAsUnicode";
 
     static {
 
@@ -284,6 +284,10 @@ public class JDBCUserStoreConstants {
                 "org.wso2.carbon.identity.user.store.count.jdbc.JDBCUserStoreCountRetriever",
                 "Name of the class that implements the count functionality",
                 new Property[] { CONNECTION.getProperty(), STRING.getProperty(), FALSE.getProperty() });
+
+        setAdvancedProperty(STORE_USER_ATTRIBUTE_VALUE_AS_UNICODE, "Store User Attribute Value As Unicode", "false",
+                "Store user attribute value as unicode",
+                new Property[] { CONNECTION.getProperty(), BOOLEAN.getProperty(), FALSE.getProperty() });
 
         //Advanced Properties (No descriptions added for each property)
         setAdvancedProperty(JDBCRealmConstants.SELECT_USER, "Select User SQL", JDBCRealmConstants.SELECT_USER_SQL, "",

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/JDBCUserStoreConstants.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/JDBCUserStoreConstants.java
@@ -52,6 +52,7 @@ public class JDBCUserStoreConstants {
     private static final String DISPLAY_NAME_ATTRIBUTE_DESCRIPTION = "This is the attribute name to display as the " +
             "display name of the user";
     public static final String DISPLAY_NAME_ATTRIBUTE = "DisplayNameAttribute";
+    public static final String STORE_USER_ATTRIBUTE_VALUE_AS_UNICODE = "storeUserAttributeValueAsUnicode";
 
     static {
 

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/JDBCUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/JDBCUserStoreManager.java
@@ -2674,7 +2674,11 @@ public class JDBCUserStoreManager extends AbstractUserStoreManager {
                     if (param == null) {
                         throw new UserStoreException("Invalid data provided");
                     } else if (param instanceof String) {
-                        prepStmt.setString(i + 1, (String) param);
+                        if (isStoreUserAttributeAsUnicode()) {
+                            prepStmt.setNString(i + 1, (String) param);
+                        } else {
+                            prepStmt.setString(i + 1, (String) param);
+                        }
                     } else if (param instanceof Integer) {
                         prepStmt.setInt(i + 1, (Integer) param);
                     } else if (param instanceof Date) {
@@ -3137,7 +3141,11 @@ public class JDBCUserStoreManager extends AbstractUserStoreManager {
             prepStmt = dbConnection.prepareStatement(sqlStmt);
             int count = 0;
             prepStmt.setString(++count, property);
-            prepStmt.setString(++count, value);
+            if (isStoreUserAttributeAsUnicode()){
+                prepStmt.setNString(++count, value);
+            } else {
+                prepStmt.setString(++count, value);
+            }
             if (sqlStmt.toUpperCase().contains(UserCoreConstants.SQL_ESCAPE_KEYWORD)) {
                 prepStmt.setString(++count, SQL_FILTER_CHAR_ESCAPE);
             }
@@ -3702,7 +3710,11 @@ public class JDBCUserStoreManager extends AbstractUserStoreManager {
                     if (param == null) {
                         throw new UserStoreException("Invalid data provided");
                     } else if (param instanceof String) {
-                        prepStmt.setString(i + 1, (String) param);
+                        if (isStoreUserAttributeAsUnicode()) {
+                            prepStmt.setNString(i + 1, (String) param);
+                        } else {
+                            prepStmt.setString(i + 1, (String) param);
+                        }
                     } else if (param instanceof Integer) {
                         prepStmt.setInt(i + 1, (Integer) param);
                     } else if (param instanceof Date) {
@@ -3956,7 +3968,11 @@ public class JDBCUserStoreManager extends AbstractUserStoreManager {
             } else {
                 prepStmt.setString(1, userRealm.getClaimManager().getAttributeName(domainName, claimUri));
                 prepStmt.setInt(2, tenantId);
-                prepStmt.setString(3, valueFilter);
+                if (isStoreUserAttributeAsUnicode()) {
+                    prepStmt.setNString(3, valueFilter);
+                } else {
+                    prepStmt.setString(3, valueFilter);
+                }
                 prepStmt.setString(4, UserCoreConstants.DEFAULT_PROFILE);
             }
 
@@ -4168,7 +4184,11 @@ public class JDBCUserStoreManager extends AbstractUserStoreManager {
             }
             prepStmt = dbConnection.prepareStatement(sqlStmt);
             prepStmt.setString(1, property);
-            prepStmt.setString(2, value);
+            if (isStoreUserAttributeAsUnicode()) {
+                prepStmt.setNString(2, value);
+            } else {
+                prepStmt.setString(2, value);
+            }
             prepStmt.setString(3, profileName);
             if (sqlStmt.contains(UserCoreConstants.UM_TENANT_COLUMN)) {
                 prepStmt.setInt(4, tenantId);
@@ -4340,7 +4360,11 @@ public class JDBCUserStoreManager extends AbstractUserStoreManager {
 
         for (Map.Entry<Integer, String> entry : stringParameters.entrySet()) {
             if (entry.getKey() > startIndex && entry.getKey() <= endIndex) {
-                prepStmt.setString(entry.getKey() - startIndex, entry.getValue());
+                if (isStoreUserAttributeAsUnicode()){
+                    prepStmt.setNString(entry.getKey() - startIndex, entry.getValue());
+                } else {
+                    prepStmt.setString(entry.getKey() - startIndex, entry.getValue());
+                }
             }
         }
 
@@ -4767,7 +4791,11 @@ public class JDBCUserStoreManager extends AbstractUserStoreManager {
             sqlStmt = realmConfig.getUserStoreProperty(JDBCRealmConstants.GET_PAGINATED_USERS_COUNT_FOR_PROP);
             prepStmt = dbConnection.prepareStatement(sqlStmt);
             prepStmt.setString(1, property);
-            prepStmt.setString(2, value);
+            if (isStoreUserAttributeAsUnicode()) {
+                prepStmt.setNString(2, value);
+            } else {
+                prepStmt.setString(2, value);
+            }
             prepStmt.setString(3, profileName);
             if (sqlStmt.contains(UserCoreConstants.UM_TENANT_COLUMN)) {
                 prepStmt.setInt(4, tenantId);
@@ -4881,5 +4909,16 @@ public class JDBCUserStoreManager extends AbstractUserStoreManager {
     private boolean isH2DB(Connection dbConnection) throws Exception {
 
         return H2.equalsIgnoreCase(DatabaseCreator.getDatabaseType(dbConnection));
+    }
+
+    /**
+     * Check if storing user attribute values as unicode is enabled.
+     *
+     * @return true if DB2, false otherwise.
+     */
+    public boolean isStoreUserAttributeAsUnicode() {
+
+        return Boolean.parseBoolean(realmConfig.getUserStoreProperty(
+                JDBCUserStoreConstants.STORE_USER_ATTRIBUTE_VALUE_AS_UNICODE));
     }
 }

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCUserStoreManager.java
@@ -839,7 +839,11 @@ public class UniqueIDJDBCUserStoreManager extends JDBCUserStoreManager {
 
             prepStmt = dbConnection.prepareStatement(sqlstmt);
             prepStmt.setString(1, preferredUserNameProperty);
-            prepStmt.setString(2, preferredUserNameValue);
+            if (isStoreUserAttributeAsUnicode()) {
+                prepStmt.setNString(2, preferredUserNameValue);
+            } else {
+                prepStmt.setString(2, preferredUserNameValue);
+            }
             prepStmt.setString(3, profileName);
             if (sqlstmt.contains(UserCoreConstants.UM_TENANT_COLUMN)) {
                 prepStmt.setInt(4, tenantId);
@@ -2166,7 +2170,11 @@ public class UniqueIDJDBCUserStoreManager extends JDBCUserStoreManager {
                     if (param == null) {
                         throw new UserStoreException("Invalid data provided");
                     } else if (param instanceof String) {
-                        prepStmt.setString(i + 1, (String) param);
+                        if (isStoreUserAttributeAsUnicode()) {
+                            prepStmt.setNString(i + 1, (String) param);
+                        } else {
+                            prepStmt.setString(i + 1, (String) param);
+                        }
                     } else if (param instanceof Integer) {
                         prepStmt.setInt(i + 1, (Integer) param);
                     } else if (param instanceof Date) {
@@ -2375,7 +2383,11 @@ public class UniqueIDJDBCUserStoreManager extends JDBCUserStoreManager {
             dbConnection = getDBConnection();
             prepStmt = dbConnection.prepareStatement(sqlStmt);
             prepStmt.setString(1, property);
-            prepStmt.setString(2, value);
+            if (isStoreUserAttributeAsUnicode()) {
+                prepStmt.setNString(2, value);
+            } else {
+                prepStmt.setString(2, value);
+            }
             prepStmt.setString(3, profileName);
             if (sqlStmt.contains(UserCoreConstants.UM_TENANT_COLUMN)) {
                 prepStmt.setInt(4, tenantId);
@@ -2870,7 +2882,11 @@ public class UniqueIDJDBCUserStoreManager extends JDBCUserStoreManager {
                     if (param == null) {
                         throw new UserStoreException("Invalid data provided");
                     } else if (param instanceof String) {
-                        prepStmt.setString(i + 1, (String) param);
+                        if (isStoreUserAttributeAsUnicode()) {
+                            prepStmt.setNString(i + 1, (String) param);
+                        } else {
+                            prepStmt.setString(i + 1, (String) param);
+                        }
                     } else if (param instanceof Integer) {
                         prepStmt.setInt(i + 1, (Integer) param);
                     } else if (param instanceof Date) {
@@ -3178,7 +3194,11 @@ public class UniqueIDJDBCUserStoreManager extends JDBCUserStoreManager {
             }
             prepStmt = dbConnection.prepareStatement(sqlStmt);
             prepStmt.setString(1, property);
-            prepStmt.setString(2, value);
+            if (isStoreUserAttributeAsUnicode()) {
+                prepStmt.setNString(2, value);
+            } else {
+                prepStmt.setString(2, value);
+            }
             prepStmt.setString(3, profileName);
             if (sqlStmt.contains(UserCoreConstants.UM_TENANT_COLUMN)) {
                 prepStmt.setInt(4, tenantId);
@@ -3247,7 +3267,11 @@ public class UniqueIDJDBCUserStoreManager extends JDBCUserStoreManager {
             sqlStmt = realmConfig.getUserStoreProperty(JDBCRealmConstants.GET_PAGINATED_USERS_COUNT_FOR_PROP_WITH_ID);
             prepStmt = dbConnection.prepareStatement(sqlStmt);
             prepStmt.setString(1, property);
-            prepStmt.setString(2, value);
+            if (isStoreUserAttributeAsUnicode()) {
+                prepStmt.setNString(2, value);
+            } else {
+                prepStmt.setString(2, value);
+            }
             prepStmt.setString(3, profileName);
             if (sqlStmt.contains(UserCoreConstants.UM_TENANT_COLUMN)) {
                 prepStmt.setInt(4, tenantId);
@@ -3423,7 +3447,11 @@ public class UniqueIDJDBCUserStoreManager extends JDBCUserStoreManager {
 
         for (Map.Entry<Integer, String> entry : stringParameters.entrySet()) {
             if (entry.getKey() > startIndex && entry.getKey() <= endIndex) {
-                prepStmt.setString(entry.getKey() - startIndex, entry.getValue());
+                if (isStoreUserAttributeAsUnicode()) {
+                    prepStmt.setNString(entry.getKey() - startIndex, entry.getValue());
+                } else {
+                    prepStmt.setString(entry.getKey() - startIndex, entry.getValue());
+                }
             }
         }
 

--- a/distribution/kernel/carbon-home/repository/resources/conf/infer.json
+++ b/distribution/kernel/carbon-home/repository/resources/conf/infer.json
@@ -30,6 +30,7 @@
       "user_store.properties.StoreSaltedPassword": true,
       "user_store.properties.UserRolesCacheEnabled": true,
       "user_store.properties.UserNameUniqueAcrossTenants": false,
+      "user_store.properties.StoreUserAttributeValueAsUnicode": false,
       "tenant_mgt.tenant_manager.type": "jdbc"
     },
     "read_only_ldap": {


### PR DESCRIPTION
## Purpose
- Currently we are storing user attribute values of a user as ASCII characters to the database.
- We were using `setString()` method to add string values to a prepared SQL statement. This will send the string value as non unicode characters.
- With this PR, we will be using `setNString()` method to add string values to a prepared SQL statement. This will send the string value as unicode characters to the database.
- `isStoreUserAttributeAsUnicode()` method is implemented to check whether the particular userstore is enabled to store user attribute values as unicode characters. Within the method, it will check for the boolean value of a userstore property named `storeUserAttributeValueAsUnicode`

## Prerequisites
- To store unicode values in the database, the data column should be in type of `NVARCHAR`. So, if the type of `UM_ATTTR_VALUE` column from `UM_USER_ATTRIBUTE` table is defined as `VARCHAR`, it has to be converted to `NVARCHAR`.

## Important
- enabling the userstore property without converting the type of the data column to NVARCHAR will cost your DB performance.