### PR TITLE
Catch unique key violation exception using sql state

### DIFF
--- a/core/org.wso2.carbon.user.core/src/test/java/org/wso2/carbon/user/core/jdbc/AdvancedJDBCRealmTest.java
+++ b/core/org.wso2.carbon.user.core/src/test/java/org/wso2/carbon/user/core/jdbc/AdvancedJDBCRealmTest.java
@@ -479,12 +479,12 @@ public class AdvancedJDBCRealmTest extends BaseTestCase {
         try {
             admin.updateUserListOfRole(realmConfig.getAdminRoleName(), null,
                     new String[]{realmConfig.getAdminUserName()});
-            TestCase.assertTrue(false);
-        } catch (Exception e) {
-            // exptected error in negative testing
             if (log.isDebugEnabled()) {
-                log.debug("Expected error, hence ignored", e);
+                log.debug("Unique key violation exception is not thrown since it is suppressed.");
             }
+        } catch (Exception e) {
+            // Error is not expected since it is suppressed.
+            TestCase.assertTrue(false);
         }
 
         int count = sampleAbstractUserManagementErrorListener.getUpdateRoleListOfUserFailureCount();


### PR DESCRIPTION
## Purpose
Fix sent by https://github.com/wso2/carbon-kernel/pull/3911 doesn't only catch unique key violation exception. Instead it also catches the null value for primary key scenarios as well. 
Hence used the sql state `23505`(ANSI standard for unique key violation) to catch the unique key violation exception only. Checked with all the supported databases types and verified that they support sql state `23505` for unique key violation exception.

Modify the unit test accordingly to not to expect exceptions generated by unique key violations when adding users to roles.