### PR TITLE
Add Missing String Formatters to `ERROR_CODE_ERROR_WHILE_AUTHENTICATION` Usages 

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
@@ -1683,7 +1683,8 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
 
                 if (!listener.authenticate(userName, credentialArgument, abstractUserStoreManager)) {
                     handleOnAuthenticateFailure(ErrorMessages.ERROR_CODE_ERROR_WHILE_AUTHENTICATION.getCode(),
-                            ErrorMessages.ERROR_CODE_ERROR_WHILE_AUTHENTICATION.getMessage(), userName,
+                            String.format(ErrorMessages.ERROR_CODE_ERROR_WHILE_AUTHENTICATION.getMessage(),
+                            StringUtils.EMPTY), userName,
                             credentialArgument);
                     return false;
                 }
@@ -11201,12 +11202,15 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
                         .authenticateWithID(preferredUserNameClaim, preferredUserNameValue, credentialArgument,
                                 abstractUserStoreManager)) {
                     handleOnAuthenticateFailureWithID(ErrorMessages.ERROR_CODE_ERROR_WHILE_AUTHENTICATION.getCode(),
-                            ErrorMessages.ERROR_CODE_ERROR_WHILE_AUTHENTICATION.getMessage(), preferredUserNameClaim,
+                            String.format(ErrorMessages.ERROR_CODE_ERROR_WHILE_AUTHENTICATION.getMessage(),
+                            StringUtils.EMPTY), preferredUserNameClaim,
                             preferredUserNameValue, credentialArgument);
 
                     authenticationResult.setAuthenticationStatus(AuthenticationResult.AuthenticationStatus.FAIL);
                     authenticationResult.setFailureReason(
-                            new FailureReason(ErrorMessages.ERROR_CODE_ERROR_WHILE_AUTHENTICATION.getMessage()));
+                            new FailureReason(String.format(
+                                    ErrorMessages.ERROR_CODE_ERROR_WHILE_AUTHENTICATION.getMessage(),
+                                    StringUtils.EMPTY)));
                     return authenticationResult;
                 }
             }

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/constants/UserCoreErrorConstants.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/constants/UserCoreErrorConstants.java
@@ -55,7 +55,7 @@ public class UserCoreErrorConstants {
         ERROR_CODE_DOMAIN_VALUE_WITH_FILTER_EMPTY("34012", "Filter value is not provided"),
         ERROR_CODE_NULL_CLAIM_URI("30018", "Claim URI is not provided"),
         // Error code related with authentication
-        ERROR_CODE_ERROR_WHILE_AUTHENTICATION("31001", "Un-expected error while authenticating, %s"),
+        ERROR_CODE_ERROR_WHILE_AUTHENTICATION("31001", "Un-expected error while authenticating. %s"),
         ERROR_CODE_ERROR_WHILE_PRE_AUTHENTICATION("31002", "Un-expected error while pre-authenticating, %s"),
         ERROR_CODE_TENANT_DEACTIVATED("31003", "Tenant has been deactivated. TenantID : %s"),
         ERROR_CODE_ERROR_WHILE_POST_AUTHENTICATION("31004", "TUn-expected error while post-authentication, %s"),


### PR DESCRIPTION
### Purpose
- Add String formatter in missing places for `ERROR_CODE_ERROR_WHILE_AUTHENTICATION` error constant usages in `AbstractUserStoreManager`.

### Related Issues
- https://github.com/wso2/product-is/issues/19250
- https://github.com/wso2/product-is/issues/10854