### PR TITLE
Add required connection string parameter for db2 database to avoid progressive streaming

### DIFF
--- a/distribution/kernel/carbon-home/repository/resources/conf/infer.json
+++ b/distribution/kernel/carbon-home/repository/resources/conf/infer.json
@@ -263,7 +263,7 @@
     },
     "db2": {
       "database.$1.driver": "com.ibm.db2.jcc.DB2Driver",
-      "database.$1.url": "jdbc:db2://$ref{database.$1.hostname}:$ref{database.$1.port}/$ref{database.$1.name}",
+      "database.$1.url": "jdbc:db2://$ref{database.$1.hostname}:$ref{database.$1.port}/$ref{database.$1.name}:progressiveStreaming=2;",
       "database.$1.validationQuery": "SELECT 1 FROM sysibm.sysdummy1"
     },
     "postgre": {


### PR DESCRIPTION
**Purpose:**
The JSON file related to the specific branding preference is being saved in the database as BLOB objects. In DB2 database, the datasource will dynamically determines the most efficient mode to return BLOB or XML data. This step is based on the size of the LOBs or XML objects.

The DB2 JDBC drivers have a parameter named `progressiveStreaming` to decide how such objects should be returned. If the value is not set or if the value is set to 1, the driver will not load the LOB data into memory all at once, but will instead load it in small chunks as you access the data. This will not be suitable for our implementation. Hence, this parameter has to be specified in the connection string as `progressiveStreaming=2` which will disable the progressive streaming.

Since this is a must required connection string parameter, we are setting it in our infer.json which will not require the user to configure the parameter manually through `deployment.toml`

**Related issue:**
- https://github.com/wso2/product-is/issues/18319

References:
[1] https://github.com/wso2/product-is/issues/18319#issuecomment-1843701560