### PR TITLE
Enable TLS 1.3 by default

### DIFF
--- a/distribution/kernel/carbon-home/repository/resources/conf/default.json
+++ b/distribution/kernel/carbon-home/repository/resources/conf/default.json
@@ -76,7 +76,7 @@
   "transport.https.properties.noCompressionUserAgents": "gozilla, traviata",
   "transport.https.properties.compressibleMimeType": "text/html,text/javascript,application/x-javascript,application/javascript,application/xml,text/css,application/xslt+xml,text/xsl,image/gif,image/jpg,image/jpeg",
   "transport.https.properties.URIEncoding": "UTF-8",
-  "transport.https.sslHostConfig.properties.protocols": "+TLSv1,+TLSv1.1,+TLSv1.2",
+  "transport.https.sslHostConfig.properties.protocols": "TLSv1.2+TLSv1.3",
   "transport.https.sslHostConfig.properties.sslProtocol": "TLS",
   "transport.https.sslHostConfig.properties.certificateVerification": "false",
   "transport.https.sslHostConfig.properties.truststoreFile": "${carbon.home}/repository/resources/security/$ref{truststore.file_name}",


### PR DESCRIPTION
## Purpose
Enabling TLSv1.3 which is the latest and most secured version of TLS, and disabling the TLSv1.0 and TLSv1.1 which are  less secured.

## Related Issues
- https://github.com/wso2/product-is/issues/18465
- https://github.com/wso2/product-is/issues/19070