### PR TITLE
Add config to define tenant keystore type.

### DIFF
--- a/core/org.wso2.carbon.base/src/test/resources/carbon.xml
+++ b/core/org.wso2.carbon.base/src/test/resources/carbon.xml
@@ -361,6 +361,7 @@
             KeyStore which will be used for encrypting/decrypting passwords
             and other sensitive information.
         -->
+        <!-- KeyStore configurations for super tenant.-->
         <KeyStore>
             <!-- Keystore file location-->
             <Location>${carbon.home}/repository/resources/security/wso2carbon.p12</Location>
@@ -373,6 +374,11 @@
             <!-- Private Key password-->
             <KeyPassword>wso2carbon</KeyPassword>
         </KeyStore>
+        <!-- KeyStore configurations for newly created tenants (not applicable to existing tenants). -->
+        <TenantKeyStore>
+            <!-- Keystore type (JKS/PKCS12 etc.)-->
+            <Type>PKCS12</Type>
+        </TenantKeyStore>
 
         <!--
             System wide trust-store which is used to maintain the certificates of all

--- a/core/org.wso2.carbon.pax-logging-log4j2-plugins/src/test/resources/carbon.xml
+++ b/core/org.wso2.carbon.pax-logging-log4j2-plugins/src/test/resources/carbon.xml
@@ -359,6 +359,7 @@
             KeyStore which will be used for encrypting/decrypting passwords
             and other sensitive information.
         -->
+        <!-- KeyStore configurations for super tenant.-->
         <KeyStore>
             <!-- Keystore file location-->
             <Location>${carbon.home}/repository/resources/security/wso2carbon.p12</Location>
@@ -371,6 +372,11 @@
             <!-- Private Key password-->
             <KeyPassword>wso2carbon</KeyPassword>
         </KeyStore>
+        <!-- KeyStore configurations for newly created tenants (not applicable to existing tenants). -->
+        <TenantKeyStore>
+            <!-- Keystore type (JKS/PKCS12 etc.)-->
+            <Type>PKCS12</Type>
+        </TenantKeyStore>
 
         <!--
             System wide trust-store which is used to maintain the certificates of all

--- a/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/security/KeystoreUtils.java
+++ b/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/security/KeystoreUtils.java
@@ -18,6 +18,7 @@
 
 package org.wso2.carbon.utils.security;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.CarbonException;
@@ -61,8 +62,18 @@ public class KeystoreUtils {
             return tileType.extension;
         }
 
+        /**
+         * If the `Security.TenantKeyStore.Type` is defined, return the type,
+         * otherwise return FALLBACK_TENANTED_KEYSTORE_FILE_TYPE.
+         */
         public static String defaultFileType() {
-            return defaultFileType;
+
+            String keystoreTypesForNewTenants = CarbonUtils.getServerConfiguration().getFirstProperty(
+                    "Security.TenantKeyStore.Type");
+            if (StringUtils.isNotBlank(keystoreTypesForNewTenants)) {
+                return keystoreTypesForNewTenants;
+            }
+            return FALLBACK_TENANTED_KEYSTORE_FILE_TYPE;
         }
 
         /**

--- a/core/org.wso2.carbon.utils/src/test/resources/carbon-utils/carbon-with-password-trim-disabled.xml
+++ b/core/org.wso2.carbon.utils/src/test/resources/carbon-utils/carbon-with-password-trim-disabled.xml
@@ -358,6 +358,7 @@
             KeyStore which will be used for encrypting/decrypting passwords
             and other sensitive information.
         -->
+        <!-- KeyStore configurations for super tenant.-->
         <KeyStore>
             <!-- Keystore file location-->
             <Location>${carbon.home}/repository/resources/security/wso2carbon.p12</Location>
@@ -370,6 +371,17 @@
             <!-- Private Key password-->
             <KeyPassword>wso2carbon</KeyPassword>
         </KeyStore>
+        <!-- KeyStore configurations for newly created tenants (not applicable to existing tenants). -->
+        <TenantKeyStore>
+            <!-- Keystore type (JKS/PKCS12 etc.)-->
+            <Type>PKCS12</Type>
+        </TenantKeyStore>
+
+        <!-- KeyStore configurations for newly created tenants (not applicable to existing tenants). -->
+        <TenantKeyStore>
+            <!-- Keystore type (JKS/PKCS12 etc.)-->
+            <Type>PKCS12</Type>
+        </TenantKeyStore>
 
         <!--
             System wide trust-store which is used to maintain the certificates of all

--- a/core/org.wso2.carbon.utils/src/test/resources/carbon-utils/carbon.xml
+++ b/core/org.wso2.carbon.utils/src/test/resources/carbon-utils/carbon.xml
@@ -362,6 +362,7 @@
             KeyStore which will be used for encrypting/decrypting passwords
             and other sensitive information.
         -->
+        <!-- KeyStore configurations for super tenant.-->
         <KeyStore>
             <!-- Keystore file location-->
             <Location>${carbon.home}/repository/resources/security/wso2carbon.p12</Location>
@@ -374,6 +375,11 @@
             <!-- Private Key password-->
             <KeyPassword>wso2carbon</KeyPassword>
         </KeyStore>
+        <!-- KeyStore configurations for newly created tenants (not applicable to existing tenants). -->
+        <TenantKeyStore>
+            <!-- Keystore type (JKS/PKCS12 etc.)-->
+            <Type>PKCS12</Type>
+        </TenantKeyStore>
 
         <!--
             System wide trust-store which is used to maintain the certificates of all

--- a/distribution/integration/tests-integration/tests/src/test/resources/serveradmin/carbon.xml
+++ b/distribution/integration/tests-integration/tests/src/test/resources/serveradmin/carbon.xml
@@ -359,6 +359,7 @@
             KeyStore which will be used for encrypting/decrypting passwords
             and other sensitive information.
         -->
+        <!-- KeyStore configurations for super tenant.-->
         <KeyStore>
             <!-- Keystore file location-->
             <Location>${carbon.home}/repository/resources/security/wso2carbon.p12</Location>
@@ -371,6 +372,11 @@
             <!-- Private Key password-->
             <KeyPassword>wso2carbon</KeyPassword>
         </KeyStore>
+        <!-- KeyStore configurations for newly created tenants (not applicable to existing tenants). -->
+        <TenantKeyStore>
+            <!-- Keystore type (JKS/PKCS12 etc.)-->
+            <Type>PKCS12</Type>
+        </TenantKeyStore>
 
         <!--
             System wide trust-store which is used to maintain the certificates of all

--- a/distribution/integration/tests-integration/user-core/src/test/resources/repository/conf/carbon.xml
+++ b/distribution/integration/tests-integration/user-core/src/test/resources/repository/conf/carbon.xml
@@ -359,6 +359,7 @@
             KeyStore which will be used for encrypting/decrypting passwords
             and other sensitive information.
         -->
+        <!-- KeyStore configurations for super tenant.-->
         <KeyStore>
             <!-- Keystore file location-->
             <Location>${carbon.home}/repository/resources/security/wso2carbon.p12</Location>
@@ -371,6 +372,11 @@
             <!-- Private Key password-->
             <KeyPassword>wso2carbon</KeyPassword>
         </KeyStore>
+        <!-- KeyStore configurations for newly created tenants (not applicable to existing tenants). -->
+        <TenantKeyStore>
+            <!-- Keystore type (JKS/PKCS12 etc.)-->
+            <Type>PKCS12</Type>
+        </TenantKeyStore>
 
         <!--
             System wide trust-store which is used to maintain the certificates of all

--- a/distribution/kernel/carbon-home/repository/conf/carbon.xml
+++ b/distribution/kernel/carbon-home/repository/conf/carbon.xml
@@ -440,6 +440,7 @@
             KeyStore which will be used for encrypting/decrypting passwords
             and other sensitive information.
         -->
+        <!-- KeyStore configurations for super tenant.-->
         <KeyStore>
             <!-- Keystore file location-->
             <Location>${carbon.home}/repository/resources/security/wso2carbon.p12</Location>
@@ -452,6 +453,11 @@
             <!-- Private Key password-->
             <KeyPassword>wso2carbon</KeyPassword>
         </KeyStore>
+        <!-- KeyStore configurations for newly created tenants (not applicable to existing tenants). -->
+        <TenantKeyStore>
+            <!-- Keystore type (JKS/PKCS12 etc.)-->
+            <Type>PKCS12</Type>
+        </TenantKeyStore>
 
         <!--
             The KeyStore which is used for encrypting/decrypting internal data.

--- a/distribution/kernel/carbon-home/repository/resources/conf/default.json
+++ b/distribution/kernel/carbon-home/repository/resources/conf/default.json
@@ -121,6 +121,7 @@
   "keystore.primary.password": "wso2carbon",
   "keystore.primary.alias": "wso2carbon",
   "keystore.primary.key_password": "wso2carbon",
+  "keystore.tenant.type": "PKCS12",
   "keystore.userstore_password_encryption": "InternalKeyStore",
   "keystore.internal.file_name": "$ref{keystore.primary.file_name}",
   "keystore.internal.type": "$ref{keystore.primary.type}",

--- a/distribution/kernel/carbon-home/repository/resources/conf/templates/repository/conf/carbon.xml.j2
+++ b/distribution/kernel/carbon-home/repository/resources/conf/templates/repository/conf/carbon.xml.j2
@@ -502,6 +502,7 @@
             KeyStore which will be used for encrypting/decrypting passwords
             and other sensitive information.
         -->
+        <!-- KeyStore configurations for super tenant.-->
         <KeyStore>
             <!-- Keystore file location-->
             <Location>${carbon.home}/repository/resources/security/{{keystore.primary.file_name}}</Location>
@@ -514,6 +515,12 @@
             <!-- Private Key password-->
             <KeyPassword>{{keystore.primary.key_password}}</KeyPassword>
         </KeyStore>
+        <!-- KeyStore configurations for newly created tenants (not applicable to existing tenants). -->
+        <TenantKeyStore>
+            <!-- Keystore type (JKS/PKCS12 etc.)-->
+            <Type>{{keystore.tenant.type}}</Type>
+        </TenantKeyStore>
+
 
         <!--
             The KeyStore which is used for encrypting/decrypting internal data.

--- a/tests/caching/src/main/resources/carbon_home/repository/conf/carbon.xml
+++ b/tests/caching/src/main/resources/carbon_home/repository/conf/carbon.xml
@@ -363,6 +363,7 @@
             KeyStore which will be used for encrypting/decrypting passwords
             and other sensitive information.
         -->
+        <!-- KeyStore configurations for super tenant.-->
         <KeyStore>
             <!-- Keystore file location-->
             <Location>${carbon.home}/repository/resources/security/wso2carbon.p12</Location>
@@ -375,6 +376,11 @@
             <!-- Private Key password-->
             <KeyPassword>wso2carbon</KeyPassword>
         </KeyStore>
+        <!-- KeyStore configurations for newly created tenants (not applicable to existing tenants). -->
+        <TenantKeyStore>
+            <!-- Keystore type (JKS/PKCS12 etc.)-->
+            <Type>PKCS12</Type>
+        </TenantKeyStore>
 
         <!--
             System wide trust-store which is used to maintain the certificates of all


### PR DESCRIPTION
Issue:
- https://github.com/wso2/product-is/issues/18466

Add following config to define the keystore type for tenants.
```
<!-- KeyStore configurations for newly created tenants (not applicable to existing tenants). -->
<TenantKeyStore>
    <!-- Keystore type (JKS/PKCS12 etc.)-->
    <Type>PKCS12</Type>
</TenantKeyStore>
```
It can be changed from the deployment.toml with following config
```
[keystore.tenant]
type = "PKCS12"

