### PR TITLE
Add UseCaseSensitiveUsernameForCacheKeys Property into User Store Config Constants

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/UserStoreConfigConstants.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/UserStoreConfigConstants.java
@@ -19,6 +19,9 @@ package org.wso2.carbon.user.core;
 
 import org.wso2.carbon.user.core.ldap.LDAPConstants;
 
+/**
+ * This class contains the constants related to User Store Configurations.
+ */
 public class UserStoreConfigConstants {
     public static final String PRIMARY = "PRIMARY";
     public static final String DOMAIN_NAME = "DomainName";
@@ -180,6 +183,11 @@ public class UserStoreConfigConstants {
     // Property for specify case insensitivity for User stores.
     public static final String CASE_INSENSITIVE_USERNAME = "CaseInsensitiveUsername";
     public static final String CASE_INSENSITIVE_USERNAME_DESCRIPTION = "Whether the username is case sensitive or not";
+
+    // Property for specify whether case-sensitive username can be used as the cache key.
+    public static final String USE_CASE_SENSITIVE_USERNAME_FOR_CACHE_KEYS = "UseCaseSensitiveUsernameForCacheKeys";
+    public static final String USE_CASE_SENSITIVE_USERNAME_FOR_CACHE_KEYS_DESCRIPTION =
+            "Whether case-sensitive username can be used as the cache key or not.";
 
     // Property to bypass account locking for the userstore.
     public static final String BYPASS_ACCOUNT_LOCK = "BypassAccountLock";

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/JDBCUserStoreConstants.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/JDBCUserStoreConstants.java
@@ -33,6 +33,9 @@ import static org.wso2.carbon.user.core.constants.UserStoreUIConstants.DataTypes
 import static org.wso2.carbon.user.core.constants.UserStoreUIConstants.DataTypes.SQL;
 import static org.wso2.carbon.user.core.constants.UserStoreUIConstants.DataTypes.STRING;
 
+/**
+ * This class contains the constants related to the JDBC User Store Manager.
+ */
 public class JDBCUserStoreConstants {
 
     //Properties for Read Active Directory User Store Manager
@@ -108,6 +111,10 @@ public class JDBCUserStoreConstants {
         setProperty(UserStoreConfigConstants.CASE_INSENSITIVE_USERNAME, "Case Insensitive Username", "false",
                 UserStoreConfigConstants.CASE_INSENSITIVE_USERNAME_DESCRIPTION,
                 new Property[] { USER.getProperty(), BOOLEAN.getProperty(), FALSE.getProperty() });
+        setProperty(UserStoreConfigConstants.USE_CASE_SENSITIVE_USERNAME_FOR_CACHE_KEYS,
+                "Use Case Sensitive Username for Cache Keys", "true",
+                UserStoreConfigConstants.USE_CASE_SENSITIVE_USERNAME_FOR_CACHE_KEYS_DESCRIPTION,
+                new Property[] { USER.getProperty(), BOOLEAN.getProperty(), TRUE.getProperty() });
 
         //set Advanced properties
         setAdvancedProperty("IsBulkImportSupported", "Is Bulk Import Supported", "false",
@@ -463,7 +470,8 @@ public class JDBCUserStoreConstants {
                 JDBCRealmConstants.GET_USERS_FOR_PROP_WITH_ID_SQL, "",
                 new Property[] { USER.getProperty(), SQL.getProperty(), FALSE.getProperty() });
         setAdvancedProperty(JDBCRealmConstants.GET_USERS_FOR_CLAIM_VALUE_WITH_ID,
-                "Get User List for Claim Value With ID SQL", JDBCRealmConstants.GET_USERS_FOR_CLAIM_VALUE_WITH_ID_SQL, "",
+                "Get User List for Claim Value With ID SQL",
+                JDBCRealmConstants.GET_USERS_FOR_CLAIM_VALUE_WITH_ID_SQL, "",
                 new Property[]{USER.getProperty(), SQL.getProperty(), FALSE.getProperty()});
         setAdvancedProperty(JDBCCaseInsensitiveConstants.GET_USERS_FOR_PROP_WITH_ID_CASE_INSENSITIVE,
                 "Get User List For Property With ID SQL With Case Insensitive Username",
@@ -614,7 +622,8 @@ public class JDBCUserStoreConstants {
         setAdvancedProperty(JDBCRealmConstants.ON_DELETE_USER_REMOVE_ATTRIBUTE,
                 "On Delete User, Remove User Attribute SQL", JDBCRealmConstants.ON_DELETE_USER_REMOVE_ATTRIBUTE_SQL, "",
                 new Property[] { USER.getProperty(), SQL.getProperty(), FALSE.getProperty() });
-        setAdvancedProperty(JDBCRealmConstants.COUNT_USERS_WITH_FILTER, "Count Users SQL With Filter", JDBCRealmConstants.COUNT_USERS_WITH_FILTER_SQL, "",
+        setAdvancedProperty(JDBCRealmConstants.COUNT_USERS_WITH_FILTER, "Count Users SQL With Filter",
+                JDBCRealmConstants.COUNT_USERS_WITH_FILTER_SQL, "",
                 new Property[] { USER.getProperty(), SQL.getProperty(), FALSE.getProperty() });
         setAdvancedProperty(JDBCRealmConstants.ON_DELETE_USER_REMOVE_ATTRIBUTE_WITH_ID,
                 "On Delete User, Remove User Attribute SQL With ID",

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/ActiveDirectoryUserStoreConstants.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/ActiveDirectoryUserStoreConstants.java
@@ -31,6 +31,9 @@ import static org.wso2.carbon.user.core.constants.UserStoreUIConstants.DataTypes
 import static org.wso2.carbon.user.core.constants.UserStoreUIConstants.DataTypes.STRING;
 import static org.wso2.carbon.user.core.ldap.LDAPConstants.DEFAULT_LDAP_TIME_FORMATS_PATTERN;
 
+/**
+ * This class contains the constants related to the Active Directory User Store Manager.
+ */
 public class ActiveDirectoryUserStoreConstants {
 
     //Properties for Read Active Directory User Store Manager
@@ -101,6 +104,10 @@ public class ActiveDirectoryUserStoreConstants {
                 new Property[] { BASIC.getProperty(), BOOLEAN.getProperty(), TRUE.getProperty() });
         setProperty(UserStoreConfigConstants.CASE_INSENSITIVE_USERNAME, "Case Insensitive Username", "true",
                 UserStoreConfigConstants.CASE_INSENSITIVE_USERNAME_DESCRIPTION,
+                new Property[] { USER.getProperty(), BOOLEAN.getProperty(), TRUE.getProperty() });
+        setProperty(UserStoreConfigConstants.USE_CASE_SENSITIVE_USERNAME_FOR_CACHE_KEYS,
+                "Use Case Sensitive Username for Cache Keys", "true",
+                UserStoreConfigConstants.USE_CASE_SENSITIVE_USERNAME_FOR_CACHE_KEYS_DESCRIPTION,
                 new Property[] { USER.getProperty(), BOOLEAN.getProperty(), TRUE.getProperty() });
 
         Property readLDAPGroups = new Property(UserStoreConfigConstants.readGroups, "true",

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/ReadOnlyLDAPUserStoreConstants.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/ReadOnlyLDAPUserStoreConstants.java
@@ -157,6 +157,10 @@ public class ReadOnlyLDAPUserStoreConstants {
         setProperty(UserStoreConfigConstants.CASE_INSENSITIVE_USERNAME, "Case Insensitive Username", "true",
                 UserStoreConfigConstants.CASE_INSENSITIVE_USERNAME_DESCRIPTION,
                 new Property[] { USER.getProperty(), BOOLEAN.getProperty(), TRUE.getProperty() });
+        setProperty(UserStoreConfigConstants.USE_CASE_SENSITIVE_USERNAME_FOR_CACHE_KEYS,
+                "Use Case Sensitive Username for Cache Keys", "true",
+                UserStoreConfigConstants.USE_CASE_SENSITIVE_USERNAME_FOR_CACHE_KEYS_DESCRIPTION,
+                new Property[] { USER.getProperty(), BOOLEAN.getProperty(), TRUE.getProperty() });
         setProperty("ReadOnly", "", "true", "",
                 new Property[] { USER.getProperty(), BOOLEAN.getProperty(), TRUE.getProperty() });
     }

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/ReadWriteLDAPUserStoreConstants.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/ReadWriteLDAPUserStoreConstants.java
@@ -30,6 +30,9 @@ import static org.wso2.carbon.user.core.constants.UserStoreUIConstants.DataTypes
 import static org.wso2.carbon.user.core.constants.UserStoreUIConstants.DataTypes.PASSWORD;
 import static org.wso2.carbon.user.core.constants.UserStoreUIConstants.DataTypes.STRING;
 
+/**
+ * This class contains the constants related to the Read Write LDAP User Store Manager.
+ */
 public class ReadWriteLDAPUserStoreConstants {
 
     //Properties for Read Write LDAP User Store Manager
@@ -84,7 +87,7 @@ public class ReadWriteLDAPUserStoreConstants {
                 new Property[] { USER.getProperty(), STRING.getProperty(), TRUE.getProperty() });
         setMandatoryPropertyForUniqueIdStore(UserStoreConfigConstants.userIdAttribute,
                 UserStoreConfigConstants.userIdAttributeName, "scimId",
-                UserStoreConfigConstants.userIdAttributeDescription,false,
+                UserStoreConfigConstants.userIdAttributeDescription, false,
                 new Property[] { USER.getProperty(), STRING.getProperty(), TRUE.getProperty() });
         setMandatoryPropertyForUniqueIdStore(UserStoreConfigConstants.userIdSearchFilter,
                 UserStoreConfigConstants.userIdSearchFilterAttributeName, "(&(objectClass=person)(scimId=?))",
@@ -170,6 +173,10 @@ public class ReadWriteLDAPUserStoreConstants {
                 new Property[]{CONNECTION.getProperty(), STRING.getProperty(), FALSE.getProperty()});
         setProperty(UserStoreConfigConstants.CASE_INSENSITIVE_USERNAME, "Case Insensitive Username", "true",
                 UserStoreConfigConstants.CASE_INSENSITIVE_USERNAME_DESCRIPTION,
+                new Property[] { USER.getProperty(), BOOLEAN.getProperty(), TRUE.getProperty() });
+        setProperty(UserStoreConfigConstants.USE_CASE_SENSITIVE_USERNAME_FOR_CACHE_KEYS,
+                "Use Case Sensitive Username for Cache Keys", "true",
+                UserStoreConfigConstants.USE_CASE_SENSITIVE_USERNAME_FOR_CACHE_KEYS_DESCRIPTION,
                 new Property[] { USER.getProperty(), BOOLEAN.getProperty(), TRUE.getProperty() });
     }
 


### PR DESCRIPTION
### Purpose
- This PR adds `UseCaseSensitiveUsernameForCacheKeys` property into following secondary user store configs which can be access by [1].
    - JDBC
    - Read Only LDAP
    - Read and Write LDAP
    - Active Directory

### Related Issues
- https://github.com/wso2/product-is/issues/18230

[1] - https://github.com/wso2/carbon-identity-framework/blob/master/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/util/IdentityUtil.java#L749-L766