### PR TITLE
Throw client exception if error is UserStoreClientException

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
@@ -848,6 +848,9 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
                 log.debug(errorMessage, e);
             }
 
+            if (e instanceof UserStoreClientException) {
+                throw new UserStoreClientException(errorMessage, e);
+            }
             throw new UserStoreException(errorMessage, e);
         }
         return userStoreAttributeValueMap;


### PR DESCRIPTION
## Purpose
> Currently a server error log is logged if the mapped attribute name of a claim is not found. The fix that was done to resolve the issue was masked because a new UserStoreException is thrown from the parent method. This PR checks the error type and throws the correct exception.

## Related PRs
- PR https://github.com/wso2/carbon-kernel/pull/3750

## Related Issues
- Issue https://github.com/wso2-enterprise/asgardeo-product/issues/21112