### PR TITLE
Removed Deprecated Management Console URL from startup logs

### DIFF
--- a/core/org.wso2.carbon.ui/src/main/java/org/wso2/carbon/ui/internal/CarbonUIServiceComponent.java
+++ b/core/org.wso2.carbon.ui/src/main/java/org/wso2/carbon/ui/internal/CarbonUIServiceComponent.java
@@ -125,9 +125,6 @@ public class CarbonUIServiceComponent {
                         "WebContextRoot can't be null or empty. It should be either '/' or '/[some value]'");
             }
             String adminConsoleURL = CarbonUIUtil.getAdminConsoleURL(webContextRoot);
-            if (adminConsoleURL != null) {
-                log.info("Mgt Console URL  : " + adminConsoleURL);
-            }
 
             //Retrieving available contexts
             ServiceReference reference =


### PR DESCRIPTION
## Purpose
> $subject

### Before
<img width="1509" alt="image" src="https://github.com/wso2/carbon-kernel/assets/75057725/14f5b9e1-10ee-4b5c-9cb9-e8edecec0287">
### After
<img width="1510" alt="image" src="https://github.com/wso2/carbon-kernel/assets/75057725/69de3cac-f577-4de8-a7e9-008a5c2e4740">

## Related Issue
- https://github.com/wso2/product-is/issues/17698
