### PR TITLE
Template the local registry db to provide configurable support

### DIFF
--- a/distribution/kernel/carbon-home/repository/resources/conf/default.json
+++ b/distribution/kernel/carbon-home/repository/resources/conf/default.json
@@ -229,5 +229,15 @@
   "remote_logging.config_sync.period": "15",
   "legacy_authz_runtime.enable": true,
   "jdbc_user_store.enable_optimized_jdbc_search": false,
-  "clustering.agent": "org.wso2.carbon.hazelcast.HazelcastClusteringAgent"
+  "clustering.agent": "org.wso2.carbon.hazelcast.HazelcastClusteringAgent",
+  "database.registry_db.url" : "jdbc:h2:async:./repository/database/WSO2CARBON_DB;DB_CLOSE_ON_EXIT=FALSE",
+  "database.registry_db.username" : "wso2carbon",
+  "database.registry_db.password" : "wso2carbon",
+  "database.registry_db.driver" : "org.h2.Driver",
+  "database.registry_db.pool_options.maxActive" : "50",
+  "database.registry_db.pool_options.maxWait" : "60000",
+  "database.registry_db.pool_options.testOnBorrow" : "true",
+  "database.registry_db.pool_options.validationQuery" : "SELECT 1",
+  "database.registry_db.pool_options.validationInterval" : "30000",
+  "database.registry_db.pool_options.defaultAutoCommit" : "true"
 }

--- a/distribution/kernel/carbon-home/repository/resources/conf/templates/repository/conf/datasources/master-datasources.xml.j2
+++ b/distribution/kernel/carbon-home/repository/resources/conf/templates/repository/conf/datasources/master-datasources.xml.j2
@@ -14,16 +14,13 @@
             </jndiConfig>
             <definition type="RDBMS">
                 <configuration>
-                    <url>jdbc:h2:async:./repository/database/WSO2CARBON_DB;DB_CLOSE_ON_EXIT=FALSE</url>
-                    <username>wso2carbon</username>
-                    <password>wso2carbon</password>
-                    <driverClassName>org.h2.Driver</driverClassName>
-                    <maxActive>50</maxActive>
-                    <maxWait>60000</maxWait>
-                    <testOnBorrow>true</testOnBorrow>
-                    <validationQuery>SELECT 1</validationQuery>
-                    <validationInterval>30000</validationInterval>
-                    <defaultAutoCommit>true</defaultAutoCommit>
+                    <url>{{database.registry_db.url}}</url>
+                    <username>{{database.registry_db.username}}</username>
+                    <password>{{database.registry_db.password}}</password>
+                    <driverClassName>{{database.registry_db.driver}}</driverClassName>
+                    {% for property_name,property_value in database.registry_db.pool_options.items() %}
+                    <{{property_name}}>{{property_value}}</{{property_name}}>
+                    {% endfor %}
                 </configuration>
             </definition>
         </datasource>


### PR DESCRIPTION
## Changes in this PR
* Templated the WSO2_CARBON_DB / local registry DB configuration to provide the support to configure an external database as the WSO2_CARBON_DB.
* Default WSO2_CARBON_DB will be the H2 database shipped with the product.
* With this change users can change the WSO2_CARBON_DB configs from the deployment.toml file with the following configs. Followings are referred to `mysql`

```
[database.registry_db]
type = "mysql"
url = "jdbc:mysql://localhost:3306/EXTERNALREGISTRYDB?useSSL=false"
username = "root"
password = "root"
```
* Since this is the local registry, this database should be created node wise.
* Fixes https://github.com/wso2/product-is/issues/15672