### PR TITLE
Upgrade the POI dependency version and ensure consistency across all POI versions.

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -475,9 +475,9 @@
 
         <orbit.version.hsqldb>1.8.0.7wso2v1</orbit.version.hsqldb>
         <orbit.version.commons.beanutils>1.8.0.wso2v1</orbit.version.commons.beanutils>
-        <orbit.version.poi>3.17.0.wso2v1</orbit.version.poi>
-        <orbit.version.poi.scratchpad>5.2.3.wso2v1</orbit.version.poi.scratchpad>
-        <orbit.version.poi.ooxml>5.2.3.wso2v1</orbit.version.poi.ooxml>
+        <orbit.version.poi>4.1.2.wso2v1</orbit.version.poi>
+        <orbit.version.poi.scratchpad>4.1.2.wso2v1</orbit.version.poi.scratchpad>
+        <orbit.version.poi.ooxml>4.1.2.wso2v1</orbit.version.poi.ooxml>
         <orbit.version.commons.lang>2.6.0.wso2v1</orbit.version.commons.lang>
         <orbit.version.commons.collection>3.2.2.wso2v1</orbit.version.commons.collection>
         <orbit.version.commons.io>2.11.0.wso2v1</orbit.version.commons.io>


### PR DESCRIPTION
### Purpose

- Upgrade poi version to 4.1.2.wso2v1 and
- To fix build issues in APIM product builds, the scratchpad and ooxml versions were downgraded to 4.1.2.wso2v1.