### PR TITLE
Throw client exception if mapped attribute name not found

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
@@ -3956,8 +3956,8 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
             } else if (DISAPLAY_NAME_CLAIM.equals(claimURI)) {
                 attributeName = this.realmConfig.getUserStoreProperty(LDAPConstants.DISPLAY_NAME_ATTRIBUTE);
             } else {
-                throw new UserStoreException("Mapped attribute cannot be found for claim : " + claimURI + " in user " +
-                        "store : " + getMyDomainName());
+                throw new UserStoreClientException("Mapped attribute cannot be found for claim : " + claimURI +
+                        " in user store : " + getMyDomainName());
             }
         }
 


### PR DESCRIPTION
## Purpose
> Currently a server error log is logged if the mapped attribute name of a claim is not found. This happens if an attribute that is not created locally is modified through an adaptive script. Since this is a client error, this PR changes the error to a client error instead. 

## Related Issues
- Issue https://github.com/wso2-enterprise/asgardeo-product/issues/21112