### PR TITLE
Limit enableOptimizedJDBCSearch optimization to username search only.

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/JDBCRealmConstants.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/JDBCRealmConstants.java
@@ -71,8 +71,8 @@ public final class JDBCRealmConstants {
     public static final String GET_USERS_FOR_PROP_WITH_ESCAPE = "GetUserListForPropertySQLWithEscape";
     public static final String GET_USERS_FOR_CLAIM_VALUE = "GetUserListForClaimValueSQL";
     public static final String GET_USERS_FOR_PROP_WITH_ID = "GetUserLisForPropertyWithIDSQL";
-    public static final String GET_USERS_FOR_UID = "GetUserListForUserIDSQL";
-    public static final String GET_USER_FOR_UID = "GetUserForUserIDSQL";
+    public static final String GET_USERS_FOR_USERNAME = "GetUserListForUsernameSQL";
+    public static final String GET_USER_FOR_USERNAME = "GetUserForUsernameSQL";
     public static final String GET_USERS_FOR_CLAIM_VALUE_WITH_ID = "GetUserListForClaimValueWithIDSQL";
     public static final String GET_PAGINATED_USERS_FOR_PROP = "GetPaginatedUserLisForPropertySQL";
     public static final String GET_PAGINATED_USERS_FOR_PROP_WITH_ID = "GetPaginatedUserLisForPropertyWithIDSQL";
@@ -311,10 +311,10 @@ public final class JDBCRealmConstants {
             + "UM_USER_ATTRIBUTE WHERE UM_USER_ATTRIBUTE.UM_USER_ID = UM_USER.UM_ID AND UM_USER_ATTRIBUTE.UM_ATTR_NAME =? " +
             "AND UM_USER_ATTRIBUTE.UM_ATTR_VALUE LIKE ? AND UM_USER_ATTRIBUTE.UM_PROFILE_ID=? " +
             "AND UM_USER_ATTRIBUTE.UM_TENANT_ID=? AND UM_USER.UM_TENANT_ID=?";
-    public static final String GET_USERS_FOR_UID_SQL = "SELECT DISTINCT UM_USER.UM_USER_ID " +
-            "FROM UM_USER WHERE UM_USER.UM_USER_ID LIKE ? AND UM_USER.UM_TENANT_ID=?";
-    public static final String GET_USER_FOR_UID_SQL = "SELECT DISTINCT UM_USER.UM_USER_ID " +
-            "FROM UM_USER WHERE UM_USER.UM_USER_ID=? AND UM_USER.UM_TENANT_ID=?";
+    public static final String GET_USERS_FOR_USERNAME_SQL = "SELECT DISTINCT UM_USER.UM_USER_ID " +
+            "FROM UM_USER WHERE UM_USER.UM_USER_NAME LIKE ? AND UM_USER.UM_TENANT_ID=?";
+    public static final String GET_USER_FOR_USERNAME_SQL = "SELECT DISTINCT UM_USER.UM_USER_ID " +
+            "FROM UM_USER WHERE UM_USER.UM_USER_NAME=? AND UM_USER.UM_TENANT_ID=?";
     public static final String GET_USERS_FOR_CLAIM_VALUE_WITH_ID_SQL = "SELECT DISTINCT UM_USER.UM_USER_ID FROM " +
             "UM_USER, UM_USER_ATTRIBUTE WHERE UM_USER_ATTRIBUTE.UM_USER_ID = UM_USER.UM_ID AND " +
             "UM_USER_ATTRIBUTE.UM_ATTR_NAME =? AND UM_USER_ATTRIBUTE.UM_ATTR_VALUE =? AND " +

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCUserStoreManager.java
@@ -2353,10 +2353,17 @@ public class UniqueIDJDBCUserStoreManager extends JDBCUserStoreManager {
         if (value == null) {
             throw new IllegalArgumentException("Filter value cannot be null");
         }
+        boolean uidIsUsername = false;
+        try {
+            String usernameMappedAttribute = claimManager.getClaimMapping(USERNAME_CLAIM_URI).getMappedAttribute();
+            uidIsUsername = usernameMappedAttribute.equals(UID);
+        } catch (org.wso2.carbon.user.api.UserStoreException e) {
+            throw new UserStoreException("Error occurred while retrieving claim mapping.", e);
+        }
 
         boolean isOptimizedSearchEnabled = Boolean.parseBoolean(ServerConfiguration.getInstance()
                 .getFirstProperty(JDBCRealmConstants.PROP_ENABLE_OPTIMIZED_JDBC_SEARCH));
-        boolean useOptimizedProcess = isOptimizedSearchEnabled && UID.equals(property);
+        boolean useOptimizedProcess = isOptimizedSearchEnabled && UID.equals(property) && uidIsUsername;
 
         String sqlStmt;
         if (value.contains(QUERY_FILTER_STRING_ANY)) {
@@ -2368,9 +2375,9 @@ public class UniqueIDJDBCUserStoreManager extends JDBCUserStoreManager {
             if (useOptimizedProcess) {
                 if (!isCaseSensitiveUsername()) {
                     sqlStmt = realmConfig.getUserStoreProperty(JDBCCaseInsensitiveConstants.
-                            GET_USERS_FOR_UID_WITH_ID_CASE_INSENSITIVE);
+                            GET_USERS_FOR_USERNAME_WITH_USERNAME_CASE_INSENSITIVE);
                 } else {
-                    sqlStmt = realmConfig.getUserStoreProperty(JDBCRealmConstants.GET_USERS_FOR_UID);
+                    sqlStmt = realmConfig.getUserStoreProperty(JDBCRealmConstants.GET_USERS_FOR_USERNAME);
                 }
             } else {
                 if (!isCaseSensitiveUsername() && UID.equals(property)) {
@@ -2384,9 +2391,9 @@ public class UniqueIDJDBCUserStoreManager extends JDBCUserStoreManager {
             if (useOptimizedProcess) {
                 if (!isCaseSensitiveUsername()) {
                     sqlStmt = realmConfig.getUserStoreProperty(JDBCCaseInsensitiveConstants
-                            .GET_USER_FOR_UID_WITH_ID_CASE_INSENSITIVE);
+                            .GET_USER_FOR_USERNAME_WITH_USERNAME_CASE_INSENSITIVE);
                 } else {
-                    sqlStmt = realmConfig.getUserStoreProperty(JDBCRealmConstants.GET_USER_FOR_UID_SQL);
+                    sqlStmt = realmConfig.getUserStoreProperty(JDBCRealmConstants.GET_USER_FOR_USERNAME);
                 }
             } else {
                 if (!isCaseSensitiveUsername() && UID.equals(property)) {

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/caseinsensitive/JDBCCaseInsensitiveConstants.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/caseinsensitive/JDBCCaseInsensitiveConstants.java
@@ -52,9 +52,10 @@ public class JDBCCaseInsensitiveConstants {
     public static final String GET_PROFILE_NAMES_FOR_USER_CASE_INSENSITIVE = "GetUserProfileNamesSQLCaseInsensitive";
     public static final String GET_USERS_FOR_PROP_WITH_ID_CASE_INSENSITIVE =
             "GetUserListForPropertyWithIDSQLCaseInsensitive";
-    public static final String GET_USERS_FOR_UID_WITH_ID_CASE_INSENSITIVE =
-            "GetUserListForUIDWithIDSQLCaseInsensitive";
-    public static final String GET_USER_FOR_UID_WITH_ID_CASE_INSENSITIVE = "GetUserForUIDWithIDSQLCaseInsensitive";
+    public static final String GET_USERS_FOR_USERNAME_WITH_USERNAME_CASE_INSENSITIVE =
+            "GetUserListForUsernameWithUsernameCaseInsensitive";
+    public static final String GET_USER_FOR_USERNAME_WITH_USERNAME_CASE_INSENSITIVE =
+            "GetUserForUsernameWithUsernameSQLCaseInsensitive";
     public static final String GET_USERS_FOR_CLAIM_VALUE_WITH_ID_CASE_INSENSITIVE =
             "GetUserListForClaimValueWithIDSQLCaseInsensitive";
     public static final String GET_USERID_FROM_USERNAME_CASE_INSENSITIVE = "GetUserIDFromUserNameSQLCaseInsensitive";
@@ -166,10 +167,11 @@ public class JDBCCaseInsensitiveConstants {
             ".UM_USER_ID FROM UM_USER, UM_USER_ATTRIBUTE WHERE UM_USER_ATTRIBUTE.UM_USER_ID = UM_USER.UM_ID AND " +
             "UM_USER_ATTRIBUTE.UM_ATTR_NAME =? AND LOWER(UM_USER_ATTRIBUTE.UM_ATTR_VALUE)=LOWER(?) AND " +
             "UM_USER_ATTRIBUTE.UM_PROFILE_ID=? AND UM_USER_ATTRIBUTE.UM_TENANT_ID=? AND UM_USER.UM_TENANT_ID=?";
-    public static final String GET_USERS_FOR_UID_WITH_ID_SQL_CASE_INSENSITIVE = "SELECT DISTINCT UM_USER.UM_USER_ID " +
-            "FROM UM_USER WHERE LOWER(UM_USER.UM_USER_ID) LIKE LOWER(?) AND UM_USER.UM_TENANT_ID=?";
-    public static final String GET_USER_FOR_UID_WITH_ID_SQL_CASE_INSENSITIVE = "SELECT DISTINCT UM_USER.UM_USER_ID " +
-            "FROM UM_USER WHERE LOWER(UM_USER.UM_USER_ID)=LOWER(?) AND UM_USER.UM_TENANT_ID=?";
+    public static final String GET_USERS_FOR_USERNAME_WITH_USERNAME_SQL_CASE_INSENSITIVE = "SELECT DISTINCT " +
+            "UM_USER.UM_USER_ID FROM UM_USER WHERE LOWER(UM_USER.UM_USER_NAME) LIKE LOWER(?) " +
+            "AND UM_USER.UM_TENANT_ID=?";
+    public static final String GET_USER_FOR_USERNAME_WITH_USERNAME_SQL_CASE_INSENSITIVE = "SELECT DISTINCT " +
+            "UM_USER.UM_USER_ID FROM UM_USER WHERE LOWER(UM_USER.UM_USER_NAME)=LOWER(?) AND UM_USER.UM_TENANT_ID=?";
     public static final String GET_PROP_FOR_PROFILE_SQL_CASE_INSENSITIVE = "SELECT UM_ATTR_VALUE FROM " +
             "UM_USER_ATTRIBUTE, UM_USER WHERE UM_USER.UM_ID = UM_USER_ATTRIBUTE.UM_USER_ID AND LOWER(UM_USER" +
             ".UM_USER_NAME)=LOWER(?) AND UM_ATTR_NAME=? AND UM_PROFILE_ID=? AND UM_USER_ATTRIBUTE.UM_TENANT_ID=? AND " +

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/util/JDBCRealmUtil.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/util/JDBCRealmUtil.java
@@ -225,13 +225,13 @@ public class JDBCRealmUtil {
             properties.put(JDBCRealmConstants.GET_USERS_FOR_PROP_WITH_ID,
                     JDBCRealmConstants.GET_USERS_FOR_PROP_WITH_ID_SQL);
         }
-        if (!properties.containsKey(JDBCRealmConstants.GET_USERS_FOR_UID)) {
-            properties.put(JDBCRealmConstants.GET_USERS_FOR_UID,
-                    JDBCRealmConstants.GET_USERS_FOR_UID_SQL);
+        if (!properties.containsKey(JDBCRealmConstants.GET_USERS_FOR_USERNAME)) {
+            properties.put(JDBCRealmConstants.GET_USERS_FOR_USERNAME,
+                    JDBCRealmConstants.GET_USERS_FOR_USERNAME_SQL);
         }
-        if (!properties.containsKey(JDBCRealmConstants.GET_USER_FOR_UID)) {
-            properties.put(JDBCRealmConstants.GET_USER_FOR_UID,
-                    JDBCRealmConstants.GET_USER_FOR_UID_SQL);
+        if (!properties.containsKey(JDBCRealmConstants.GET_USER_FOR_USERNAME)) {
+            properties.put(JDBCRealmConstants.GET_USER_FOR_USERNAME,
+                    JDBCRealmConstants.GET_USER_FOR_USERNAME_SQL);
         }
         if (!properties.containsKey(JDBCRealmConstants.GET_USERS_FOR_CLAIM_VALUE_WITH_ID)) {
             properties.put(JDBCRealmConstants.GET_USERS_FOR_CLAIM_VALUE_WITH_ID,
@@ -241,13 +241,13 @@ public class JDBCRealmUtil {
             properties.put(JDBCCaseInsensitiveConstants.GET_USERS_FOR_PROP_WITH_ID_CASE_INSENSITIVE,
                     JDBCCaseInsensitiveConstants.GET_USERS_FOR_PROP_WITH_ID_SQL_CASE_INSENSITIVE);
         }
-        if(!properties.containsKey(JDBCCaseInsensitiveConstants.GET_USERS_FOR_UID_WITH_ID_CASE_INSENSITIVE)) {
-            properties.put(JDBCCaseInsensitiveConstants.GET_USERS_FOR_UID_WITH_ID_CASE_INSENSITIVE,
-                    JDBCCaseInsensitiveConstants.GET_USERS_FOR_UID_WITH_ID_SQL_CASE_INSENSITIVE);
+        if(!properties.containsKey(JDBCCaseInsensitiveConstants.GET_USERS_FOR_USERNAME_WITH_USERNAME_CASE_INSENSITIVE)) {
+            properties.put(JDBCCaseInsensitiveConstants.GET_USERS_FOR_USERNAME_WITH_USERNAME_CASE_INSENSITIVE,
+                    JDBCCaseInsensitiveConstants.GET_USERS_FOR_USERNAME_WITH_USERNAME_SQL_CASE_INSENSITIVE);
         }
-        if(!properties.containsKey(JDBCCaseInsensitiveConstants.GET_USER_FOR_UID_WITH_ID_CASE_INSENSITIVE)) {
-            properties.put(JDBCCaseInsensitiveConstants.GET_USER_FOR_UID_WITH_ID_CASE_INSENSITIVE,
-                    JDBCCaseInsensitiveConstants.GET_USER_FOR_UID_WITH_ID_SQL_CASE_INSENSITIVE);
+        if(!properties.containsKey(JDBCCaseInsensitiveConstants.GET_USER_FOR_USERNAME_WITH_USERNAME_CASE_INSENSITIVE)) {
+            properties.put(JDBCCaseInsensitiveConstants.GET_USER_FOR_USERNAME_WITH_USERNAME_CASE_INSENSITIVE,
+                    JDBCCaseInsensitiveConstants.GET_USER_FOR_USERNAME_WITH_USERNAME_SQL_CASE_INSENSITIVE);
         }
         if (!properties.containsKey(JDBCCaseInsensitiveConstants.GET_USERS_FOR_CLAIM_VALUE_WITH_ID_CASE_INSENSITIVE)) {
             properties.put(JDBCCaseInsensitiveConstants.GET_USERS_FOR_CLAIM_VALUE_WITH_ID_CASE_INSENSITIVE,


### PR DESCRIPTION
## Purpose 
Limit enableOptimizedJDBCSearch optimization to username search only since the no other attributes are saved in the UM_USER table. 

## Related PR 
> https://github.com/wso2/carbon-kernel/pull/3759

## Related Issue 
> https://github.com/wso2/product-is/issues/17986