### PR TITLE
[4.9.x] Bump pax-logging version to 2.2.1-wso2v2

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -523,8 +523,8 @@
         <version.commons.logging>1.2</version.commons.logging>
 
         <!--PAX Logging related dependency versions-->
-        <pax.logging.api.version>2.2.1-wso2v1</pax.logging.api.version>
-        <pax.logging.log4j2.version>2.2.1-wso2v1</pax.logging.log4j2.version>
+        <pax.logging.api.version>2.2.1-wso2v2</pax.logging.api.version>
+        <pax.logging.log4j2.version>2.2.1-wso2v2</pax.logging.log4j2.version>
 
         <!--<version.opensaml2>2.4.1.wso2v1</version.opensaml2>-->
         <version.compass>2.0.1.wso2v2</version.compass>


### PR DESCRIPTION
## Purpose
This PR bumps the pax-logging version to 2.2.1-wso2v2