### PR TITLE
Remove version information from the resource path when checking permissions

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/authorization/JDBCAuthorizationManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/authorization/JDBCAuthorizationManager.java
@@ -213,6 +213,10 @@ public class JDBCAuthorizationManager implements AuthorizationManager {
     public boolean isUserAuthorized(String userName, String resourceId, String action)
             throws UserStoreException {
 
+        // Regular expression to match and remove any version information appended to the resource path.
+        String versionRegex = ";version:\\d+";
+        resourceId = resourceId.replaceAll(versionRegex, "");
+
         if (!preserveCaseForResources && resourceId != null) {
             resourceId = resourceId.toLowerCase();
         }


### PR DESCRIPTION
In the permission tree, all versions of a resource should adhere to the permission set of the base version of that resource, therefore version info is removed from the checking resource id path. 