### PR TITLE
[4.9.x] Apply fixes from patches to identity components

### DIFF
--- a/core/org.wso2.carbon.utils/pom.xml
+++ b/core/org.wso2.carbon.utils/pom.xml
@@ -229,6 +229,10 @@
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.orbit.org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+        </dependency>
     </dependencies>
 
     <properties>

--- a/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/CarbonConstants.java
+++ b/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/CarbonConstants.java
@@ -515,4 +515,8 @@ public final class CarbonConstants {
             }
         }
     }
+    // Constants related to hostname verification
+    public static final String DEFAULT_AND_LOCALHOST = "DefaultAndLocalhost";
+    public static final String ALLOW_ALL = "AllowAll";
+    public static final String HOST_NAME_VERIFIER = "httpclient.hostnameVerifier";
 }

--- a/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/CustomHostNameVerifier.java
+++ b/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/CustomHostNameVerifier.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.utils;
+
+import org.apache.commons.lang.ArrayUtils;
+import org.apache.http.conn.ssl.AbstractVerifier;
+
+import javax.net.ssl.SSLException;
+
+/**
+ * Custom hostname verifier class to allow Default and localhost behavior.
+ */
+public class CustomHostNameVerifier extends AbstractVerifier {
+
+    private static final String[] LOCAL_HOSTS = {"::1", "127.0.0.1", "localhost", "localhost.localdomain"};
+
+    @Override
+    public void verify(String hostname, String[] commonNames, String[] subjectAlternativeNames) throws SSLException {
+
+        String[] subjectAltsWithLocalhosts = (String[]) ArrayUtils.addAll(subjectAlternativeNames, LOCAL_HOSTS);
+
+        if (ArrayUtils.isNotEmpty(commonNames) && !ArrayUtils.contains(subjectAlternativeNames, commonNames[0])) {
+            subjectAltsWithLocalhosts = (String[]) ArrayUtils.add(subjectAltsWithLocalhosts, commonNames[0]);
+        }
+        super.verify(hostname, commonNames, subjectAltsWithLocalhosts, false);
+    }
+}

--- a/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/HTTPClientUtils.java
+++ b/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/HTTPClientUtils.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.utils;
+
+import org.apache.http.conn.ssl.AllowAllHostnameVerifier;
+import org.apache.http.conn.ssl.X509HostnameVerifier;
+import org.apache.http.impl.client.HttpClientBuilder;
+
+import static org.wso2.carbon.CarbonConstants.*;
+
+/**
+ * Util methods for HTTP Client.
+ */
+public class HTTPClientUtils {
+
+
+    private HTTPClientUtils() {
+        //disable external instantiation
+    }
+
+    /**
+     * Get the httpclient builder with custom hostname verifier.
+     *
+     * @return HttpClientBuilder.
+     */
+    public static HttpClientBuilder createClientWithCustomVerifier() {
+
+        HttpClientBuilder httpClientBuilder = HttpClientBuilder.create().useSystemProperties();
+        if (DEFAULT_AND_LOCALHOST.equals(System.getProperty(HOST_NAME_VERIFIER))) {
+            X509HostnameVerifier hostnameVerifier = new CustomHostNameVerifier();
+            httpClientBuilder.setHostnameVerifier(hostnameVerifier);
+        } else if (ALLOW_ALL.equals(System.getProperty(HOST_NAME_VERIFIER))) {
+            httpClientBuilder.setHostnameVerifier(new AllowAllHostnameVerifier());
+        }
+
+        return httpClientBuilder;
+    }
+}

--- a/core/org.wso2.carbon.utils/src/test/java/org/wso2/carbon/utils/HTTPClientUtilsTest.java
+++ b/core/org.wso2.carbon.utils/src/test/java/org/wso2/carbon/utils/HTTPClientUtilsTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.utils;
+
+import org.apache.http.conn.ssl.AllowAllHostnameVerifier;
+import org.apache.http.conn.ssl.X509HostnameVerifier;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import org.wso2.carbon.BaseTest;
+
+import java.lang.reflect.Field;
+
+import static org.wso2.carbon.CarbonConstants.ALLOW_ALL;
+import static org.wso2.carbon.CarbonConstants.DEFAULT_AND_LOCALHOST;
+import static org.wso2.carbon.CarbonConstants.HOST_NAME_VERIFIER;
+
+public class HTTPClientUtilsTest extends BaseTest {
+
+    public static final String DUMMY_PROPERTY = "dummy";
+
+    @AfterMethod
+    public void tearDown() {
+    }
+
+    @DataProvider(name = "hostnameVerifierDataProvider")
+    public Object[][] hostnameVerifierDataProvider() {
+        return new Object[][]{
+                {DEFAULT_AND_LOCALHOST, CustomHostNameVerifier.class},
+                {ALLOW_ALL, AllowAllHostnameVerifier.class},
+                {DUMMY_PROPERTY, null}
+        };
+    }
+
+    @Test(dataProvider = "hostnameVerifierDataProvider")
+    public void testCreateClientWithCustomVerifierDefaultAndLocalHost(String hostnameVerifierType,
+                                                                      Class<? extends X509HostnameVerifier> expectedVerifier) throws NoSuchFieldException, IllegalAccessException {
+
+        System.setProperty(HOST_NAME_VERIFIER, hostnameVerifierType);
+
+        HttpClientBuilder httpClientBuilder = HTTPClientUtils.createClientWithCustomVerifier();
+
+        // Use reflection APIs to get the hostname verifier field value
+        Class<HttpClientBuilder> httpClientBuilderClass = HttpClientBuilder.class;
+        Field hostnameVerifierField = httpClientBuilderClass.getDeclaredField("hostnameVerifier");
+        hostnameVerifierField.setAccessible(true);
+
+        // If the hostname verifier property is set to "DEFAULT_AND_LOCALHOST" or "ALLOW_ALL", the hostname verifier
+        // field in the httpClientBuilder should be set with an instance of the expected verifier class.
+        // Otherwise, it should be null.
+        X509HostnameVerifier hostnameVerifier = (X509HostnameVerifier) hostnameVerifierField.get(httpClientBuilder);
+        if (expectedVerifier == null) {
+            Assert.assertNull(hostnameVerifier);
+        } else {
+            Assert.assertTrue(expectedVerifier.isInstance(hostnameVerifier));
+        }
+    }
+}

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -654,6 +654,10 @@
         <config.mapper.version>1.0.23</config.mapper.version>
         <version.stax.ex>1.8.3</version.stax.ex>
         <version.saaj.impl>1.5.0</version.saaj.impl>
+        <httpcomponents-httpclient.wso2.version>4.3.6.wso2v2</httpcomponents-httpclient.wso2.version>
+        <httpcomponents-httpclient.imp.pkg.version.range>
+            [4.3.1.wso2v2,5.0.0)
+        </httpcomponents-httpclient.imp.pkg.version.range>
     </properties>
 
     <dependencyManagement>
@@ -1896,6 +1900,11 @@
                 <artifactId>log4j-jcl</artifactId>
                 <version>${version.log4j.core}</version>
                 <optional>true</optional>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.orbit.org.apache.httpcomponents</groupId>
+                <artifactId>httpclient</artifactId>
+                <version>${httpcomponents-httpclient.wso2.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.sun.xml.messaging.saaj</groupId>


### PR DESCRIPTION
PR contains the following fixes : 

- Add support for "DefaultAndLocalhost" and "AllowAll" hostname verification behaviours 
  