### PR TITLE
Fix server when updating group name

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
@@ -17860,6 +17860,8 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
                     .renameGroup(userStore.getDomainFreeGroupId(), UserCoreUtil.removeDomainFromName(newGroupName));
         }
         // #################### Domain Name Free Zone Starts Here ################################
+        // For non recursive user stores, we need to check the domain of the new group name.
+        newGroupName = UserCoreUtil.removeDomainFromName(newGroupName);
         if (!isGroupNameValid(newGroupName)) {
             String regEx = realmConfig
                     .getUserStoreProperty(UserCoreConstants.RealmConfig.PROPERTY_ROLE_NAME_JAVA_REG_EX);

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCUserStoreManager.java
@@ -3930,8 +3930,8 @@ public class UniqueIDJDBCUserStoreManager extends JDBCUserStoreManager {
         String domainFreeNewGroupName = UserCoreUtil.removeDomainFromName(newGroupName);
         if (!StringUtils.equalsIgnoreCase(domainFreeCurrentGroupName, domainFreeNewGroupName) &&
                 isExistingRole(domainFreeNewGroupName)) {
-            throw new UserStoreException("Role name: " + domainFreeNewGroupName
-                    + " in the system. Please pick another role name.");
+            throw new UserStoreClientException("Group name: " + domainFreeNewGroupName
+                    + " in the system. Please pick another group name.");
         }
         String sqlStmt = realmConfig.getUserStoreProperty(JDBCRealmConstants.UPDATE_GROUP_NAME);
         if (StringUtils.isBlank(sqlStmt)) {


### PR DESCRIPTION
## Purpose
Fix throwing a server error when renaming a group to an existing group name.
- Resolves: https://github.com/wso2/product-is/issues/19845

## Goals
Fix throwing server error.

## Approach
The primary userstore is not recursive. Therefore mandatory domain removal will be done. 

