### PR TITLE
Fix the cache issue after deleting a group

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
@@ -17878,6 +17878,9 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
         // Invoke legacy listeners to maintain backward compatibility.
         handleDoPostDeleteRole(groupName, false);
         // #################### </Post-Listeners> #####################################################
+
+        // Clear the userRole cache.
+        clearUserRolesCacheByTenant(tenantId);
     }
 
     @Override


### PR DESCRIPTION
## Purpose
-  Fix the cache issue after deleting a group
- After deleting a group, the userRole cache which has the roles of the users should clear.
- From this PR, We clear the cache after a successful deletion of a group

## Related issue
https://github.com/wso2/product-is/issues/20055

