### PR TITLE
[4.9.x] Bump POI version to 5.2.5.wso2v1

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -428,7 +428,7 @@
         <version.ant.contrib>1.0b3</version.ant.contrib>
 
         <!-- Apache xmlbeans -->
-        <version.xmlbeans>3.1.0.wso2v1</version.xmlbeans>
+        <version.xmlbeans>5.2.0.wso2v1</version.xmlbeans>
 
         <!-- Apache woden-->
         <version.woden>1.0.0.M9-wso2v1</version.woden>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -479,7 +479,7 @@
         <orbit.version.poi.ooxml>4.1.2.wso2v1</orbit.version.poi.ooxml>
         <orbit.version.commons.lang>2.6.0.wso2v1</orbit.version.commons.lang>
         <orbit.version.commons.collection>3.2.2.wso2v1</orbit.version.commons.collection>
-        <orbit.version.commons.io>2.11.0.wso2v1</orbit.version.commons.io>
+        <orbit.version.commons.io>2.15.1.wso2v1</orbit.version.commons.io>
         <orbit.version.smack>3.0.4.wso2v1</orbit.version.smack>
         <orbit.version.apacheds>1.5.7-wso2v1</orbit.version.apacheds>
         <orbit.version.geronimo-jms_1.1_spec>1.1.1.wso2v1</orbit.version.geronimo-jms_1.1_spec>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -474,9 +474,9 @@
         <orbit.version.jettison>1.3.4.wso2v1</orbit.version.jettison>
 
         <orbit.version.hsqldb>1.8.0.7wso2v1</orbit.version.hsqldb>
-        <orbit.version.poi>4.1.2.wso2v1</orbit.version.poi>
-        <orbit.version.poi.scratchpad>4.1.2.wso2v1</orbit.version.poi.scratchpad>
-        <orbit.version.poi.ooxml>4.1.2.wso2v1</orbit.version.poi.ooxml>
+        <orbit.version.poi>5.2.5.wso2v1</orbit.version.poi>
+        <orbit.version.poi.scratchpad>5.2.5.wso2v1</orbit.version.poi.scratchpad>
+        <orbit.version.poi.ooxml>5.2.5.wso2v1</orbit.version.poi.ooxml>
         <orbit.version.commons.lang>2.6.0.wso2v1</orbit.version.commons.lang>
         <orbit.version.commons.collection>3.2.2.wso2v1</orbit.version.commons.collection>
         <orbit.version.commons.io>2.15.1.wso2v1</orbit.version.commons.io>


### PR DESCRIPTION
## Purpose

This PR adds the following changes,
- [Upgrade poi version to 5.2.5.wso2v1](https://github.com/wso2/carbon-kernel/commit/cde6c5f2f84124ff4557f438068ddb774dc0fbbd)
- [Bump the commons-io version to 2.15.1.wso2v1](https://github.com/wso2/carbon-kernel/commit/b3dbf08ddc297da1183ab74ad756e1650b040d66)
- [Bump the xmlbeans version to 5.2.0.wso2v1](https://github.com/wso2/carbon-kernel/commit/08c059d8fe24e36a1cd060bfa09b0ddb6c229091)