### PR TITLE
Add management console deprecation banner

### DIFF
--- a/core/org.wso2.carbon.ui/src/main/resources/web/admin/layout/header.jsp
+++ b/core/org.wso2.carbon.ui/src/main/resources/web/admin/layout/header.jsp
@@ -163,4 +163,13 @@
 		</div>
         </div>
     </div>
+    <%
+     if (CarbonUtils.isManagementConsoleBannerEnabled()) {
+    %>
+    <div style="background-color: #fff5e8;text-align: justify;padding: 10px;align-self: center;">
+        Management Console is currently operating in legacy mode. It offers limited functionality, including Multi-Tenancy, XACML, and Keystore Management. For a more comprehensive suite of features, we strongly recommend using the new console. Management Console is intended for specific, limited use cases only.
+    </div>
+    <%
+    }
+    %>
 </fmt:bundle>

--- a/core/org.wso2.carbon.ui/src/main/resources/web/admin/layout/header.jsp
+++ b/core/org.wso2.carbon.ui/src/main/resources/web/admin/layout/header.jsp
@@ -167,7 +167,7 @@
      if (CarbonUtils.isManagementConsoleBannerEnabled()) {
     %>
     <div style="background-color: #fff5e8;text-align: justify;padding: 10px;align-self: center;">
-        Management Console is currently operating in legacy mode. It offers limited functionality, including Multi-Tenancy, XACML, and Keystore Management. For a more comprehensive suite of features, we strongly recommend using the new console. Management Console is intended for specific, limited use cases only.
+        Management Console is currently operating in legacy mode. It offers limited functionality, including Multi-Tenancy, XACML, and Keystore Management. For a more comprehensive suite of features, we strongly recommend using the new console.
     </div>
     <%
     }

--- a/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/CarbonUtils.java
+++ b/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/CarbonUtils.java
@@ -1515,4 +1515,25 @@ public class CarbonUtils {
 
         return isInputValidationEnabledConfig == null || Boolean.parseBoolean(isInputValidationEnabledConfig);
     }
+
+    /**
+     * Function to extract ManagementConsoleDeprecationBannerEnabled configuration from carbon.xml.
+     * <pre>
+     * {@code
+     *   <ManagementConsoleDeprecationBannerEnabled>true</ManagementConsoleDeprecationBannerEnabled>
+     * }
+     * </pre>
+     *
+     * @return isManagementConsoleBannerEnabled.
+     */
+    public static boolean isManagementConsoleBannerEnabled() {
+
+        boolean isManagementConsoleBannerEnabled = false;
+        String isManagementConsoleBannerEnabledConfig = ServerConfiguration.getInstance().
+                getFirstProperty("ManagementConsoleDeprecationBannerEnabled");
+        if (isManagementConsoleBannerEnabledConfig != null) {
+            isManagementConsoleBannerEnabled = Boolean.parseBoolean(isManagementConsoleBannerEnabledConfig);
+        }
+        return isManagementConsoleBannerEnabled;
+    }
 }

--- a/distribution/kernel/carbon-home/repository/conf/carbon.xml
+++ b/distribution/kernel/carbon-home/repository/conf/carbon.xml
@@ -743,4 +743,7 @@
 
     <!-- Configure legacy identity server authorization runtime -->
     <EnableLegacyAuthzRuntime>false</EnableLegacyAuthzRuntime>
+
+    <!-- Enable/Disable the deprecation banner in the management console -->
+    <ManagementConsoleDeprecationBannerEnabled>false</ManagementConsoleDeprecationBannerEnabled>
 </Server>

--- a/distribution/kernel/carbon-home/repository/resources/conf/templates/repository/conf/carbon.xml.j2
+++ b/distribution/kernel/carbon-home/repository/resources/conf/templates/repository/conf/carbon.xml.j2
@@ -847,4 +847,6 @@
         <enableOptimizedJDBCSearch>{{jdbc_user_store.enable_optimized_jdbc_search}}</enableOptimizedJDBCSearch>
     </JDBCUserStore>
 
+    <!-- Enable/Disable the deprecation banner in the management console -->
+    <ManagementConsoleDeprecationBannerEnabled>{{management_console_deprecation_banner.enable}}</ManagementConsoleDeprecationBannerEnabled>
 </Server>


### PR DESCRIPTION
## Purpose
> Add a notice banner to indicate that management console is being deprecated and only a limited set of features will be provided through this.

This is by default disabled and enabled through the following deployment config.

```
[management_console_deprecation_banner]
enable = true
```
## Issue

https://github.com/wso2/product-is/issues/18950
