### PR TITLE
[4.10.x] Enabling Registry Read-only mode through deployment.toml

### DIFF
--- a/distribution/kernel/carbon-home/repository/resources/conf/default.json
+++ b/distribution/kernel/carbon-home/repository/resources/conf/default.json
@@ -1,4 +1,5 @@
 {
+  "registry_mode.readOnly": false,
   "server.default_cache_timeout": "15m",
   "server.default_realm_cache_timeout": "30m",
   "server.force_local_cache": true,

--- a/distribution/kernel/carbon-home/repository/resources/conf/key-mappings.json
+++ b/distribution/kernel/carbon-home/repository/resources/conf/key-mappings.json
@@ -1,4 +1,5 @@
 {
+  "registry_mode.readOnly": "registryMode.readOnly",
   "tenant_mgt.tenant_manager.config_builder": "tenant_mgt.tenant_manager.properties.MultiTenantRealmConfigBuilder",
   "database.shared_db.pool_options.max_active": "database.shared_db.pool_options.maxActive",
   "database.shared_db.pool_options.max_wait": "database.shared_db.pool_options.maxWait",

--- a/distribution/kernel/carbon-home/repository/resources/conf/key-mappings.json
+++ b/distribution/kernel/carbon-home/repository/resources/conf/key-mappings.json
@@ -1,5 +1,5 @@
 {
-  "registry_mode.readOnly": "registryMode.readOnly",
+  "registry_mode.readOnly": "registry_mode.readOnly",
   "tenant_mgt.tenant_manager.config_builder": "tenant_mgt.tenant_manager.properties.MultiTenantRealmConfigBuilder",
   "database.shared_db.pool_options.max_active": "database.shared_db.pool_options.maxActive",
   "database.shared_db.pool_options.max_wait": "database.shared_db.pool_options.maxWait",

--- a/distribution/kernel/carbon-home/repository/resources/conf/templates/repository/conf/registry.xml.j2
+++ b/distribution/kernel/carbon-home/repository/resources/conf/templates/repository/conf/registry.xml.j2
@@ -23,7 +23,7 @@
     -->
 
     <currentDBConfig>wso2registry</currentDBConfig>
-    <readOnly>false</readOnly>
+    <readOnly>{{registry_mode.readOnly}}</readOnly>
     <enableCache>true</enableCache>
     <registryRoot>/</registryRoot>
 


### PR DESCRIPTION
## Purpose
> Enabling Registry Read-only mode through deployment.toml

## Goals
> This will enable users to switch the registry mode to read-only/read-write easily using the deployment.toml

## Approach
> We made few changes in the following files.

1. registry.xml.j2
2. default.json
3. key-mappings.json