### PR TITLE
Implement group id support for ReadWrite LDAP and AD User Store Managers

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/UniqueIDUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/UniqueIDUserStoreManager.java
@@ -605,6 +605,18 @@ public interface UniqueIDUserStoreManager extends UserStoreManager {
     boolean isGroupExist(String groupID) throws UserStoreException;
 
     /**
+     * Check whether a group exists with the given name.
+     *
+     * @param groupName Group name.
+     * @return Return true if group exists in the system.
+     * @throws UserStoreException If an error occurs while checking whether a group exists in the system.
+     */
+    default boolean isGroupExistWithName(String groupName) throws UserStoreException {
+
+        throw new NotImplementedException("Operation is not supported.");
+    }
+
+    /**
      * Delete a group.
      *
      * @param groupID Group ID.

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractGroupManagementErrorEventListener.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractGroupManagementErrorEventListener.java
@@ -186,13 +186,6 @@ public class AbstractGroupManagementErrorEventListener implements GroupManagemen
     }
 
     @Override
-    public boolean onAddGroupFailure(String errorCode, String errorMessage, List<String> userIDs,
-                                     Group group, UserStoreManager userStoreManager) throws UserStoreException {
-
-        return true;
-    }
-
-    @Override
     public boolean onPreAddGroupFailure(String errorCode, String errorMessage, String groupName, List<String> userIDs,
                                         List<Claim> claims, UserStoreManager userStoreManager) {
 
@@ -200,8 +193,9 @@ public class AbstractGroupManagementErrorEventListener implements GroupManagemen
     }
 
     @Override
-    public boolean onPostAddGroupFailure(String errorCode, String errorMessage, List<String> userIDs, Group group,
-                                         UserStoreManager userStoreManager) throws UserStoreException {
+    public boolean onPostAddGroupFailure(String errorCode, String errorMessage, String groupName, String groupId,
+                                         List<String> userIDs, List<Claim> claims, UserStoreManager userStoreManager)
+            throws UserStoreException {
 
         return true;
     }

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractGroupManagementErrorEventListener.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractGroupManagementErrorEventListener.java
@@ -176,4 +176,75 @@ public class AbstractGroupManagementErrorEventListener implements GroupManagemen
 
         return true;
     }
+
+    @Override
+    public boolean onAddGroupFailure(String errorCode, String errorMessage, String groupName, List<String> userIDs,
+                                     List<Claim> claims, UserStoreManager userStoreManager)
+            throws UserStoreException {
+
+        return true;
+    }
+
+    @Override
+    public boolean onAddGroupFailure(String errorCode, String errorMessage, List<String> userIDs,
+                                     Group group, UserStoreManager userStoreManager) throws UserStoreException {
+
+        return true;
+    }
+
+    @Override
+    public boolean onPreAddGroupFailure(String errorCode, String errorMessage, String groupName, List<String> userIDs,
+                                        List<Claim> claims, UserStoreManager userStoreManager) {
+
+        return true;
+    }
+
+    @Override
+    public boolean onPostAddGroupFailure(String errorCode, String errorMessage, List<String> userIDs, Group group,
+                                         UserStoreManager userStoreManager) throws UserStoreException {
+
+        return true;
+    }
+
+    @Override
+    public boolean onPreDeleteGroupFailure(String errorCode, String errorMessage, String groupId,
+                                           UserStoreManager userStoreManager) throws UserStoreException {
+
+        return true;
+    }
+
+    @Override
+    public boolean onPostDeleteGroupFailure(String errorCode, String errorMessage, String groupId, String groupName,
+                                            UserStoreManager userStoreManager) throws UserStoreException {
+
+        return true;
+    }
+
+    @Override
+    public boolean onDeleteGroupFailure(String errorCode, String errorMessage, String groupId,
+                                        UserStoreManager userStoreManager) throws UserStoreException {
+
+        return true;
+    }
+
+    @Override
+    public boolean onPreRenameGroupFailure(String errorCode, String errorMessage, String groupId, String newGroupName,
+                                           UserStoreManager userStoreManager) throws UserStoreException {
+
+        return true;
+    }
+
+    @Override
+    public boolean onPostRenameGroupFailure(String errorCode, String errorMessage, String groupId, String newGroupName,
+                                            UserStoreManager userStoreManager) throws UserStoreException {
+
+        return true;
+    }
+
+    @Override
+    public boolean onRenameGroupFailure(String errorCode, String errorMessage, String groupId, String newGroupName,
+                                        UserStoreManager userStoreManager) throws UserStoreException {
+
+        return true;
+    }
 }

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractGroupOperationEventListener.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractGroupOperationEventListener.java
@@ -119,4 +119,44 @@ public class AbstractGroupOperationEventListener implements GroupOperationEventL
 
         return true;
     }
+
+    @Override
+    public boolean preAddGroup(String groupName, List<String> userIds, List<Claim> claims,
+                               UserStoreManager userStoreManager) throws UserStoreException {
+
+        return true;
+    }
+
+    @Override
+    public boolean postAddGroup(List<String> userIds, Group group, UserStoreManager userStoreManager)
+            throws UserStoreException {
+
+        return true;
+    }
+
+    @Override
+    public boolean preDeleteGroup(String groupId, UserStoreManager userStoreManager) throws UserStoreException {
+
+        return true;
+    }
+
+    @Override
+    public boolean postDeleteGroup(String groupId, String groupName, UserStoreManager userStoreManager) throws UserStoreException {
+
+        return true;
+    }
+
+    @Override
+    public boolean preRenameGroup(String groupId, String newGroupName, UserStoreManager userStoreManager)
+            throws UserStoreException {
+
+        return true;
+    }
+
+    @Override
+    public boolean postRenameGroup(String groupId, String newGroupName, UserStoreManager userStoreManager)
+            throws UserStoreException {
+
+        return true;
+    }
 }

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractGroupOperationEventListener.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractGroupOperationEventListener.java
@@ -128,8 +128,8 @@ public class AbstractGroupOperationEventListener implements GroupOperationEventL
     }
 
     @Override
-    public boolean postAddGroup(List<String> userIds, Group group, UserStoreManager userStoreManager)
-            throws UserStoreException {
+    public boolean postAddGroup(String groupName, String groupId, List<String> userIds, List<Claim> claims,
+                                UserStoreManager userStoreManager) throws UserStoreException {
 
         return true;
     }

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractGroupResolver.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractGroupResolver.java
@@ -90,4 +90,17 @@ public class AbstractGroupResolver implements GroupResolver {
 
         return true;
     }
+
+    @Override
+    public boolean addGroup(Group group, UserStoreManager userStoreManager)
+            throws UserStoreException {
+
+        return true;
+    }
+
+    @Override
+    public boolean deleteGroupByName(String groupName, UserStoreManager userStoreManager) throws UserStoreException {
+
+        return true;
+    }
 }

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/GroupUniqueIDDomainResolver.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/GroupUniqueIDDomainResolver.java
@@ -24,6 +24,7 @@ import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.user.api.UserStoreManager;
 import org.wso2.carbon.user.core.UserCoreConstants;
+import org.wso2.carbon.user.core.UserStoreClientException;
 import org.wso2.carbon.user.core.UserStoreException;
 import org.wso2.carbon.user.core.service.RealmService;
 import org.wso2.carbon.user.core.util.UserCoreUtil;
@@ -128,8 +129,8 @@ public class GroupUniqueIDDomainResolver {
                     if (log.isDebugEnabled()) {
                         log.debug("Entry is outdated. Clearing cache and the database entries.");
                     }
-                    deleteDomainFromDB(domainName, groupId, tenantId);
                     clearGroupIDResolverCache(groupId, tenantId);
+                    deleteDomainFromDB(domainName, groupId, tenantId);
                     domainName = null;
                 }
             }
@@ -151,7 +152,8 @@ public class GroupUniqueIDDomainResolver {
      *                           the userstore manager does not support group uuid.
      * @throws UserStoreException If an error occurred while setting the domain name for the group id.
      */
-    public void setDomainForGroupId(String groupId, String userstoreDomain, int tenantId, boolean persistToCacheOnly) throws UserStoreException {
+    public void setDomainForGroupId(String groupId, String userstoreDomain, int tenantId, boolean persistToCacheOnly)
+            throws UserStoreException {
 
         try {
             if (StringUtils.isEmpty(groupId) || StringUtils.isEmpty(userstoreDomain)) {
@@ -176,6 +178,59 @@ public class GroupUniqueIDDomainResolver {
             if (log.isDebugEnabled()) {
                 log.debug(String.format("Successfully persisted group id: %s against domain: %s and added to " +
                         "the cache", groupId, userstoreDomain));
+            }
+        } finally {
+            PrivilegedCarbonContext.endTenantFlow();
+        }
+    }
+
+    /**
+     * Remove the domain to group mappings for the given group id given tenant.
+     *
+     * @param groupId         Group unique id.
+     * @param userstoreDomain Userstore domain name.
+     * @param tenantId        Tenant id.
+     * @param clearOnlyCache  Whether to clear the cache only. This needs to be set to true if the userstore manager
+     *                        does not support group uuid
+     * @throws UserStoreException If an error occurred while removing the domain name for the group id.
+     */
+    public void removeDomainForGroupId(String groupId, String userstoreDomain, int tenantId, boolean clearOnlyCache)
+            throws UserStoreException {
+
+        try {
+            if (StringUtils.isEmpty(groupId)) {
+                throw new UserStoreException("group id cannot be empty or null");
+            }
+            PrivilegedCarbonContext.startTenantFlow();
+            PrivilegedCarbonContext carbonContext = PrivilegedCarbonContext.getThreadLocalCarbonContext();
+            carbonContext.setTenantId(tenantId, true);
+            CacheManager cacheManager = Caching.getCacheManagerFactory()
+                    .getCacheManager(GROUP_UNIQUE_ID_DOMAIN_RESOLVER_CACHE_MANGER_NAME);
+            Cache<String, String> uniqueIdDomainCache =
+                    cacheManager.getCache(GROUP_UNIQUE_ID_DOMAIN_RESOLVER_CACHE_NAME);
+            uniqueIdDomainCache.remove(groupId);
+            clearGroupIDResolverCache(groupId, tenantId);
+            if (log.isDebugEnabled()) {
+                log.debug(String.format("Successfully removed group id: %s from the cache", groupId));
+            }
+            if (!clearOnlyCache) {
+                String domainInDb = getDomainFromDB(groupId, tenantId);
+                if (StringUtils.isBlank(domainInDb)) {
+                    if (log.isDebugEnabled()) {
+                        log.debug(String.format("No domain name found for the give group id: %s", groupId));
+                    }
+                    return;
+                }
+                if (!domainInDb.equals(userstoreDomain)) {
+                    throw new UserStoreClientException(
+                            String.format("Provided domain group id: %s name: %s does not match " +
+                                            "with the domain name in the database: %s in tenant: %s", groupId, userstoreDomain,
+                                    domainInDb, tenantId));
+                }
+                deleteDomainFromDB(userstoreDomain, groupId, tenantId);
+                if (log.isDebugEnabled()) {
+                    log.debug(String.format("Successfully removed group id: %s from the database", groupId));
+                }
             }
         } finally {
             PrivilegedCarbonContext.endTenantFlow();

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/constants/UserCoreErrorConstants.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/constants/UserCoreErrorConstants.java
@@ -234,6 +234,11 @@ public class UserCoreErrorConstants {
         ERROR_EMPTY_USER_ID("60006", "User id cannot be empty"),
         ERROR_NO_USER_WITH_USERNAME("60007", "No user found with username: %s in " +
                 "userstore domain: %s"),
+        ERROR_EMPTY_GROUP("60008", "Group cannot be empty"),
+        ERROR_GROUP_NOT_IN_USER_STORE("60009", "New group name: %s does match with the userstore name " +
+                " of the existing group with id: %s"),
+        ERROR_CODE_INVALID_GROUP_NAME("60010",  "Group name %s is not valid. Group name must be a "
+                + "non null string with format: %s"),
 
         // Server error codes related to group operations.
         ERROR_DURING_PRE_GET_GROUP_BY_ID("65001",
@@ -268,7 +273,22 @@ public class UserCoreErrorConstants {
                 "response in userstore: %s in tenant: %s"),
         ERROR_WHILE_GETTING_GROUPS("65016", "Error occurred while getting the groups"),
         ERROR_WHILE_PERFORMING_PAGINATED_SEARCH("65017", "Error occurred while performing the " +
-                "paginated search");
+                "paginated search"),
+        ERROR_DURING_PRE_ADD_GROUP("65018", "Un-expected error during pre add group: %s"),
+        ERROR_CODE_GROUP_ALREADY_EXISTS("65019", "Group name: %s exists in the userstore. " +
+                "Please pick another group name."),
+        ERROR_CODE_GROUP_UUID_NOT_SUPPORTED("65020", "Group UUID is not supported in the userstore"),
+        ERROR_DURING_POST_ADD_GROUP("65021", "Un-expected error during post add group: %s"),
+        ERROR_DURING_PRE_DELETE_GROUP("65022",
+                "Un-expected error during pre delete groups with ID with condition, %s"),
+        ERROR_DURING_POST_DELETE_GROUP("65023",
+                "Un-expected error during post delete groups with ID with condition, %s"),
+        ERROR_WHILE_DELETE_GROUP("65024", "Un-expected error while deleting group, %s"),
+        ERROR_DURING_PRE_RENAME_GROUP("65025",
+                "Un-expected error during pre rename groups with ID with condition, %s"),
+        ERROR_DURING_POST_RENAME_GROUP("65026",
+                "Un-expected error during post rename groups with ID with condition, %s"),
+        ERROR_WHILE_RENAME_GROUP("65027", "Un-expected error while renaming group, %s");
 
         private final String code;
         private final String message;

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/JDBCUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/JDBCUserStoreManager.java
@@ -945,22 +945,22 @@ public class JDBCUserStoreManager extends AbstractUserStoreManager {
 
     protected boolean isExistingJDBCRole(RoleContext context) throws UserStoreException {
 
-        boolean isExisting;
         String roleName = context.getRoleName();
-
         String sqlStmt = realmConfig.getUserStoreProperty(JDBCRealmConstants.GET_IS_ROLE_EXISTING);
-        if (sqlStmt == null) {
+        if (StringUtils.isBlank(sqlStmt)) {
             throw new UserStoreException("The sql statement for is role existing role null");
         }
-
         if (sqlStmt.contains(UserCoreConstants.UM_TENANT_COLUMN)) {
-            isExisting =
-                    isValueExisting(sqlStmt, null, roleName, ((JDBCRoleContext) context).getTenantId());
-        } else {
-            isExisting = isValueExisting(sqlStmt, null, roleName);
+            return isValueExisting(sqlStmt, null, roleName, ((JDBCRoleContext) context).getTenantId());
         }
+        return isValueExisting(sqlStmt, null, roleName);
+    }
 
-        return isExisting;
+    @Override
+    protected boolean doCheckExistingGroupName(String groupName) throws UserStoreException {
+
+        RoleContext roleContext = createRoleContext(groupName);
+        return isExistingJDBCRole(roleContext);
     }
 
     /**

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/ActiveDirectoryUserStoreConstants.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/ActiveDirectoryUserStoreConstants.java
@@ -91,6 +91,16 @@ public class ActiveDirectoryUserStoreConstants {
                 UserStoreConfigConstants.usernameListFilterDescription, false,
                 new Property[] { USER.getProperty(), STRING.getProperty(), TRUE.getProperty() });
 
+        // Group Id Related Userstore Configurations - By default this will be disabled.
+        setMandatoryPropertyForUniqueIdStore(UserStoreConfigConstants.GROUP_ID_ENABLED,
+                UserStoreConfigConstants.GROUP_ID_ENABLED_DISPLAY_NAME, Boolean.toString(false),
+                UserStoreConfigConstants.GROUP_ID_ENABLED_DESCRIPTION, false,
+                new Property[]{GROUP.getProperty(), STRING.getProperty(), TRUE.getProperty()});
+        setMandatoryPropertyForUniqueIdStore(UserStoreConfigConstants.GROUP_ID_ATTRIBUTE,
+                UserStoreConfigConstants.GROUP_ID_ATTRIBUTE_DISPLAY_NAME, LDAPConstants.DEFAULT_GROUP_ID_ATTRIBUTE,
+                UserStoreConfigConstants.GROUP_ID_ATTRIBUTE_DESCRIPTION, false,
+                new Property[]{GROUP.getProperty(), STRING.getProperty(), TRUE.getProperty()});
+
         //Set optional properties
 
         setProperty(UserStoreConfigConstants.userDNPattern, "User DN Pattern", "",
@@ -160,6 +170,16 @@ public class ActiveDirectoryUserStoreConstants {
                 new Property[] { GROUP.getProperty(), STRING.getProperty(), TRUE.getProperty() });
         setProperty(UserStoreConfigConstants.groupNameListFilter, "Group List Filter", "(objectcategory=group)",
                 UserStoreConfigConstants.groupNameListFilterDescription,
+                new Property[] { GROUP.getProperty(), STRING.getProperty(), TRUE.getProperty() });
+        setProperty(UserStoreConfigConstants.GROUP_CREATED_DATE_ATTRIBUTE,
+                UserStoreConfigConstants.GROUP_CREATED_DATE_ATTRIBUTE_DISPLAY_NAME,
+                LDAPConstants.DEFAULT_GROUP_CREATED_DATE_ATTRIBUTE,
+                UserStoreConfigConstants.GROUP_CREATED_DATE_ATTRIBUTE_DESCRIPTION,
+                new Property[] { GROUP.getProperty(), STRING.getProperty(), TRUE.getProperty() });
+        setProperty(UserStoreConfigConstants.GROUP_LAST_MODIFIED_DATE_ATTRIBUTE,
+                UserStoreConfigConstants.GROUP_LAST_MODIFIED_DATE_ATTRIBUTE_DISPLAY_NAME,
+                LDAPConstants.DEFAULT_GROUP_LAST_MODIFIED_DATE_ATTRIBUTE,
+                UserStoreConfigConstants.GROUP_LAST_MODIFIED_DATE_ATTRIBUTE_DESCRIPTION,
                 new Property[] { GROUP.getProperty(), STRING.getProperty(), TRUE.getProperty() });
 
         setProperty(roleDNPattern, "Group DN Pattern", "", roleDNPatternDescription,

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/ReadOnlyLDAPUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/ReadOnlyLDAPUserStoreManager.java
@@ -794,6 +794,13 @@ public class ReadOnlyLDAPUserStoreManager extends AbstractUserStoreManager {
 
     }
 
+    @Override
+    protected boolean doCheckExistingGroupName(String groupName) throws UserStoreException {
+
+        RoleContext roleContext = createRoleContext(groupName);
+        return isExistingLDAPRole(roleContext);
+    }
+
     protected boolean isExistingLDAPRole(RoleContext context) throws UserStoreException {
 
         boolean debug = log.isDebugEnabled();

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/ReadWriteLDAPUserStoreConstants.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/ReadWriteLDAPUserStoreConstants.java
@@ -94,6 +94,16 @@ public class ReadWriteLDAPUserStoreConstants {
                 UserStoreConfigConstants.userIdSearchFilterDescription, false,
                 new Property[] { USER.getProperty(), STRING.getProperty(), TRUE.getProperty() });
 
+        // Group Id Related Userstore Configurations - By default this will be disabled.
+        setMandatoryPropertyForUniqueIdStore(UserStoreConfigConstants.GROUP_ID_ENABLED,
+                UserStoreConfigConstants.GROUP_ID_ENABLED_DISPLAY_NAME, Boolean.toString(false),
+                UserStoreConfigConstants.GROUP_ID_ENABLED_DESCRIPTION, false,
+                new Property[]{GROUP.getProperty(), STRING.getProperty(), TRUE.getProperty()});
+        setMandatoryPropertyForUniqueIdStore(UserStoreConfigConstants.GROUP_ID_ATTRIBUTE,
+                UserStoreConfigConstants.GROUP_ID_ATTRIBUTE_DISPLAY_NAME, LDAPConstants.DEFAULT_GROUP_ID_ATTRIBUTE,
+                UserStoreConfigConstants.GROUP_ID_ATTRIBUTE_DESCRIPTION, false,
+                new Property[]{GROUP.getProperty(), STRING.getProperty(), TRUE.getProperty()});
+
         setProperty(UserStoreConfigConstants.userDNPattern, "User DN Pattern", "",
                 UserStoreConfigConstants.userDNPatternDescription,
                 new Property[] { USER.getProperty(), STRING.getProperty(), FALSE.getProperty() });
@@ -123,6 +133,16 @@ public class ReadWriteLDAPUserStoreConstants {
                 new Property[] { GROUP.getProperty(), STRING.getProperty(), TRUE.getProperty() });
         setProperty(UserStoreConfigConstants.groupNameListFilter, "Group List Filter", "(objectClass=groupOfNames)",
                 UserStoreConfigConstants.groupNameListFilterDescription,
+                new Property[] { GROUP.getProperty(), STRING.getProperty(), TRUE.getProperty() });
+        setProperty(UserStoreConfigConstants.GROUP_CREATED_DATE_ATTRIBUTE,
+                UserStoreConfigConstants.GROUP_CREATED_DATE_ATTRIBUTE_DISPLAY_NAME,
+                LDAPConstants.DEFAULT_GROUP_CREATED_DATE_ATTRIBUTE,
+                UserStoreConfigConstants.GROUP_CREATED_DATE_ATTRIBUTE_DESCRIPTION,
+                new Property[] { GROUP.getProperty(), STRING.getProperty(), TRUE.getProperty() });
+        setProperty(UserStoreConfigConstants.GROUP_LAST_MODIFIED_DATE_ATTRIBUTE,
+                UserStoreConfigConstants.GROUP_LAST_MODIFIED_DATE_ATTRIBUTE_DISPLAY_NAME,
+                LDAPConstants.DEFAULT_GROUP_LAST_MODIFIED_DATE_ATTRIBUTE,
+                UserStoreConfigConstants.GROUP_LAST_MODIFIED_DATE_ATTRIBUTE_DESCRIPTION,
                 new Property[] { GROUP.getProperty(), STRING.getProperty(), TRUE.getProperty() });
         setProperty(roleDNPattern, "Group DN Pattern", "", roleDNPatternDescription,
                 new Property[] { GROUP.getProperty(), STRING.getProperty(), FALSE.getProperty() });

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/listener/GroupManagementErrorEventListener.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/listener/GroupManagementErrorEventListener.java
@@ -22,7 +22,6 @@ import org.wso2.carbon.user.core.NotImplementedException;
 import org.wso2.carbon.user.core.UserStoreException;
 import org.wso2.carbon.user.core.UserStoreManager;
 import org.wso2.carbon.user.core.common.Claim;
-import org.wso2.carbon.user.core.common.Group;
 import org.wso2.carbon.user.core.model.Condition;
 
 import java.util.List;
@@ -150,7 +149,7 @@ public interface GroupManagementErrorEventListener {
      * @throws UserStoreException If an error occurred while performing the operation.
      */
     boolean onPostGetGroupsListByUserIdFailure(String errorCode, String errorMessage, String userId,
-                                              UserStoreManager userStoreManager) throws UserStoreException;
+                                               UserStoreManager userStoreManager) throws UserStoreException;
 
     /**
      * Defines any additional actions that need to be done when there is a failure after getting the group by id.
@@ -331,25 +330,7 @@ public interface GroupManagementErrorEventListener {
      * @throws UserStoreException If an error occurred while performing the operation.
      */
     default boolean onAddGroupFailure(String errorCode, String errorMessage, String groupName, List<String> userIDs,
-                                      List<Claim> claims, UserStoreManager userStoreManager)
-            throws UserStoreException {
-
-        throw new NotImplementedException("onAddGroupWithIDFailure is not implemented");
-    }
-
-    /**
-     * Defines any additional actions that need to be done when there is a failure while adding a group.
-     *
-     * @param errorCode        Error code.
-     * @param errorMessage     Error message.
-     * @param userIDs          User id list.
-     * @param group            Group object.
-     * @param userStoreManager Userstore manager.
-     * @return True if the handling succeeded.
-     * @throws UserStoreException If an error occurred while performing the operation.
-     */
-    default boolean onAddGroupFailure(String errorCode, String errorMessage, List<String> userIDs,
-                                      Group group, UserStoreManager userStoreManager) throws UserStoreException {
+                                      List<Claim> claims, UserStoreManager userStoreManager) throws UserStoreException {
 
         throw new NotImplementedException("onAddGroupWithIDFailure is not implemented");
     }
@@ -378,14 +359,16 @@ public interface GroupManagementErrorEventListener {
      *
      * @param errorCode        Error code.
      * @param errorMessage     Error message.
+     * @param groupName        Group name.
+     * @param groupId          Group id.
      * @param userIDs          User id list.
-     * @param group            Group object.
+     * @param claims           Claims list.
      * @param userStoreManager Userstore manager.
      * @return True if the handling succeeded.
      * @throws UserStoreException If an error occurred while performing the operation.
      */
-    default boolean onPostAddGroupFailure(String errorCode, String errorMessage, List<String> userIDs, Group group,
-                                          UserStoreManager userStoreManager)
+    default boolean onPostAddGroupFailure(String errorCode, String errorMessage, String groupName, String groupId,
+                                          List<String> userIDs, List<Claim> claims, UserStoreManager userStoreManager)
             throws UserStoreException {
 
         throw new NotImplementedException("onAddGroupWithIDFailure is not implemented");

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/listener/GroupManagementErrorEventListener.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/listener/GroupManagementErrorEventListener.java
@@ -18,8 +18,11 @@
 
 package org.wso2.carbon.user.core.listener;
 
+import org.wso2.carbon.user.core.NotImplementedException;
 import org.wso2.carbon.user.core.UserStoreException;
 import org.wso2.carbon.user.core.UserStoreManager;
+import org.wso2.carbon.user.core.common.Claim;
+import org.wso2.carbon.user.core.common.Group;
 import org.wso2.carbon.user.core.model.Condition;
 
 import java.util.List;
@@ -314,4 +317,177 @@ public interface GroupManagementErrorEventListener {
     boolean onListGroupsFailure(String errorCode, String errorMessage, Condition condition, int limit, int offset,
                                 String domain, String sortBy, String sortOrder, UserStoreManager userStoreManager)
             throws UserStoreException;
+
+    /**
+     * Defines any additional actions that need to be done when there is a failure while adding a group.
+     *
+     * @param errorCode        Error code.
+     * @param errorMessage     Error message.
+     * @param groupName        Group name.
+     * @param userIDs          User id list.
+     * @param claims           Claims list.
+     * @param userStoreManager Userstore manager.
+     * @return True if the handling succeeded.
+     * @throws UserStoreException If an error occurred while performing the operation.
+     */
+    default boolean onAddGroupFailure(String errorCode, String errorMessage, String groupName, List<String> userIDs,
+                                      List<Claim> claims, UserStoreManager userStoreManager)
+            throws UserStoreException {
+
+        throw new NotImplementedException("onAddGroupWithIDFailure is not implemented");
+    }
+
+    /**
+     * Defines any additional actions that need to be done when there is a failure while adding a group.
+     *
+     * @param errorCode        Error code.
+     * @param errorMessage     Error message.
+     * @param userIDs          User id list.
+     * @param group            Group object.
+     * @param userStoreManager Userstore manager.
+     * @return True if the handling succeeded.
+     * @throws UserStoreException If an error occurred while performing the operation.
+     */
+    default boolean onAddGroupFailure(String errorCode, String errorMessage, List<String> userIDs,
+                                      Group group, UserStoreManager userStoreManager) throws UserStoreException {
+
+        throw new NotImplementedException("onAddGroupWithIDFailure is not implemented");
+    }
+
+    /**
+     * Defines any additional actions that need to be done when there is a failure before adding a group with group id.
+     *
+     * @param errorCode        Error code.
+     * @param errorMessage     Error message.
+     * @param groupName        Group name.
+     * @param userIDs          User id list.
+     * @param claims           Claims list.
+     * @param userStoreManager Userstore manager.
+     * @return True if the handling succeeded.
+     * @throws UserStoreException If an error occurred while performing the operation.
+     */
+    default boolean onPreAddGroupFailure(String errorCode, String errorMessage, String groupName, List<String> userIDs,
+                                         List<Claim> claims, UserStoreManager userStoreManager)
+            throws UserStoreException {
+
+        throw new NotImplementedException("onAddGroupWithIDFailure is not implemented");
+    }
+
+    /**
+     * Defines any additional actions that need to be done when there is a failure after adding a group with group id.
+     *
+     * @param errorCode        Error code.
+     * @param errorMessage     Error message.
+     * @param userIDs          User id list.
+     * @param group            Group object.
+     * @param userStoreManager Userstore manager.
+     * @return True if the handling succeeded.
+     * @throws UserStoreException If an error occurred while performing the operation.
+     */
+    default boolean onPostAddGroupFailure(String errorCode, String errorMessage, List<String> userIDs, Group group,
+                                          UserStoreManager userStoreManager)
+            throws UserStoreException {
+
+        throw new NotImplementedException("onAddGroupWithIDFailure is not implemented");
+    }
+
+    /**
+     * Defines any additional actions that need to be done when there is a failure before deleting a group.
+     *
+     * @param errorCode        Error code.
+     * @param errorMessage     Error message.
+     * @param groupId          Group id.
+     * @param userStoreManager Userstore manager.
+     * @return True if the handling succeeded.
+     * @throws UserStoreException If an error occurred while performing the operation.
+     */
+    default boolean onPreDeleteGroupFailure(String errorCode, String errorMessage, String groupId,
+                                            UserStoreManager userStoreManager) throws UserStoreException {
+
+        throw new NotImplementedException("onPreDeleteGroupFailure is not implemented");
+    }
+
+    /**
+     * Defines any additional actions that need to be done when there is a failure after deleting a group.
+     *
+     * @param errorCode        Error code.
+     * @param errorMessage     Error message.
+     * @param groupId          Group id.
+     * @param groupName        Group name.
+     * @param userStoreManager Userstore manager.
+     * @return True if the handling succeeded.
+     * @throws UserStoreException If an error occurred while performing the operation.
+     */
+    default boolean onPostDeleteGroupFailure(String errorCode, String errorMessage, String groupId, String groupName,
+                                             UserStoreManager userStoreManager) throws UserStoreException {
+
+        throw new NotImplementedException("onPostDeleteGroupFailure is not implemented");
+    }
+
+    /**
+     * Defines any additional actions that need to be done when there is a failure while deleting a group.
+     *
+     * @param errorCode        Error code.
+     * @param errorMessage     Error message.
+     * @param groupId          Group id.
+     * @param userStoreManager Userstore manager.
+     * @return True if the handling succeeded.
+     * @throws UserStoreException If an error occurred while performing the operation.
+     */
+    default boolean onDeleteGroupFailure(String errorCode, String errorMessage, String groupId,
+                                         UserStoreManager userStoreManager) throws UserStoreException {
+
+        throw new NotImplementedException("onDeleteGroupFailure is not implemented");
+    }
+
+    /**
+     * Defines any additional actions that need to be done when there is a failure before renaming a group.
+     *
+     * @param errorCode        Error code.
+     * @param errorMessage     Error message.
+     * @param groupId          Group id.
+     * @param newGroupName     New group name.
+     * @param userStoreManager Userstore manager.
+     * @return True if the handling succeeded.
+     * @throws UserStoreException If an error occurred while performing the operation.
+     */
+    default boolean onPreRenameGroupFailure(String errorCode, String errorMessage, String groupId, String newGroupName,
+                                            UserStoreManager userStoreManager) throws UserStoreException {
+
+        throw new NotImplementedException("onPreRenameGroupFailure is not implemented");
+    }
+
+    /**
+     * Defines any additional actions that need to be done when there is a failure after renaming a group.
+     *
+     * @param errorCode        Error code.
+     * @param errorMessage     Error message.
+     * @param groupId          Group id.
+     * @param newGroupName     New group name.
+     * @param userStoreManager Userstore manager.
+     * @return True if the handling succeeded.
+     * @throws UserStoreException If an error occurred while performing the operation.
+     */
+    default boolean onPostRenameGroupFailure(String errorCode, String errorMessage, String groupId, String newGroupName,
+                                             UserStoreManager userStoreManager) throws UserStoreException {
+
+        throw new NotImplementedException("onPostRenameGroupFailure is not implemented");
+    }
+
+    /**
+     * Defines any additional actions that need to be done when there is a failure while renaming a group.
+     *
+     * @param errorCode        Error code.
+     * @param errorMessage     Error message.
+     * @param groupId          Group id.
+     * @param newGroupName     New group name.
+     * @param userStoreManager Userstore manager.
+     * @return True if the handling succeeded.
+     * @throws UserStoreException If an error occurred while performing the operation.
+     */
+    default boolean onRenameGroupFailure(String errorCode, String errorMessage, String groupId, String newGroupName,
+                                         UserStoreManager userStoreManager) throws UserStoreException {
+
+        throw new NotImplementedException("onRenameGroupFailure is not implemented");
+    }
 }

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/listener/GroupOperationEventListener.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/listener/GroupOperationEventListener.java
@@ -272,7 +272,7 @@ public interface GroupOperationEventListener {
      * Defines any additional action after renaming the group.
      *
      * @param groupId          Group unique id.
-     * @param newGroupName     Group name.
+     * @param newGroupName     New group name.
      * @param userStoreManager The underlying UserStoreManager.
      * @return Whether execution of this method of the underlying UserStoreManager must happen.
      */

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/listener/GroupOperationEventListener.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/listener/GroupOperationEventListener.java
@@ -209,13 +209,15 @@ public interface GroupOperationEventListener {
     /**
      * Defines any additional action after adding the group.
      *
+     * @param groupName        Group unique name
+     * @param groupId          Group Id.
      * @param userIds          List of user ids.
-     * @param group            Group object.
+     * @param claims           List of claims.
      * @param userStoreManager The underlying UserStoreManager.
      * @return Whether execution of this method of the underlying UserStoreManager must happen.
      */
-    default boolean postAddGroup(List<String> userIds, Group group, UserStoreManager userStoreManager)
-            throws UserStoreException {
+    default boolean postAddGroup(String groupName, String groupId, List<String> userIds, List<Claim> claims,
+                                 UserStoreManager userStoreManager) throws UserStoreException {
 
         throw new NotImplementedException(
                 "Post add group operation is not implemented for " + this.getClass().getName());
@@ -270,7 +272,7 @@ public interface GroupOperationEventListener {
      * Defines any additional action after renaming the group.
      *
      * @param groupId          Group unique id.
-     * @param groupName        Group name.
+     * @param newGroupName     Group name.
      * @param userStoreManager The underlying UserStoreManager.
      * @return Whether execution of this method of the underlying UserStoreManager must happen.
      */

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/listener/GroupOperationEventListener.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/listener/GroupOperationEventListener.java
@@ -18,8 +18,10 @@
 
 package org.wso2.carbon.user.core.listener;
 
+import org.wso2.carbon.user.core.NotImplementedException;
 import org.wso2.carbon.user.core.UserStoreException;
 import org.wso2.carbon.user.core.UserStoreManager;
+import org.wso2.carbon.user.core.common.Claim;
 import org.wso2.carbon.user.core.common.Group;
 import org.wso2.carbon.user.core.model.Condition;
 
@@ -186,4 +188,96 @@ public interface GroupOperationEventListener {
      */
     boolean postListGroups(Condition condition, int limit, int offset, String sortBy, String domain, String sortOrder,
                            List<Group> groupsList, UserStoreManager userStoreManager) throws UserStoreException;
+
+    /**
+     * Defines any additional action before adding the group.
+     *
+     * @param groupName        Group unique name.
+     * @param userIds          List of user ids.
+     * @param claims           List of claims.
+     * @param userStoreManager The underlying UserStoreManager.
+     * @return Whether execution of this method of the underlying UserStoreManager must happen.
+     * @throws UserStoreException If an error occurred while performing the operation.
+     */
+    default boolean preAddGroup(String groupName, List<String> userIds, List<Claim> claims,
+                                UserStoreManager userStoreManager) throws UserStoreException {
+
+        throw new NotImplementedException(
+                "Pre add group operation is not implemented for " + this.getClass().getName());
+    }
+
+    /**
+     * Defines any additional action after adding the group.
+     *
+     * @param userIds          List of user ids.
+     * @param group            Group object.
+     * @param userStoreManager The underlying UserStoreManager.
+     * @return Whether execution of this method of the underlying UserStoreManager must happen.
+     */
+    default boolean postAddGroup(List<String> userIds, Group group, UserStoreManager userStoreManager)
+            throws UserStoreException {
+
+        throw new NotImplementedException(
+                "Post add group operation is not implemented for " + this.getClass().getName());
+    }
+
+    /**
+     * Defines any additional action before deleting the group.
+     *
+     * @param groupId          Group unique id.
+     * @param userStoreManager The underlying UserStoreManager.
+     * @return Whether execution of this method of the underlying UserStoreManager must happen.
+     * @throws UserStoreException If an error occurred while performing the operation.
+     */
+    default boolean preDeleteGroup(String groupId, UserStoreManager userStoreManager) throws UserStoreException {
+
+        throw new NotImplementedException(
+                "Pre delete group operation is not implemented for " + this.getClass().getName());
+    }
+
+    /**
+     * Defines any additional action after deleting the group.
+     *
+     * @param groupId          Group unique id.
+     * @param groupName        Group name.
+     * @param userStoreManager The underlying UserStoreManager.
+     * @return Whether execution of this method of the underlying UserStoreManager must happen.
+     */
+    default boolean postDeleteGroup(String groupId, String groupName, UserStoreManager userStoreManager)
+            throws UserStoreException {
+
+        throw new NotImplementedException(
+                "Post delete group operation is not implemented for " + this.getClass().getName());
+    }
+
+    /**
+     * Defines any additional action before renaming the group.
+     *
+     * @param groupId          Group unique id.
+     * @param newGroupName     New group name.
+     * @param userStoreManager The underlying UserStoreManager.
+     * @return Whether execution of this method of the underlying UserStoreManager must happen.
+     * @throws UserStoreException If an error occurred while performing the operation.
+     */
+    default boolean preRenameGroup(String groupId, String newGroupName, UserStoreManager userStoreManager)
+            throws UserStoreException {
+
+        throw new NotImplementedException(
+                "Pre renaming group operation is not implemented for " + this.getClass().getName());
+    }
+
+    /**
+     * Defines any additional action after renaming the group.
+     *
+     * @param groupId          Group unique id.
+     * @param groupName        Group name.
+     * @param userStoreManager The underlying UserStoreManager.
+     * @return Whether execution of this method of the underlying UserStoreManager must happen.
+     */
+    default boolean postRenameGroup(String groupId, String newGroupName, UserStoreManager userStoreManager)
+            throws UserStoreException {
+
+        throw new NotImplementedException(
+                "Post rename group operation is not implemented for " + this.getClass().getName());
+    }
 }

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/listener/GroupResolver.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/listener/GroupResolver.java
@@ -18,6 +18,7 @@
 
 package org.wso2.carbon.user.core.listener;
 
+import org.wso2.carbon.user.core.NotImplementedException;
 import org.wso2.carbon.user.core.UserStoreException;
 import org.wso2.carbon.user.core.UserStoreManager;
 import org.wso2.carbon.user.core.common.Group;
@@ -44,6 +45,33 @@ public interface GroupResolver {
      * @return The execution order identifier integer value.
      */
     int getExecutionOrderId();
+
+    /**
+     * Add a group with the given name and claims.
+     *
+     * @param group            Group object.
+     * @param userStoreManager The underlying UserStoreManager.
+     * @return True if the method execution was successful.
+     * @throws UserStoreException If an error occurred.
+     */
+    default boolean addGroup(Group group, UserStoreManager userStoreManager) throws UserStoreException {
+
+        throw new NotImplementedException("addGroup method is not implemented for " + this.getClass().getName());
+    }
+
+    /**
+     * Delete the group with the given name.
+     *
+     * @param groupName        Group unique name.
+     * @param userStoreManager The underlying UserStoreManager.
+     * @return True if the method execution was successful.
+     * @throws UserStoreException If an error occurred.
+     */
+    default boolean deleteGroupByName(String groupName, UserStoreManager userStoreManager) throws UserStoreException {
+
+        throw new NotImplementedException(
+                "deleteGroupByName method is not implemented for " + this.getClass().getName());
+    }
 
     /**
      * Resolve the domain name of the group with the given id.

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/util/UserCoreUtil.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/util/UserCoreUtil.java
@@ -727,6 +727,21 @@ public final class UserCoreUtil {
     }
 
     /**
+     * Remove the domain part from the list of names.
+     *
+     * @param names Names list.
+     * @return Domain free names list.
+     */
+    public static List<String> removeDomainFromNames(List<String> names) {
+
+        String[] nameList = removeDomainFromNames(names.toArray(new String[0]));
+        if (ArrayUtils.isEmpty(nameList)) {
+            return new ArrayList<>();
+        }
+        return Arrays.asList(nameList);
+    }
+
+    /**
      * @param domainName
      * @param userName
      * @param displayName


### PR DESCRIPTION
## Purpose
Implement Group UUID support for ReadWrite LDAP and AD. 
- Resolves 2nd Todo in https://github.com/wso2/product-is/issues/7913
- Part of https://github.com/wso2/product-is/issues/16368

## Approach

- Used the existing mapper capabilities to manage group meta attributes in the user store side.
- Made sure the for UMs which does not support group uuid feature, the meta information is managed in the scim talbes.

## User stories
N/A

## Release note
TBA

## Documentation
Need to document once the JDBC support is available. 

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
 - Unit tests : No tests for LDAP
 - Integration tests:
   - Existing tests should cover all scenarios
   - Todo: Write more tests for plugging a new user store. 

## Security checks

- [x]  Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
- [x]  Ran FindSecurityBugs plugin and verified report? yes/no
- [x]  Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
N/A

## Related PRs
This is the main PR. There are several more associated with this.

## Migrations (if applicable)
- TBD

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.