### PR TITLE
Revert unescaping username from kernel

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCUserStoreManager.java
@@ -79,7 +79,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static org.apache.commons.lang3.StringEscapeUtils.unescapeJava;
 import static org.wso2.carbon.user.core.constants.UserCoreErrorConstants.ErrorMessages.ERROR_CODE_DUPLICATE_WHILE_ADDING_A_USER;
 import static org.wso2.carbon.user.core.constants.UserCoreErrorConstants.ErrorMessages.ERROR_CODE_DUPLICATE_WHILE_ADDING_ROLE;
 import static org.wso2.carbon.user.core.constants.UserCoreErrorConstants.ErrorMessages.ERROR_CODE_DUPLICATE_WHILE_WRITING_TO_DATABASE;
@@ -1292,8 +1291,6 @@ public class UniqueIDJDBCUserStoreManager extends JDBCUserStoreManager {
         if (userName == null) {
             throw new IllegalArgumentException("userName cannot be null.");
         }
-        // Remove escape characters from the username since it can be an encoded username.
-        userName = unescapeJava(userName);
 
         Connection dbConnection = null;
         String sqlStmt;


### PR DESCRIPTION
## Purpose
The fix sent to https://github.com/wso2/product-is/issues/18700 causes the issue reported in https://github.com/wso2/product-is/issues/19056. 
So it is decided to revert that PR and handle the encoding issue from the jsp level. 

## Related PR
- https://github.com/wso2/carbon-kernel/pull/3774

## Related Issue
- https://github.com/wso2/product-is/issues/19056