### PR TITLE
Remove MD5 default usage

### DIFF
--- a/distribution/kernel/carbon-home/repository/resources/conf/default.json
+++ b/distribution/kernel/carbon-home/repository/resources/conf/default.json
@@ -220,7 +220,7 @@
   "sts.callback_handler" : "org.wso2.carbon.identity.sts.common.identity.provider.AttributeCallbackHandler",
   "tenant_mgt.enable_tenant_theme_mgt" : true,
   "tenant_mgt.enable_tenant_validation_for_nonsaas_username" : true,
-  "tenant_mgt.signing_alg" : "MD5withRSA",
+  "tenant_mgt.signing_alg" : "SHA256withRSA",
   "jce_provider.provider_name" : "BC",
   "signature_util.enable_sha256_algo" : true,
   "tenant_mgt.enable_input_validation" : false,


### PR DESCRIPTION
## Proposed changes in this pull request

The default behavior of our products uses MD5 which is no longer considered as secure. This PR changes the default usage to SHA256 in the following flows.
- Tenant Creation: Public certificate signing for keystore

## Migration impact
Changes to signature and digest algorithms will only affect newly created Tenants

Public certificates of newly created keystores will be signed using SHA256withRSA. To revert this behavior, use the following deployment.toml config. 
```
[tenant_mgt]
signing_alg = "MD5withRSA"
```

## Related issues
 
- Issue https://github.com/wso2/product-is/issues/16817
- Issue https://github.com/wso2/product-is/issues/17851

