### PR TITLE
Fix tenant creation issue

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/tenant/JDBCTenantManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/tenant/JDBCTenantManager.java
@@ -278,15 +278,13 @@ public class JDBCTenantManager implements TenantManager {
             InputStream is = new ByteArrayInputStream(realmConfigString.getBytes());
             prepStmt.setBinaryStream(5, is, is.available());
 
-            if (isTenantUniqueIdColumnAvailable()) {
+            if (isOrgUUIDColumnAvailable && !isTenantUniqueIdColumnAvailable()) {
+                prepStmt.setString(6, tenant.getAssociatedOrganizationUUID());
+            } else if (!isOrgUUIDColumnAvailable && isTenantUniqueIdColumnAvailable()) {
                 prepStmt.setString(6, tenant.getTenantUniqueID());
-                if (isOrgUUIDColumnAvailable) {
-                    prepStmt.setString(7, tenant.getAssociatedOrganizationUUID());
-                }
-            } else {
-                if (isOrgUUIDColumnAvailable) {
-                    prepStmt.setString(6, tenant.getAssociatedOrganizationUUID());
-                }
+            } else if (isOrgUUIDColumnAvailable && isTenantUniqueIdColumnAvailable()) {
+                prepStmt.setString(6, tenant.getAssociatedOrganizationUUID());
+                prepStmt.setString(7, tenant.getTenantUniqueID());
             }
 
             prepStmt.executeUpdate();


### PR DESCRIPTION
## Purpose
> $subject

This PR introduces a refined approach to setting parameters on a PreparedStatement based on the availability of specific columns in a database schema, specifically `UM_ORG_UUID` and `UM_TENANT_UUID`. The original code had a logical flaw that could lead to incorrect parameter setting due to overlapping conditions and misaligned parameter indices when both `UM_ORG_UUID` and `UM_TENANT_UUID` were available. The improved logic clearly separates the conditions under which each parameter is set, ensuring that:

1. If only `UM_ORG_UUID` is available, it is correctly set as the 6th parameter.
2. If only `UM_TENANT_UUID` is available, it is correctly set as the 6th parameter.
3. If both are available, `UM_ORG_UUID` is set as the 6th parameter and `UM_TENANT_UUID` as the 7th, aligning with the database schema.

### Related issues
- https://github.com/wso2/product-is/issues/19978