### PR TITLE
Revert db commits in the middle of user deletion db connection

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCUserStoreManager.java
@@ -1597,12 +1597,10 @@ public class UniqueIDJDBCUserStoreManager extends JDBCUserStoreManager {
             if (sqlStmt1.contains(UserCoreConstants.UM_TENANT_COLUMN)) {
                 this.updateStringValuesToDatabase(dbConnection, sqlStmt1, userID, tenantId, tenantId);
                 this.updateStringValuesToDatabase(dbConnection, sqlStmt2, userID, tenantId, tenantId);
-                dbConnection.commit();
                 this.updateStringValuesToDatabase(dbConnection, sqlStmt3, userID, tenantId);
             } else {
                 this.updateStringValuesToDatabase(dbConnection, sqlStmt1, userID);
                 this.updateStringValuesToDatabase(dbConnection, sqlStmt2, userID);
-                dbConnection.commit();
                 this.updateStringValuesToDatabase(dbConnection, sqlStmt3, userID);
             }
             dbConnection.commit();


### PR DESCRIPTION
## Purpose
> This PR https://github.com/wso2/carbon-kernel/pull/3623 added a fix to solve an intermittent deadlock issue when there are multiple concurrent scim2 user delete request to delete several users who belong to the same group. But with this fix user rollback flow has broken since we cannot rollback the info once the transaction is committed. And in the meantime this can lead to stale user data when the following query fails to execute properly.

> Also we have added indexes to the UM_USER_ATTRIBUTE and UM_USER_ROLE tables to improve the user deletion query performance. Hence the probability for occurring the deadlock scenario has reduced further. And the fixed introduced in https://github.com/wso2/carbon-kernel/pull/3623 can lead to some stale user scenario, reverting it by this PR.

## Related PRs
- https://github.com/wso2/carbon-kernel/pull/3623