### PR TITLE
[4.9.x] Bump bouncycastle dependencies to 1.77.0

### DIFF
--- a/core/org.wso2.carbon.core.services/pom.xml
+++ b/core/org.wso2.carbon.core.services/pom.xml
@@ -62,7 +62,7 @@
         </dependency>
         <dependency>
             <groupId>org.wso2.orbit.org.bouncycastle</groupId>
-            <artifactId>bcprov-jdk15on</artifactId>
+            <artifactId>bcprov-jdk18on</artifactId>
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>

--- a/core/org.wso2.carbon.core/pom.xml
+++ b/core/org.wso2.carbon.core/pom.xml
@@ -56,7 +56,7 @@
         </dependency>
         <dependency>
             <groupId>org.wso2.orbit.org.bouncycastle</groupId>
-            <artifactId>bcprov-jdk15on</artifactId>
+            <artifactId>bcprov-jdk18on</artifactId>
         </dependency>
         <dependency>
             <groupId>org.wso2.carbon</groupId>

--- a/core/org.wso2.carbon.utils/pom.xml
+++ b/core/org.wso2.carbon.utils/pom.xml
@@ -27,7 +27,7 @@
     <dependencies>
         <dependency>
             <groupId>org.wso2.orbit.org.bouncycastle</groupId>
-            <artifactId>bcprov-jdk15on</artifactId>
+            <artifactId>bcprov-jdk18on</artifactId>
         </dependency>
         <dependency>
             <groupId>org.wso2.carbon</groupId>

--- a/features/org.wso2.carbon.core.server.feature/pom.xml
+++ b/features/org.wso2.carbon.core.server.feature/pom.xml
@@ -70,9 +70,9 @@
                                 </bundleDef>
                                 <bundleDef>org.wso2.carbon:org.wso2.carbon.admin.advisory.mgt:${carbon.kernel.version}
                                 </bundleDef>
-                                <bundleDef>org.wso2.orbit.org.bouncycastle:bcprov-jdk15on:${bouncycastle.version}
+                                <bundleDef>org.wso2.orbit.org.bouncycastle:bcprov-jdk18on:${bouncycastle.provider.version}
                                 </bundleDef>
-                                <bundleDef>org.wso2.orbit.org.bouncycastle:bcpkix-jdk15on:${bouncycastle.version}
+                                <bundleDef>org.wso2.orbit.org.bouncycastle:bcpkix-jdk18on:${bouncycastle.pkix.version}
                                 </bundleDef>
                                 <bundleDef>org.wso2.orbit.org.apache.poi:poi-ooxml:${orbit.version.poi.ooxml}
                                 </bundleDef>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -502,7 +502,8 @@
         <hibernate.orbit.version>3.2.5.ga-wso2v1</hibernate.orbit.version>
 
         <!-- bouncycastle -->
-        <bouncycastle.version>1.70.0.wso2v1</bouncycastle.version>
+        <bouncycastle.pkix.version>1.77.0.wso2v2</bouncycastle.pkix.version>
+        <bouncycastle.provider.version>1.77.0.wso2v1</bouncycastle.provider.version>
         <imp.pkg.version.bcp>[1.0.0, 2.0.0)</imp.pkg.version.bcp>
 
         <!--BPS specific-->
@@ -982,13 +983,13 @@
             </dependency>
             <dependency>
                 <groupId>org.wso2.orbit.org.bouncycastle</groupId>
-                <artifactId>bcprov-jdk15on</artifactId>
-                <version>${bouncycastle.version}</version>
+                <artifactId>bcprov-jdk18on</artifactId>
+                <version>${bouncycastle.provider.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.wso2.orbit.org.bouncycastle</groupId>
-                <artifactId>bcpkix-jdk15on</artifactId>
-                <version>${bouncycastle.version}</version>
+                <artifactId>bcpkix-jdk18on</artifactId>
+                <version>${bouncycastle.pkix.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.compass-project.wso2</groupId>


### PR DESCRIPTION
## Purpose
This PR bumps the bouncycastle provider and pkix dependencies to jdk18on 1.77.0 version.