### PR TITLE
Change SHA1 default usage for passiveSTS

### DIFF
--- a/distribution/kernel/carbon-home/repository/resources/conf/default.json
+++ b/distribution/kernel/carbon-home/repository/resources/conf/default.json
@@ -218,6 +218,8 @@
   "versioning_configuration.enable_versioning_ratings": false,
   "versioning_configuration.enable_version_resources_on_change" : false,
   "sts.callback_handler" : "org.wso2.carbon.identity.sts.common.identity.provider.AttributeCallbackHandler",
+  "sts.signature_algorithm" : "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256",
+  "sts.digest_algorithm" : "http://www.w3.org/2001/04/xmlenc#sha256",
   "tenant_mgt.enable_tenant_theme_mgt" : true,
   "tenant_mgt.enable_tenant_validation_for_nonsaas_username" : true,
   "tenant_mgt.signing_alg" : "SHA256withRSA",


### PR DESCRIPTION
## Purpose

The default behavior of our products uses SHA1 which is no longer considered as secure. This PR changes the SHA1 usages of the following flows to SHA256.

- Default response signing method and response digest method in Passive STS response.

### Migration impact
The default signing and digest algorithms of Passive STS response would change for all existing apps. The following config can be used to revert enabling the default SHA256 signing and digest algorithms in Passive STS response.
```
[sts]
signature_algorithm = "http://www.w3.org/2000/09/xmldsig#rsa-sha1"
digest_algorithm = "http://www.w3.org/2000/09/xmldsig#sha1"
```

## Related issues
 
- Issue https://github.com/wso2/product-is/issues/15793

## Related PRs

- PR https://github.com/wso2/carbon-identity-framework/pull/4567
- PR https://github.com/wso2-extensions/identity-outbound-auth-samlsso/pull/162
- PR https://github.com/wso2-extensions/identity-metadata-saml2/pull/85
- PR https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/2076
- PR https://github.com/wso2/cipher-tool/pull/78
- PR https://github.com/wso2/carbon-kernel/pull/3574
- PR https://github.com/wso2-extensions/identity-user-account-association/pull/47
- PR https://github.com/wso2-enterprise/asgardeo-website/pull/639
- PR https://github.com/wso2-extensions/identity-governance/pull/707
- PR https://github.com/wso2-extensions/identity-inbound-auth-openid/pull/92
- PR https://github.com/wso2-extensions/identity-outbound-auth-sms-otp/pull/173
- PR https://github.com/wso2-extensions/identity-outbound-auth-email-otp/pull/157

## Documentation

- PR https://github.com/wso2/docs-is/pull/3717