### PR TITLE
Apply select with update lock only for MSSQL

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCUserStoreManager.java
@@ -2840,8 +2840,11 @@ public class UniqueIDJDBCUserStoreManager extends JDBCUserStoreManager {
             }
 
             // Select and update lock the rows to be updated in a particular order before the actual update operation to
-            // prevent the deadlock scenario in issue https://github.com/wso2-enterprise/asgardeo-product/issues/21031
-            selectRowsForUpdate(dbConnection, userID);
+            // prevent the deadlock scenario in issue https://github.com/wso2-enterprise/asgardeo-product/issues/21031.
+            // Currently, this issue is only reproduced in SQL Server.
+            if (isMSSQLDB(dbConnection)) {
+                selectRowsForUpdate(dbConnection, userID);
+            }
             int[] counts = prepStmt.executeBatch();
             if (log.isDebugEnabled()) {
                 int totalUpdated = 0;
@@ -3939,6 +3942,21 @@ public class UniqueIDJDBCUserStoreManager extends JDBCUserStoreManager {
                 log.debug(errorMessage, e);
             }
             throw new UserStoreException(errorMessage, e);
+        }
+    }
+
+    /**
+     * Check if the DB is MSSQL.
+     *
+     * @return true if MSSQL, false otherwise.
+     * @throws UserStoreException if error occurred while getting database type.
+     */
+    private boolean isMSSQLDB(Connection dbConnection) throws UserStoreException {
+
+        try {
+            return MSSQL.equalsIgnoreCase(DatabaseCreator.getDatabaseType(dbConnection));
+        } catch (Exception e) {
+            throw new UserStoreException("Error while retrieving the DB type. ", e);
         }
     }
 }


### PR DESCRIPTION
## Purpose
> The related PR added a change where an update lock is applied to the relevant user attribute rows before being updated. It was noted that this deadlock scenario occurs only in SQL Server, and this syntax of using lock hints `WITH (UPDLOCK)` is only supported in MSSQL. The deadlock scenario is not reproduced in H2. Therefore this PR excludes other types of DBs from being affected by this fix.
Note: If we are to use the same fix in any other DB in future, we have to use the syntax `SELECT ... FOR UPDATE`.

## Related PRs
- PR https://github.com/wso2/carbon-kernel/pull/3748

## Related Issues
- Issue https://github.com/wso2-enterprise/asgardeo-product/issues/21031

