### PR TITLE
Close input streams in XsdUtil

### DIFF
--- a/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/transports/util/XsdUtil.java
+++ b/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/transports/util/XsdUtil.java
@@ -137,6 +137,7 @@ public final class XsdUtil {
                             }
                         }
                         outstream.flush();
+                        instream.close();
                         return;
                     } else {
                         ByteArrayOutputStream baos = new ByteArrayOutputStream();
@@ -190,14 +191,15 @@ public final class XsdUtil {
                     outputStream.flush();
                 }
             } else if  (xsds.endsWith(".xsd") && xsds.indexOf("..") == -1){
-                InputStream in = axisService.getClassLoader()
-                        .getResourceAsStream(DeploymentConstants.META_INF + "/" + xsds);
-                if (in != null) {
-                    outputStream.write(IOUtils.getStreamAsByteArray(in));
-                    outputStream.flush();
-                    outputStream.close();
-                } else {
-                    response.setError(HttpServletResponse.SC_NOT_FOUND);
+                try (InputStream in = axisService.getClassLoader()
+                        .getResourceAsStream(DeploymentConstants.META_INF + "/" + xsds)) {
+                    if (in != null) {
+                        outputStream.write(IOUtils.getStreamAsByteArray(in));
+                        outputStream.flush();
+                        outputStream.close();
+                    } else {
+                        response.setError(HttpServletResponse.SC_NOT_FOUND);
+                    }
                 }
             } else {
                 String msg = "Invalid schema " + xsds + " requested";


### PR DESCRIPTION
## Purpose
This PR is to fix the issue of input streams not being properly closed.

instream.close() has been used in line 140 instead of a try with resources block due to the instream being reassigned below in the else block in line 147[1]

[1] https://github.com/wso2/carbon-kernel/compare/4.9.x...Lakshan-Banneheke:carbon-kernel:4.9.x?expand=1#diff-ab615c6f59a473c336a7d8261f308ef24686cd96adecb2535a6b80dd1ac8e554R147