### PR TITLE
Deprecate public method and remove its user to mitigate security vulnerability

### DIFF
--- a/core/org.wso2.carbon.registry.core/src/main/java/org/wso2/carbon/registry/core/jdbc/handlers/CustomEditManager.java
+++ b/core/org.wso2.carbon.registry.core/src/main/java/org/wso2/carbon/registry/core/jdbc/handlers/CustomEditManager.java
@@ -113,16 +113,5 @@ public class CustomEditManager {
             path = request.getParameter("parentPath");
             responseSent = editProcessor.processNewContent(path, viewKey, request, response);
         }
-
-        if (!responseSent) {
-            String redirectURL = request.getParameter("redirectURL");
-            if (redirectURL != null) {
-                RegistryUtils.redirect(response, redirectURL);
-            } else {
-                ResourcePath resourcePath = new ResourcePath(path);
-                RegistryUtils.redirect(
-                        response, "/wso2registry/web" + resourcePath.getPathWithVersion());
-            }
-        }
     }
 }

--- a/core/org.wso2.carbon.registry.core/src/main/java/org/wso2/carbon/registry/core/utils/RegistryUtils.java
+++ b/core/org.wso2.carbon.registry.core/src/main/java/org/wso2/carbon/registry/core/utils/RegistryUtils.java
@@ -411,6 +411,7 @@ public final class RegistryUtils {
      * @param response the HTTP Response.
      * @param url      The URL to redirect to.
      */
+    @Deprecated
     public static void redirect(HttpServletResponse response, String url) {
 
         try {


### PR DESCRIPTION
The redirect() method accepts a url which is directly retrieved from the parameter sent through the request which can contain non-legit urls which can leas to phishing attacks. Hence removing the usage of the code since there are no usecases found which triggers the relevant method and deprecating the public method.