### PR TITLE
Fix group id resolving for unique group id disabled secondary userstores

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
@@ -18110,10 +18110,10 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
 
         // #################### Invoke userstore methods ####################
         Group group = new Group(null, groupName);
+        group.setUserStoreDomain(getMyDomainName());
         if (isUniqueGroupIdEnabled(this)) {
             String groupId = this.doGetGroupIdFromGroupName(groupName);
             group.setGroupID(groupId);
-            group.setUserStoreDomain(getMyDomainName());
         } else {
             // Invoking group resolver to get data from the legacy approach.
             GroupResolver groupResolver = UserStoreMgtDataHolder.getInstance().getGroupResolver();


### PR DESCRIPTION
## Purpose
> Currently when trying to resolve the group ids of groups in secondary userstores in which unique group id is not enabled, it doesn't get resolved properly since userstore domain is not passed to the group object which is consumed in the group resolver. With this PR, we are setting the userstore domain to the groups object for  unique group id is not enabled cases as well.

Issue - https://github.com/wso2/product-is/issues/20109