### PR TITLE
Implement doUpdateUserListOfGroup method in UniqueId JDBC userstore

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCUserStoreManager.java
@@ -3965,6 +3965,25 @@ public class UniqueIDJDBCUserStoreManager extends JDBCUserStoreManager {
     }
 
     @Override
+    public void doUpdateUserListOfGroup(String groupId, List<String> deletedUserIds, List<String> newUserIds)
+            throws UserStoreException {
+
+        if (!isUniqueGroupIdEnabled()) {
+            throw new UserStoreException("Group ID is not supported for userstore: " + getMyDomainName());
+        }
+        if (StringUtils.isBlank(groupId)) {
+            throw new UserStoreException(ERROR_EMPTY_GROUP_ID.getMessage());
+        }
+        String groupName = doGetGroupNameFromGroupId(groupId);
+        if (StringUtils.isBlank(groupId)) {
+            throw new UserStoreException(
+                    String.format(ERROR_NO_GROUP_FOUND_WITH_ID.getMessage(), groupId, getTenantDomain(tenantId)));
+        }
+        doUpdateUserListOfRoleWithID(UserCoreUtil.removeDomainFromName(groupName),
+                deletedUserIds.toArray(new String[0]), newUserIds.toArray(new String[0]));
+    }
+
+    @Override
     public void doDeleteGroupByGroupId(String groupId) throws UserStoreException {
 
         if (!isUniqueGroupIdEnabled()) {


### PR DESCRIPTION
## Purpose
Implement `doUpdateUserListOfGroup` method in UniqueId JDBC userstore manager class

## Related Issue
- Part of https://github.com/wso2/product-is/issues/7914

## Approach
Override the new do method introduced via https://github.com/wso2/carbon-kernel/pull/3839
Anyhow there were no external usage in this newly introduced API(`updateUserListOfGroup` API.).