### PR TITLE
Differentiate the AWS config params with the toml configs

### DIFF
--- a/core/org.wso2.carbon.hazelcast/src/main/java/org/wso2/carbon/hazelcast/aws/AWSBasedMembershipScheme.java
+++ b/core/org.wso2.carbon.hazelcast/src/main/java/org/wso2/carbon/hazelcast/aws/AWSBasedMembershipScheme.java
@@ -102,15 +102,15 @@ public class AWSBasedMembershipScheme implements HazelcastMembershipScheme {
         AwsConfig awsConfig = networkConfig.getJoin().getAwsConfig();
         awsConfig.setEnabled(true);
 
-        Parameter accessKey = getParameter(AWSConstants.ACCESS_KEY);
-        Parameter secretKey = getParameter(AWSConstants.SECRET_KEY);
-        Parameter iamRole = getParameter(AWSConstants.IAM_ROLE);
-        Parameter securityGroup = getParameter(AWSConstants.SECURITY_GROUP);
-        Parameter connTimeout = getParameter(AWSConstants.CONNECTION_TIMEOUT);
-        Parameter hostHeader = getParameter(AWSConstants.HOST_HEADER);
-        Parameter region = getParameter(AWSConstants.REGION);
-        Parameter tagKey = getParameter(AWSConstants.TAG_KEY);
-        Parameter tagValue = getParameter(AWSConstants.TAG_VALUE);
+        Parameter accessKey = getParameter(AWSConstants.ACCESS_KEY_LOCAL_PARAM);
+        Parameter secretKey = getParameter(AWSConstants.SECRET_KEY_LOCAL_PARAM);
+        Parameter iamRole = getParameter(AWSConstants.IAM_ROLE_LOCAL_PARAM);
+        Parameter securityGroup = getParameter(AWSConstants.SECURITY_GROUP_LOCAL_PARAM);
+        Parameter connTimeout = getParameter(AWSConstants.CONNECTION_TIMEOUT_LOCAL_PARAM);
+        Parameter hostHeader = getParameter(AWSConstants.HOST_HEADER_LOCAL_PARAM);
+        Parameter region = getParameter(AWSConstants.REGION_LOCAL_PARAM);
+        Parameter tagKey = getParameter(AWSConstants.TAG_KEY_LOCAL_PARAM);
+        Parameter tagValue = getParameter(AWSConstants.TAG_VALUE_LOCAL_PARAM);
 
         SecretResolver secretResolver = getAxis2SecretResolver();
 

--- a/core/org.wso2.carbon.hazelcast/src/main/java/org/wso2/carbon/hazelcast/aws/AWSConstants.java
+++ b/core/org.wso2.carbon.hazelcast/src/main/java/org/wso2/carbon/hazelcast/aws/AWSConstants.java
@@ -32,4 +32,13 @@ public class AWSConstants {
     public static final String TAG_VALUE = "tag-value";
     public static final String IAM_ROLE = "iam-role";
     public static final String NETWORK_INTERFACE = "networkInterface";
+    public static final String ACCESS_KEY_LOCAL_PARAM = "accessKey";
+    public static final String SECRET_KEY_LOCAL_PARAM = "secretKey";
+    public static final String SECURITY_GROUP_LOCAL_PARAM = "securityGroup" ;
+    public static final String CONNECTION_TIMEOUT_LOCAL_PARAM ="connTimeout" ;
+    public static final String HOST_HEADER_LOCAL_PARAM = "hostHeader";
+    public static final String REGION_LOCAL_PARAM = "region";
+    public static final String TAG_KEY_LOCAL_PARAM = "tagKey";
+    public static final String TAG_VALUE_LOCAL_PARAM = "tagValue";
+    public static final String IAM_ROLE_LOCAL_PARAM = "iamRole";
 }


### PR DESCRIPTION
## Purpose
* $subject
* Fixes : https://github.com/wso2/product-is/issues/18496
* Previously from a HazelCast update, the config param names were changed according to [1]. Since this change affected to the existing configs, introduced old params to extract the configs from IS and traslating to the new params.

[1] https://docs.hazelcast.org/docs/4.0/manual/html-single/#aws-element