### PR TITLE
Make group UUID enalbed ootb

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
@@ -6030,9 +6030,9 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
         if (!isReadOnly() && writeGroupsEnabled) {
             try {
                 if (isUniqueGroupIdEnabled()) {
-                    String groupID = getGroupIdByGroupName(userStore.getDomainFreeGroupName());
+                    String groupID = getGroupIdByGroupName(UserCoreUtil.removeDomainFromName(roleName));
                     clearGroupIDResolverCache(groupID, tenantId);
-                    doUpdateGroupNameByGroupId(groupID, userStore.getDomainFreeGroupName());
+                    doUpdateGroupNameByGroupId(groupID, UserCoreUtil.removeDomainFromName(newRoleName));
                     addGroupNameToGroupIdCache(groupID, newRoleName, getMyDomainName());
                 } else {
                     doUpdateRoleName(userStore.getDomainFreeName(), userStoreNew.getDomainFreeName());
@@ -17249,7 +17249,8 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
         UserStore userStore = getUserStoreWithGroupName(groupName);
         if (userStore.isRecurssive()) {
             return ((UniqueIDUserStoreManager) userStore.getUserStoreManager())
-                    .addGroup(userStore.getDomainFreeGroupName(), UserCoreUtil.removeDomainFromNames(usersIds), claims);
+                    .addGroup(UserCoreUtil.removeDomainFromName(groupName),
+                            UserCoreUtil.removeDomainFromNames(usersIds), claims);
         }
         // #################### Domain Name Free Zone Starts Here ################################
         claims = CollectionUtils.isEmpty(claims) ? new ArrayList<>() : claims;
@@ -17785,7 +17786,7 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
         UserStore userStore = getUserStoreWithGroupName(groupName);
         if (userStore.isRecurssive()) {
             return ((AbstractUserStoreManager) userStore.getUserStoreManager()).isGroupExistWithName(
-                    userStore.getDomainFreeGroupName());
+                    UserCoreUtil.removeDomainFromName(groupName));
         }
         // #################### Domain Name Free Zone Starts Here ################################
         return StringUtils.isNotBlank(getGroupIdByGroupName(groupName));
@@ -17866,7 +17867,7 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
         UserStore newUserStore = getUserStoreWithGroupName(newGroupName);
         if (userStore.isRecurssive()) {
             return ((AbstractUserStoreManager) userStore.getUserStoreManager())
-                    .renameGroup(userStore.getDomainFreeGroupId(), newUserStore.getDomainFreeGroupName());
+                    .renameGroup(userStore.getDomainFreeGroupId(), UserCoreUtil.removeDomainFromName(newGroupName));
         }
         // #################### Domain Name Free Zone Starts Here ################################
         if (!isGroupNameValid(newGroupName)) {
@@ -17917,7 +17918,7 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
                 doUpdateGroupNameByGroupId(groupID, newGroupName);
             } else {
                 // Current group name does not have the domain here.
-                doUpdateGroupName(currentGroupName, newUserStore.getDomainFreeGroupName());
+                doUpdateGroupName(currentGroupName, UserCoreUtil.removeDomainFromName(newGroupName));
             }
         } catch (UserStoreException e) {
             // Add the deleted mapping back to the cache and the DB.

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
@@ -7355,8 +7355,7 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
                                                    List<String> newUserIds) throws UserStoreException {
 
         try {
-            for (GroupOperationEventListener listener : UMListenerServiceComponent
-                    .getGroupOperationEventListeners()) {
+            for (GroupOperationEventListener listener : UMListenerServiceComponent.getGroupOperationEventListeners()) {
                 if (listener instanceof AbstractGroupOperationEventListener) {
                     AbstractGroupOperationEventListener newListener = (AbstractGroupOperationEventListener) listener;
                     if (!newListener.preUpdateUserListOfGroup(groupId, deletedUserIds, newUserIds,
@@ -7391,8 +7390,7 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
             throws UserStoreException {
 
         try {
-            for (GroupOperationEventListener listener : UMListenerServiceComponent
-                    .getGroupOperationEventListeners()) {
+            for (GroupOperationEventListener listener : UMListenerServiceComponent.getGroupOperationEventListeners()) {
                 if (listener instanceof AbstractGroupOperationEventListener) {
                     AbstractGroupOperationEventListener newListener = (AbstractGroupOperationEventListener) listener;
                     if (!newListener.postUpdateUserListOfGroup(groupId, deletedUserIds, newUserIds,

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/ActiveDirectoryUserStoreConstants.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/ActiveDirectoryUserStoreConstants.java
@@ -91,11 +91,7 @@ public class ActiveDirectoryUserStoreConstants {
                 UserStoreConfigConstants.usernameListFilterDescription, false,
                 new Property[] { USER.getProperty(), STRING.getProperty(), TRUE.getProperty() });
 
-        // Group Id Related Userstore Configurations - By default this will be disabled.
-        setMandatoryPropertyForUniqueIdStore(UserStoreConfigConstants.GROUP_ID_ENABLED,
-                UserStoreConfigConstants.GROUP_ID_ENABLED_DISPLAY_NAME, Boolean.toString(false),
-                UserStoreConfigConstants.GROUP_ID_ENABLED_DESCRIPTION, false,
-                new Property[]{GROUP.getProperty(), STRING.getProperty(), TRUE.getProperty()});
+        // Only for unique id supported user store managers.
         setMandatoryPropertyForUniqueIdStore(UserStoreConfigConstants.GROUP_ID_ATTRIBUTE,
                 UserStoreConfigConstants.GROUP_ID_ATTRIBUTE_DISPLAY_NAME, LDAPConstants.DEFAULT_GROUP_ID_ATTRIBUTE,
                 UserStoreConfigConstants.GROUP_ID_ATTRIBUTE_DESCRIPTION, false,
@@ -151,14 +147,6 @@ public class ActiveDirectoryUserStoreConstants {
         setProperty(UserStoreConfigConstants.groupSearchBase, "Group Search Base", "CN=Users,DC=WSO2,DC=Com",
                 UserStoreConfigConstants.groupSearchBaseDescription,
                 new Property[] { GROUP.getProperty(), STRING.getProperty(), TRUE.getProperty() });
-        setProperty(UserStoreConfigConstants.GROUP_CREATED_DATE_ATTRIBUTE,
-                UserStoreConfigConstants.GROUP_CREATED_DATE_ATTRIBUTE_DISPLAY_NAME, "whenCreated",
-                UserStoreConfigConstants.GROUP_CREATED_DATE_ATTRIBUTE_DESCRIPTION,
-                new Property[] { GROUP.getProperty(), BOOLEAN.getProperty(), TRUE.getProperty() });
-        setProperty(UserStoreConfigConstants.GROUP_LAST_MODIFIED_DATE_ATTRIBUTE,
-                UserStoreConfigConstants.GROUP_LAST_MODIFIED_DATE_ATTRIBUTE_DISPLAY_NAME, "whenChanged",
-                UserStoreConfigConstants.GROUP_LAST_MODIFIED_DATE_ATTRIBUTE_DESCRIPTION,
-                new Property[] { GROUP.getProperty(), BOOLEAN.getProperty(), TRUE.getProperty() });
         setProperty(UserStoreConfigConstants.groupEntryObjectClass, "Group Entry Object Class", "group",
                 UserStoreConfigConstants.groupEntryObjectClassDescription,
                 new Property[] { GROUP.getProperty(), STRING.getProperty(), TRUE.getProperty() });
@@ -170,16 +158,6 @@ public class ActiveDirectoryUserStoreConstants {
                 new Property[] { GROUP.getProperty(), STRING.getProperty(), TRUE.getProperty() });
         setProperty(UserStoreConfigConstants.groupNameListFilter, "Group List Filter", "(objectcategory=group)",
                 UserStoreConfigConstants.groupNameListFilterDescription,
-                new Property[] { GROUP.getProperty(), STRING.getProperty(), TRUE.getProperty() });
-        setProperty(UserStoreConfigConstants.GROUP_CREATED_DATE_ATTRIBUTE,
-                UserStoreConfigConstants.GROUP_CREATED_DATE_ATTRIBUTE_DISPLAY_NAME,
-                LDAPConstants.DEFAULT_GROUP_CREATED_DATE_ATTRIBUTE,
-                UserStoreConfigConstants.GROUP_CREATED_DATE_ATTRIBUTE_DESCRIPTION,
-                new Property[] { GROUP.getProperty(), STRING.getProperty(), TRUE.getProperty() });
-        setProperty(UserStoreConfigConstants.GROUP_LAST_MODIFIED_DATE_ATTRIBUTE,
-                UserStoreConfigConstants.GROUP_LAST_MODIFIED_DATE_ATTRIBUTE_DISPLAY_NAME,
-                LDAPConstants.DEFAULT_GROUP_LAST_MODIFIED_DATE_ATTRIBUTE,
-                UserStoreConfigConstants.GROUP_LAST_MODIFIED_DATE_ATTRIBUTE_DESCRIPTION,
                 new Property[] { GROUP.getProperty(), STRING.getProperty(), TRUE.getProperty() });
 
         setProperty(roleDNPattern, "Group DN Pattern", "", roleDNPatternDescription,
@@ -233,15 +211,6 @@ public class ActiveDirectoryUserStoreConstants {
                 "com.sun.jndi.ldap.LdapCtxFactory", UserStoreConfigConstants.lDAPInitialContextFactoryDescription,
                 new Property[] { CONNECTION.getProperty(), STRING.getProperty(), FALSE.getProperty() });
 
-        // Group Id Related Userstore Configurations - By default this will be disabled.
-        setMandatoryPropertyForUniqueIdStore(UserStoreConfigConstants.GROUP_ID_ENABLED,
-                UserStoreConfigConstants.GROUP_ID_ENABLED_DISPLAY_NAME, Boolean.toString(false),
-                UserStoreConfigConstants.GROUP_ID_ENABLED_DESCRIPTION, false,
-                new Property[]{GROUP.getProperty(), BOOLEAN.getProperty(), TRUE.getProperty()});
-        setMandatoryPropertyForUniqueIdStore(UserStoreConfigConstants.GROUP_ID_ATTRIBUTE,
-                UserStoreConfigConstants.GROUP_ID_ATTRIBUTE_DISPLAY_NAME, "objectGuid",
-                UserStoreConfigConstants.GROUP_ID_ATTRIBUTE_DESCRIPTION, false,
-                new Property[]{GROUP.getProperty(), STRING.getProperty(), TRUE.getProperty()});
         setMandatoryPropertyForUniqueIdStore(UserStoreConfigConstants.userIdAttribute,
                 UserStoreConfigConstants.userIdAttributeName, UserStoreConfigConstants.OBJECT_GUID,
                 UserStoreConfigConstants.userIdAttributeDescription, false,

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/ReadOnlyLDAPUserStoreConstants.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/ReadOnlyLDAPUserStoreConstants.java
@@ -83,11 +83,7 @@ public class ReadOnlyLDAPUserStoreConstants {
                 UserStoreConfigConstants.userIdSearchFilterDescription, false,
                 new Property[] { USER.getProperty(), STRING.getProperty(), TRUE.getProperty() });
 
-        // Group Id Related Userstore Configurations - By default this will be disabled.
-        setMandatoryPropertyForUniqueIdStore(UserStoreConfigConstants.GROUP_ID_ENABLED,
-                UserStoreConfigConstants.GROUP_ID_ENABLED_DISPLAY_NAME, Boolean.toString(false),
-                UserStoreConfigConstants.GROUP_ID_ENABLED_DESCRIPTION, false,
-                new Property[]{GROUP.getProperty(), BOOLEAN.getProperty(), TRUE.getProperty()});
+        // Only for unique id supported user store managers.
         setMandatoryPropertyForUniqueIdStore(UserStoreConfigConstants.GROUP_ID_ATTRIBUTE,
                 UserStoreConfigConstants.GROUP_ID_ATTRIBUTE_DISPLAY_NAME, LDAPConstants.DEFAULT_GROUP_ID_ATTRIBUTE,
                 UserStoreConfigConstants.GROUP_ID_ATTRIBUTE_DESCRIPTION, false,
@@ -115,16 +111,6 @@ public class ReadOnlyLDAPUserStoreConstants {
                 new Property[] { GROUP.getProperty(), STRING.getProperty(), TRUE.getProperty() });
         setProperty(UserStoreConfigConstants.groupNameListFilter, "Group List Filter", "(objectClass=groupOfNames)",
                 UserStoreConfigConstants.groupNameListFilterDescription,
-                new Property[] { GROUP.getProperty(), STRING.getProperty(), TRUE.getProperty() });
-        setProperty(UserStoreConfigConstants.GROUP_CREATED_DATE_ATTRIBUTE,
-                UserStoreConfigConstants.GROUP_CREATED_DATE_ATTRIBUTE_DISPLAY_NAME,
-                LDAPConstants.DEFAULT_GROUP_CREATED_DATE_ATTRIBUTE,
-                UserStoreConfigConstants.GROUP_CREATED_DATE_ATTRIBUTE_DESCRIPTION,
-                new Property[] { GROUP.getProperty(), STRING.getProperty(), TRUE.getProperty() });
-        setProperty(UserStoreConfigConstants.GROUP_LAST_MODIFIED_DATE_ATTRIBUTE,
-                UserStoreConfigConstants.GROUP_LAST_MODIFIED_DATE_ATTRIBUTE_DISPLAY_NAME,
-                LDAPConstants.DEFAULT_GROUP_LAST_MODIFIED_DATE_ATTRIBUTE,
-                UserStoreConfigConstants.GROUP_LAST_MODIFIED_DATE_ATTRIBUTE_DESCRIPTION,
                 new Property[] { GROUP.getProperty(), STRING.getProperty(), TRUE.getProperty() });
 
         setProperty(roleDNPattern, "Group DN Pattern", "", roleDNPatternDescription,

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/ReadWriteLDAPUserStoreConstants.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/ReadWriteLDAPUserStoreConstants.java
@@ -94,11 +94,7 @@ public class ReadWriteLDAPUserStoreConstants {
                 UserStoreConfigConstants.userIdSearchFilterDescription, false,
                 new Property[] { USER.getProperty(), STRING.getProperty(), TRUE.getProperty() });
 
-        // Group Id Related Userstore Configurations - By default this will be disabled.
-        setMandatoryPropertyForUniqueIdStore(UserStoreConfigConstants.GROUP_ID_ENABLED,
-                UserStoreConfigConstants.GROUP_ID_ENABLED_DISPLAY_NAME, Boolean.toString(false),
-                UserStoreConfigConstants.GROUP_ID_ENABLED_DESCRIPTION, false,
-                new Property[]{GROUP.getProperty(), STRING.getProperty(), TRUE.getProperty()});
+        // Only for unique id supported user store managers.
         setMandatoryPropertyForUniqueIdStore(UserStoreConfigConstants.GROUP_ID_ATTRIBUTE,
                 UserStoreConfigConstants.GROUP_ID_ATTRIBUTE_DISPLAY_NAME, LDAPConstants.DEFAULT_GROUP_ID_ATTRIBUTE,
                 UserStoreConfigConstants.GROUP_ID_ATTRIBUTE_DESCRIPTION, false,
@@ -133,16 +129,6 @@ public class ReadWriteLDAPUserStoreConstants {
                 new Property[] { GROUP.getProperty(), STRING.getProperty(), TRUE.getProperty() });
         setProperty(UserStoreConfigConstants.groupNameListFilter, "Group List Filter", "(objectClass=groupOfNames)",
                 UserStoreConfigConstants.groupNameListFilterDescription,
-                new Property[] { GROUP.getProperty(), STRING.getProperty(), TRUE.getProperty() });
-        setProperty(UserStoreConfigConstants.GROUP_CREATED_DATE_ATTRIBUTE,
-                UserStoreConfigConstants.GROUP_CREATED_DATE_ATTRIBUTE_DISPLAY_NAME,
-                LDAPConstants.DEFAULT_GROUP_CREATED_DATE_ATTRIBUTE,
-                UserStoreConfigConstants.GROUP_CREATED_DATE_ATTRIBUTE_DESCRIPTION,
-                new Property[] { GROUP.getProperty(), STRING.getProperty(), TRUE.getProperty() });
-        setProperty(UserStoreConfigConstants.GROUP_LAST_MODIFIED_DATE_ATTRIBUTE,
-                UserStoreConfigConstants.GROUP_LAST_MODIFIED_DATE_ATTRIBUTE_DISPLAY_NAME,
-                LDAPConstants.DEFAULT_GROUP_LAST_MODIFIED_DATE_ATTRIBUTE,
-                UserStoreConfigConstants.GROUP_LAST_MODIFIED_DATE_ATTRIBUTE_DESCRIPTION,
                 new Property[] { GROUP.getProperty(), STRING.getProperty(), TRUE.getProperty() });
         setProperty(roleDNPattern, "Group DN Pattern", "", roleDNPatternDescription,
                 new Property[] { GROUP.getProperty(), STRING.getProperty(), FALSE.getProperty() });

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/UniqueIDActiveDirectoryUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/UniqueIDActiveDirectoryUserStoreManager.java
@@ -1143,6 +1143,18 @@ public class UniqueIDActiveDirectoryUserStoreManager extends UniqueIDReadWriteLD
                 UserStoreConfigConstants.singleValuedAttributesDisplayName, " ",
                 UserStoreConfigConstants.singleValuedAttributesDescription,
                 new Property[] { CONNECTION.getProperty(), STRING.getProperty(), FALSE.getProperty() });
+        setAdvancedProperty(UserStoreConfigConstants.GROUP_ID_ENABLED,
+                UserStoreConfigConstants.GROUP_ID_ENABLED_DISPLAY_NAME, Boolean.toString(true),
+                UserStoreConfigConstants.GROUP_ID_ENABLED_DESCRIPTION,
+                new Property[]{GROUP.getProperty(), BOOLEAN.getProperty(), TRUE.getProperty()});
+        setAdvancedProperty(UserStoreConfigConstants.GROUP_CREATED_DATE_ATTRIBUTE,
+                UserStoreConfigConstants.GROUP_CREATED_DATE_ATTRIBUTE_DISPLAY_NAME, "whenCreated",
+                UserStoreConfigConstants.GROUP_CREATED_DATE_ATTRIBUTE_DESCRIPTION,
+                new Property[] { GROUP.getProperty(), BOOLEAN.getProperty(), TRUE.getProperty() });
+        setAdvancedProperty(UserStoreConfigConstants.GROUP_LAST_MODIFIED_DATE_ATTRIBUTE,
+                UserStoreConfigConstants.GROUP_LAST_MODIFIED_DATE_ATTRIBUTE_DISPLAY_NAME, "whenChanged",
+                UserStoreConfigConstants.GROUP_LAST_MODIFIED_DATE_ATTRIBUTE_DESCRIPTION,
+                new Property[] { GROUP.getProperty(), BOOLEAN.getProperty(), TRUE.getProperty() });
     }
 
     private static void setAdvancedProperty(String name, String displayName, String value, String description,

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/UniqueIDReadOnlyLDAPUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/UniqueIDReadOnlyLDAPUserStoreManager.java
@@ -2686,6 +2686,20 @@ public class UniqueIDReadOnlyLDAPUserStoreManager extends ReadOnlyLDAPUserStoreM
                 UserStoreConfigConstants.timestampAttributesDisplayName, " ",
                 UserStoreConfigConstants.timestampAttributesDescription,
                 new Property[] { CONNECTION.getProperty(), STRING.getProperty(), FALSE.getProperty() });
+        setAdvancedProperty(UserStoreConfigConstants.GROUP_ID_ENABLED,
+                UserStoreConfigConstants.GROUP_ID_ENABLED_DISPLAY_NAME, Boolean.toString(true),
+                UserStoreConfigConstants.GROUP_ID_ENABLED_DESCRIPTION,
+                new Property[]{GROUP.getProperty(), BOOLEAN.getProperty(), TRUE.getProperty()});
+        setAdvancedProperty(UserStoreConfigConstants.GROUP_CREATED_DATE_ATTRIBUTE,
+                UserStoreConfigConstants.GROUP_CREATED_DATE_ATTRIBUTE_DISPLAY_NAME,
+                LDAPConstants.DEFAULT_GROUP_CREATED_DATE_ATTRIBUTE,
+                UserStoreConfigConstants.GROUP_CREATED_DATE_ATTRIBUTE_DESCRIPTION,
+                new Property[] { GROUP.getProperty(), STRING.getProperty(), TRUE.getProperty() });
+        setAdvancedProperty(UserStoreConfigConstants.GROUP_LAST_MODIFIED_DATE_ATTRIBUTE,
+                UserStoreConfigConstants.GROUP_LAST_MODIFIED_DATE_ATTRIBUTE_DISPLAY_NAME,
+                LDAPConstants.DEFAULT_GROUP_LAST_MODIFIED_DATE_ATTRIBUTE,
+                UserStoreConfigConstants.GROUP_LAST_MODIFIED_DATE_ATTRIBUTE_DESCRIPTION,
+                new Property[] { GROUP.getProperty(), STRING.getProperty(), TRUE.getProperty() });
     }
 
     private static void setAdvancedProperty(String name, String displayName, String value, String description,

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/UniqueIDReadWriteLDAPUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/UniqueIDReadWriteLDAPUserStoreManager.java
@@ -2668,6 +2668,20 @@ public class UniqueIDReadWriteLDAPUserStoreManager extends UniqueIDReadOnlyLDAPU
                 UserStoreConfigConstants.timestampAttributesDisplayName, " ",
                 UserStoreConfigConstants.timestampAttributesDescription,
                 new Property[] { CONNECTION.getProperty(), STRING.getProperty(), FALSE.getProperty() });
+        setAdvancedProperty(UserStoreConfigConstants.GROUP_ID_ENABLED,
+                UserStoreConfigConstants.GROUP_ID_ENABLED_DISPLAY_NAME, Boolean.toString(true),
+                UserStoreConfigConstants.GROUP_ID_ENABLED_DESCRIPTION,
+                new Property[]{GROUP.getProperty(), BOOLEAN.getProperty(), TRUE.getProperty()});
+        setAdvancedProperty(UserStoreConfigConstants.GROUP_CREATED_DATE_ATTRIBUTE,
+                UserStoreConfigConstants.GROUP_CREATED_DATE_ATTRIBUTE_DISPLAY_NAME,
+                LDAPConstants.DEFAULT_GROUP_CREATED_DATE_ATTRIBUTE,
+                UserStoreConfigConstants.GROUP_CREATED_DATE_ATTRIBUTE_DESCRIPTION,
+                new Property[] { GROUP.getProperty(), STRING.getProperty(), TRUE.getProperty() });
+        setAdvancedProperty(UserStoreConfigConstants.GROUP_LAST_MODIFIED_DATE_ATTRIBUTE,
+                UserStoreConfigConstants.GROUP_LAST_MODIFIED_DATE_ATTRIBUTE_DISPLAY_NAME,
+                LDAPConstants.DEFAULT_GROUP_LAST_MODIFIED_DATE_ATTRIBUTE,
+                UserStoreConfigConstants.GROUP_LAST_MODIFIED_DATE_ATTRIBUTE_DESCRIPTION,
+                new Property[] { GROUP.getProperty(), STRING.getProperty(), TRUE.getProperty() });
     }
 
     @Override

--- a/distribution/kernel/carbon-home/repository/resources/conf/infer.json
+++ b/distribution/kernel/carbon-home/repository/resources/conf/infer.json
@@ -85,7 +85,11 @@
       "user_store.properties.ConnectionRetryDelay": "2m",
       "user_store.properties.UserIDAttribute": "scimId",
       "user_store.properties.UserIdSearchFilter": "(&amp;(objectClass=person)(uid=?))",
-      "user_store.properties.CaseInsensitiveUsername": true
+      "user_store.properties.CaseInsensitiveUsername": true,
+      "user_store.properties.GroupIDEnabled": true,
+      "user_store.properties.GroupIdAttribute": "entryUUID",
+      "user_store.properties.GroupLastModifiedDateAttribute": "modifyTimestamp",
+      "user_store.properties.GroupCreatedDateAttribute": "createTimestamp"
     },
     "read_write_ldap": {
       "user_store.class": "org.wso2.carbon.user.core.ldap.ReadWriteLDAPUserStoreManager",
@@ -155,7 +159,11 @@
       "user_store.properties.ConnectionRetryDelay": "2m",
       "user_store.properties.UserIDAttribute": "scimId",
       "user_store.properties.UserIdSearchFilter": "(&amp;(objectClass=person)(uid=?))",
-      "user_store.properties.CaseInsensitiveUsername": true
+      "user_store.properties.CaseInsensitiveUsername": true,
+      "user_store.properties.GroupIDEnabled": true,
+      "user_store.properties.GroupIdAttribute": "entryUUID",
+      "user_store.properties.GroupLastModifiedDateAttribute": "modifyTimestamp",
+      "user_store.properties.GroupCreatedDateAttribute": "createTimestamp"
     },
     "active_directory": {
       "user_store.class": "org.wso2.carbon.user.core.ldap.ActiveDirectoryUserStoreManager",
@@ -237,7 +245,11 @@
       "user_store.properties.'java.naming.ldap.attributes.binary'": "objectGuid",
       "user_store.properties.ImmutableAttributes": "objectGuid",
       "user_store.properties.UserIdSearchFilter": "(&amp;(objectClass=person)(uid=?))",
-      "user_store.properties.CaseInsensitiveUsername": true
+      "user_store.properties.CaseInsensitiveUsername": true,
+      "user_store.properties.GroupIDEnabled": true,
+      "user_store.properties.GroupIdAttribute": "objectGUID",
+      "user_store.properties.GroupLastModifiedDateAttribute": "whenCreated",
+      "user_store.properties.GroupCreatedDateAttribute": "whenChanged"
     }
   },
   "database.$1.type": {

--- a/distribution/kernel/carbon-home/repository/resources/conf/key-mappings.json
+++ b/distribution/kernel/carbon-home/repository/resources/conf/key-mappings.json
@@ -87,6 +87,10 @@
   "user_store.ssl_certificate_validation_enabled": "user_store.properties.SSLCertificateValidationEnabled",
   "user_store.date_and_time_pattern": "user_store.properties.DateAndTimePattern",
   "user_store.single_valued_attributes": "user_store.properties.SingleValuedAttributes",
+  "user_store.group_id_enabled": "user_store.properties.GroupIDEnabled",
+  "user_store.group_id_attribute": "user_store.properties.GroupIdAttribute",
+  "user_store.group_modified_timestamp_attribute": "user_store.properties.GroupLastModifiedDateAttribute",
+  "user_store.group_created_timestamp_attribute": "user_store.properties.GroupCreatedDateAttribute",
 
   "transport.https.properties.certificate_verification": "transport.https.sslHostConfig.properties.certificateVerification",
   "transport.https.properties.protocols": "transport.https.sslHostConfig.properties.protocols",


### PR DESCRIPTION
## Purpose
Enable group uuid by default for unique id enabled AD and LDAP.
- Part of https://github.com/wso2/product-is/issues/7913
- Part of https://github.com/wso2/product-is/issues/16368

## Goals
Enable group uuid by default for unique id enabled AD and LDAP.

## Approach
- Removed the existing enabled property and changed it to `true`
- Moved configurations to the advanced configs section (except group id attribute config)
   - Operational attributes defined in the core schema cannot be changed. Therefore no need to provide the ability to configure. The option is there in case this is changed.
- Group id attribute can change. 
- Updated `infer.json` with specific values so that there is no need to upgrade the attributes from toml. The option is there in case they need to be changed.
- Added key mapping to configure from time.
