### PR TITLE
Fix the ReadGroup property format issue in AD

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/ActiveDirectoryUserStoreConstants.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/ActiveDirectoryUserStoreConstants.java
@@ -117,30 +117,9 @@ public class ActiveDirectoryUserStoreConstants {
                 UserStoreConfigConstants.USE_CASE_SENSITIVE_USERNAME_FOR_CACHE_KEYS_DESCRIPTION,
                 new Property[] { USER.getProperty(), BOOLEAN.getProperty(), TRUE.getProperty() });
 
-        Property readLDAPGroups = new Property(UserStoreConfigConstants.readGroups, "true",
-                "Read Groups#" + UserStoreConfigConstants.readLDAPGroupsDescription,
+        setProperty(UserStoreConfigConstants.readGroups, "Read Groups", "true",
+                UserStoreConfigConstants.readLDAPGroupsDescription,
                 new Property[] { GROUP.getProperty(), BOOLEAN.getProperty(), TRUE.getProperty() });
-        //Mandatory only if readGroups is enabled
-        Property groupSearchBase = new Property(UserStoreConfigConstants.groupSearchBase, "CN=Users,DC=WSO2,DC=Com",
-                "Group Search Base#" + UserStoreConfigConstants.groupSearchBaseDescription,
-                new Property[] { GROUP.getProperty(), STRING.getProperty(), TRUE.getProperty() });
-        Property groupNameListFilter = new Property(UserStoreConfigConstants.groupNameListFilter,
-                "(objectcategory=group)", "Group Filter#" + UserStoreConfigConstants.groupNameListFilterDescription,
-                new Property[] { GROUP.getProperty(), STRING.getProperty(), TRUE.getProperty() });
-        Property groupNameAttribute = new Property(UserStoreConfigConstants.groupNameAttribute, "cn",
-                "Group Name Attribute#" + UserStoreConfigConstants.groupNameAttributeDescription,
-                new Property[] { GROUP.getProperty(), STRING.getProperty(), TRUE.getProperty() });
-        Property membershipAttribute = new Property(UserStoreConfigConstants.membershipAttribute, "member",
-                "Membership Attribute#" + UserStoreConfigConstants.membershipAttributeDescription,
-                new Property[] { GROUP.getProperty(), STRING.getProperty(), TRUE.getProperty() });
-        Property groupNameSearchFilter = new Property(UserStoreConfigConstants.groupNameSearchFilter,
-                "(&(objectClass=group)(cn=?))",
-                "Group Search Filter#" + UserStoreConfigConstants.groupNameSearchFilterDescription,
-                new Property[] { GROUP.getProperty(), STRING.getProperty(), TRUE.getProperty() });
-        readLDAPGroups.setChildProperties(new Property[] {
-                groupSearchBase, groupNameAttribute, groupNameListFilter, membershipAttribute, groupNameSearchFilter
-        });
-        OPTIONAL_ACTIVE_DIRECTORY_UM_PROPERTIES.add(readLDAPGroups);
 
         setProperty(UserStoreConfigConstants.writeGroups, "Write Groups", "true",
                 UserStoreConfigConstants.writeGroupsDescription,


### PR DESCRIPTION
## Purpose
- Resolves https://github.com/wso2/product-is/issues/19621


### Note
- Above removed properties(groupSearchBase, groupNameAttribute, groupNameListFilter, membershipAttribute, groupNameSearchFilter) are already setting seperately here.https://github.com/wso2/carbon-kernel/blob/2e83b4df85988f0dac3ff6f3ec0b1f26cafe9725/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/ActiveDirectoryUserStoreConstants.java#L127-L141
- So no need to add them as child properties of `ReadGroups` property.
- We are doing the same approach in LDAP also https://github.com/wso2/carbon-kernel/blob/3f826d7e8924e46712531a57ef55711edae2eaaf/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/ReadWriteLDAPUserStoreConstants.java#L112-L114
