### PR TITLE
Resolve user store when current domain name is passed

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
@@ -6412,7 +6412,7 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
             String domain = filter.substring(0, index);
 
             UserStoreManager secManager = this;
-            if (StringUtils.isNotEmpty(domain) && !StringUtils.equals(getMyDomainName(), domain)) {
+            if (!StringUtils.equalsIgnoreCase(getMyDomainName(), domain)) {
                 secManager = getSecondaryUserStoreManager(domain);
             }
 

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
@@ -6411,7 +6411,11 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
             // Using the short-circuit. User name comes with the domain name.
             String domain = filter.substring(0, index);
 
-            UserStoreManager secManager = getSecondaryUserStoreManager(domain);
+            UserStoreManager secManager = this;
+            if (StringUtils.isNotEmpty(domain) && !StringUtils.equals(getMyDomainName(), domain)) {
+                secManager = getSecondaryUserStoreManager(domain);
+            }
+
             if (secManager != null) {
                 // We have a secondary UserStoreManager registered for this domain.
                 filter = filter.substring(index + 1);


### PR DESCRIPTION
### Purpose 

`getSecondaryUserStoreManager(domain)` method utilises a hashmap from the AbstractUserStoreManager class to resolve the user store. But this hashmap is populated only in the primary user store instance resulting in the method returning null. Added a validation to refer to the current instance if the domain name to resolve match the domain name of the current instance. 

### Related issue
- https://github.com/wso2/product-is/issues/18985