### PR TITLE
Select and apply Update lock to user attribute rows before update

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/JDBCRealmConstants.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/JDBCRealmConstants.java
@@ -130,6 +130,7 @@ public final class JDBCRealmConstants {
     public static final String ADD_USER_PROPERTY_WITH_ID = "AddUserPropertyWithIDSQL";
     public static final String UPDATE_USER_PROPERTY = "UpdateUserPropertySQL";
     public static final String UPDATE_USER_PROPERTY_WITH_ID = "UpdateUserPropertyWithIDSQL";
+    public static final String SELECT_USER_PROPERTIES_WITH_ID = "SelectUserPropertiesWithIDSQL";
     public static final String DELETE_USER_PROPERTY = "DeleteUserPropertySQL";
     public static final String DELETE_USER_PROPERTY_WITH_ID = "DeleteUserPropertyWWithIDSQL";
     public static final String USER_NAME_UNIQUE = "UserNameUniqueAcrossTenantsSQL";
@@ -440,6 +441,7 @@ public final class JDBCRealmConstants {
     public static final String UPDATE_USER_PROPERTY_WITH_ID_SQL = "UPDATE UM_USER_ATTRIBUTE SET UM_ATTR_VALUE=? WHERE "
             + "UM_USER_ID=(SELECT UM_ID FROM UM_USER WHERE UM_USER_ID=? AND UM_TENANT_ID=?) AND UM_ATTR_NAME=? AND "
             + "UM_PROFILE_ID=? AND UM_TENANT_ID=?";
+    public static final String SELECT_USER_PROPERTIES_WITH_ID_SQL = "SELECT * FROM UM_USER_ATTRIBUTE WITH (UPDLOCK) WHERE UM_USER_ID=(SELECT UM_ID FROM UM_USER WHERE UM_USER_ID=? AND UM_TENANT_ID=?) ORDER BY UM_ID;";
     public static final String DELETE_USER_PROPERTY_SQL = "DELETE FROM UM_USER_ATTRIBUTE WHERE UM_USER_ID=(SELECT UM_ID FROM UM_USER WHERE UM_USER_NAME=? AND UM_TENANT_ID=?) AND UM_ATTR_NAME=? AND UM_PROFILE_ID=? AND UM_TENANT_ID=?";
     public static final String DELETE_USER_PROPERTY_WITH_ID_SQL = "DELETE FROM UM_USER_ATTRIBUTE WHERE UM_USER_ID="
             + "(SELECT UM_ID FROM UM_USER WHERE UM_USER_ID=? AND UM_TENANT_ID=?) AND UM_ATTR_NAME=? AND "

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/JDBCUserStoreConstants.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/JDBCUserStoreConstants.java
@@ -654,6 +654,9 @@ public class JDBCUserStoreConstants {
         setAdvancedProperty(JDBCRealmConstants.UPDATE_USER_PROPERTY_WITH_ID, "Update User Property With ID SQL",
                 JDBCRealmConstants.UPDATE_USER_PROPERTY_WITH_ID_SQL, "",
                 new Property[] { USER.getProperty(), SQL.getProperty(), FALSE.getProperty() });
+        setAdvancedProperty(JDBCRealmConstants.SELECT_USER_PROPERTIES_WITH_ID, "Select User Properties With ID SQL",
+                JDBCRealmConstants.SELECT_USER_PROPERTIES_WITH_ID_SQL, "",
+                new Property[] { USER.getProperty(), SQL.getProperty(), FALSE.getProperty() });
         setAdvancedProperty(JDBCCaseInsensitiveConstants.UPDATE_USER_PROPERTY_CASE_INSENSITIVE,
                 "Update User Property SQL With Case Insensitive Username",
                 JDBCCaseInsensitiveConstants.UPDATE_USER_PROPERTY_SQL_CASE_INSENSITIVE, "",

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/util/JDBCRealmUtil.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/util/JDBCRealmUtil.java
@@ -463,6 +463,10 @@ public class JDBCRealmUtil {
             properties.put(JDBCRealmConstants.UPDATE_USER_PROPERTY_WITH_ID,
                     JDBCRealmConstants.UPDATE_USER_PROPERTY_WITH_ID_SQL);
         }
+        if (!properties.containsKey(JDBCRealmConstants.SELECT_USER_PROPERTIES_WITH_ID)) {
+            properties.put(JDBCRealmConstants.SELECT_USER_PROPERTIES_WITH_ID,
+                    JDBCRealmConstants.SELECT_USER_PROPERTIES_WITH_ID_SQL);
+        }
         if (!properties.containsKey(JDBCRealmConstants.DELETE_USER_PROPERTY)) {
             properties.put(JDBCRealmConstants.DELETE_USER_PROPERTY,
                     JDBCRealmConstants.DELETE_USER_PROPERTY_SQL);


### PR DESCRIPTION
## Purpose
> This PR applies an update lock to the user attribute rows of the user being updated, before the update operation is executed. This is to prevent the deadlock in the related issue.

## Goals
> Fix the deadlock issue occurring when concurrent user update requests are made (different users are updated)

## Approach
> Do a SELECT on the relevant rows of a particular user and apply an UPDATE lock on these rows in a deterministic order specified by ORDER BY before executing the update. This ensures that all competing transactions acquire locks in the same order, minimizing the potential for deadlocks [1].

[1] https://dba.stackexchange.com/questions/257217/why-am-i-getting-a-deadlock-for-a-single-update-query

## Related Issues
- Issue https://github.com/wso2-enterprise/asgardeo-product/issues/21031