### PR TITLE
Handle ResourceNotFoundException in isCachedKeyStoreValid

### DIFF
--- a/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/util/KeyStoreManager.java
+++ b/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/util/KeyStoreManager.java
@@ -26,6 +26,7 @@ import org.wso2.carbon.core.internal.CarbonCoreDataHolder;
 import org.wso2.carbon.registry.api.Registry;
 import org.wso2.carbon.registry.core.Resource;
 import org.wso2.carbon.registry.core.exceptions.RegistryException;
+import org.wso2.carbon.registry.core.exceptions.ResourceNotFoundException;
 import org.wso2.carbon.registry.core.service.RegistryService;
 import org.wso2.carbon.utils.CarbonUtils;
 import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
@@ -499,6 +500,12 @@ public class KeyStoreManager {
             }
         } catch (org.wso2.carbon.registry.api.RegistryException e) {
             String errorMsg = "Error reading key store meta data from registry.";
+            if (e instanceof ResourceNotFoundException) {
+                if (log.isDebugEnabled()) {
+                    log.debug(errorMsg, e);
+                }
+                return false;
+            }
             log.error(errorMsg, e);
             throw new SecurityException(errorMsg, e);
         }


### PR DESCRIPTION
## Purpose
> This fix addresses the related issue where in the `isCachedKeyStoreValid` method it was identified that there are cases where although the relevant key-store file has been already added to the cache (`loadedKeyStores`), it is not found in runtime, probably because the cache might be corrupted. In this case, instead of throwing the `ResourceNotFoundException` error we should return false to indicate that the key-store is not found in cache, thus the remaining implementation will try to retrieve it from the database instead.

## Related issues
- Issue https://github.com/wso2-enterprise/asgardeo-product/issues/21175