### PR TITLE
Suppress stack trace from being displayed to end users

### DIFF
--- a/core/org.wso2.carbon.registry.core/src/main/java/org/wso2/carbon/registry/app/RemoteResourceImpl.java
+++ b/core/org.wso2.carbon.registry.core/src/main/java/org/wso2/carbon/registry/app/RemoteResourceImpl.java
@@ -150,8 +150,9 @@ public class RemoteResourceImpl extends ResourceImpl {
                 return uc.getInputStream();
 
             } catch (IOException e) {
-                throw new RegistryException("Couldn't open stream to source URL " + contentURL,
-                        new Throwable("Couldn't open stream to source URL " + contentURL));
+                String message = "Couldn't open stream to source URL " + contentURL;
+                log.debug(message, e);
+                throw new RegistryException(message, new RegistryException(message));
             }
         }
 

--- a/core/org.wso2.carbon.registry.core/src/main/java/org/wso2/carbon/registry/app/RemoteResourceImpl.java
+++ b/core/org.wso2.carbon.registry.core/src/main/java/org/wso2/carbon/registry/app/RemoteResourceImpl.java
@@ -150,7 +150,8 @@ public class RemoteResourceImpl extends ResourceImpl {
                 return uc.getInputStream();
 
             } catch (IOException e) {
-                throw new RegistryException("Couldn't open stream to source URL " + contentURL, e);
+                throw new RegistryException("Couldn't open stream to source URL " + contentURL,
+                        new Throwable("Couldn't open stream to source URL " + contentURL));
             }
         }
 


### PR DESCRIPTION
## Purpose
> Return generic error messages and to suppress stack traces from being displayed to end users.  

### Reason
> The application calls the java.net.URL.openConnection() function, which will result in data being transferred out of the application (via the network or another medium). As these data can be potentially sensitive, the stack trace of exception need to be suppressed. 