### PR TITLE
Add successful message indication for banner config update

### DIFF
--- a/core/admin-advisory-mgt/org.wso2.carbon.admin.advisory.mgt.ui/src/main/resources/web/admin-advisory-mgt/admin-advisory-banner-finish-ajaxprocessor.jsp
+++ b/core/admin-advisory-mgt/org.wso2.carbon.admin.advisory.mgt.ui/src/main/resources/web/admin-advisory-mgt/admin-advisory-banner-finish-ajaxprocessor.jsp
@@ -59,6 +59,7 @@
 
         // Save the new configuration.
         configClient.saveBannerConfig(adminAdvisoryBannerConfig);
+        CarbonUIMessage.sendCarbonUIMessage("Successfully updated the configuration!", CarbonUIMessage.INFO, request);
 
 %>
     <script type="text/javascript">


### PR DESCRIPTION
## Purpose
This PR adds a successful indication message when the Admin advisory banner configuration is updated successfully.

<img width="1512" alt="Screen Shot 2024-03-26 at 6 50 41 PM" src="https://github.com/wso2/carbon-kernel/assets/8557410/a5f97e12-2bea-4e45-9e2c-4803384a203e">
