### PR TITLE
Fix for issue Password grant not working for migrated users

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
@@ -11277,8 +11277,14 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
                             .doAuthenticateWithID(preferredUserNameProperty, preferredUserNameValue, credentialObj,
                                     profileName);
                 } else {
-                    List<String> users = doGetUserList(preferredUserNameClaim, preferredUserNameValue, profileName,
-                            abstractUserStoreManager.getMyDomainName(), abstractUserStoreManager);
+                    List<String> users = new ArrayList<>();
+                    if (preferredUserNameProperty.equals(getUserNameMappedAttribute())) {
+                        users.add(UserCoreUtil.addDomainToName(preferredUserNameValue,
+                                abstractUserStoreManager.getMyDomainName()));
+                    } else {
+                        users = doGetUserList(preferredUserNameClaim, preferredUserNameValue, profileName,
+                                abstractUserStoreManager.getMyDomainName(), abstractUserStoreManager);
+                    }
                     if (users.size() != 1) {
                         String message = "Users count matching to claim: " + preferredUserNameClaim + " and value: "
                                 + preferredUserNameValue + " is: " + users.size();


### PR DESCRIPTION
### Purpose
Issue: Password grant is not working for users migrated from non unique id user stores from APIM 2.6.0
Issue link: https://github.com/wso2/api-manager/issues/2775