### PR TITLE
 Improve management console login performance for the super admin user 

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/authorization/JDBCAuthorizationManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/authorization/JDBCAuthorizationManager.java
@@ -48,6 +48,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.SQLIntegrityConstraintViolationException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
@@ -508,9 +509,13 @@ public class JDBCAuthorizationManager implements AuthorizationManager {
             String[] roles = this.userRealm.getUserStoreManager().getRoleListOfUser(userName);
             if (skipAuthzCheckForSuperAdmin && MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.equals(
                     CarbonContext.getThreadLocalCarbonContext().getTenantDomain())) {
-                if (caseInSensitiveAuthorizationRules && realmConfig.getAdminUserName().equalsIgnoreCase(userName)) {
+                boolean isSuperAdmin =
+                        Arrays.stream(roles).anyMatch(role -> role.equals(realmConfig.getAdminRoleName()));
+                if (isSuperAdmin && caseInSensitiveAuthorizationRules &&
+                        realmConfig.getAdminUserName().equalsIgnoreCase(userName)) {
                     roles = new String[]{realmConfig.getAdminRoleName()};
-                } else if (realmConfig.getAdminUserName().equals(userName)) {
+                } else if (isSuperAdmin && !caseInSensitiveAuthorizationRules &&
+                        realmConfig.getAdminUserName().equals(userName)) {
                     roles = new String[]{realmConfig.getAdminRoleName()};
                 }
             }

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/authorization/JDBCAuthorizationManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/authorization/JDBCAuthorizationManager.java
@@ -506,6 +506,14 @@ public class JDBCAuthorizationManager implements AuthorizationManager {
         List<String> lstPermissions = new ArrayList<>();
         if (isRoleAndGroupSeparationEnabled || verifyByRetrievingAllUserRoles) {
             String[] roles = this.userRealm.getUserStoreManager().getRoleListOfUser(userName);
+            if (skipAuthzCheckForSuperAdmin && MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.equals(
+                    CarbonContext.getThreadLocalCarbonContext().getTenantDomain())) {
+                if (caseInSensitiveAuthorizationRules && realmConfig.getAdminUserName().equalsIgnoreCase(userName)) {
+                    roles = new String[]{realmConfig.getAdminRoleName()};
+                } else if (realmConfig.getAdminUserName().equals(userName)) {
+                    roles = new String[]{realmConfig.getAdminRoleName()};
+                }
+            }
             permissionTree.updatePermissionTree();
             permissionTree.getUIResourcesForRoles(roles, lstPermissions, permissionRootPath);
             String[] permissions = lstPermissions.toArray(new String[0]);


### PR DESCRIPTION
### Purpose

There is a slowness when logging into the management console using the super admin user when there are many roles (200k+). This PR mitigates the slowness. 

Since the getUIResourcesForRoles method recursively calls all roles against the available permissions tree, resulting in a performance impact. We can limit this process for the super admin by passing only the super admin role to this method, thus avoiding unnecessary role lookups and recursion. To achieve this, we can modify the getAllowedUIResourcesForUser method in the JDBCAuthorizationManager class to add only the super admin role to the roles list and pass only that role to the permissionTree.getUIResourcesForRoles() method.

### Related Issue

https://github.com/wso2/product-is/issues/20165

