### PR TITLE
[perf] Add super tenant check for tenant resolving logic

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/tenant/JDBCTenantManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/tenant/JDBCTenantManager.java
@@ -426,9 +426,10 @@ public class JDBCTenantManager implements TenantManager {
     @SuppressWarnings("unchecked")
     public Tenant getTenant(int tenantId) throws UserStoreException {
 
-
+        if (tenantId == MultitenantConstants.SUPER_TENANT_ID) {
+            return null;
+        }
         TenantCacheEntry<Tenant> entry = tenantCacheManager.getValueFromCache(new TenantIdKey(tenantId));
-
         if ((entry != null) && (entry.getTenant() != null)) {
             return entry.getTenant();
         }


### PR DESCRIPTION
## Purpose
> In this effort, as the super tenant entry is not added to the UM_TENANT table, for super tenant id skipping the DB search for the tenant.

Related issues:
- https://github.com/wso2/product-is/issues/16517