### PR TITLE
Use group unique id supported addGroup method in server start

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
@@ -9778,7 +9778,13 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
                             }
                             if (!groupExist && !isReadOnly() && writeGroupsEnabled) {
                                 if (isUniqueUserIdEnabled()) {
-                                    this.doAddRoleWithID(adminRoleName, new String[] { adminUserID }, false);
+                                    if (isUniqueGroupIdEnabled()) {
+                                        List<String> members = new ArrayList<>();
+                                        members.add(adminUserID);
+                                        this.doAddGroup(adminRoleName, generateGroupUUID(), members, null);
+                                    } else {
+                                        this.doAddRoleWithID(adminRoleName, new String[]{adminUserID}, false);
+                                    }
                                 } else {
                                     this.doAddRole(adminRoleName, new String[] { adminUserName }, false);
                                 }


### PR DESCRIPTION
## Purpose
Use group unique id supported addGroup method in server start

- Part of https://github.com/wso2/product-is/issues/7914
- Part of https://github.com/wso2/product-is/issues/16368