### PR TITLE
Make optional parameters configurable for the Kubernetes membership scheme

### DIFF
--- a/core/org.wso2.carbon.hazelcast/src/main/java/org/wso2/carbon/hazelcast/kubernetes/KubernetesConstants.java
+++ b/core/org.wso2.carbon.hazelcast/src/main/java/org/wso2/carbon/hazelcast/kubernetes/KubernetesConstants.java
@@ -30,4 +30,11 @@ public class KubernetesConstants {
     public static final String SERVICE_NAME = "service-name";
 
     public static final String SERVICE_PORT = "service-port";
+    public static final String KUBERNETES_API_SERVER_PROPERTY = "KUBERNETES_API_SERVER";
+    public static final String KUBERNETES_MASTER = "kubernetes-master";
+    public static final String KUBERNETES_API_SERVER_TOKEN_PROPERTY = "KUBERNETES_API_SERVER_TOKEN";
+    public static final String KUBERNETES_API_SERVER_TOKEN = "api-token";
+    public static final String KUBERNETES_SERVICE_HOST = "KUBERNETES_SERVICE_HOST";
+    public static final String KUBERNETES_SERVICE_PORT_HTTPS = "KUBERNETES_SERVICE_PORT_HTTPS";
+    public static final String PROTOCOL_HTTPS = "https";
 }


### PR DESCRIPTION
## Purpose

With the previous implementation of Hazelcast, some optional properties were configurable. However, with the Hazelcast upgrade from version 3.x to 4.x, these properties cannot be configured.

Compared to the previously supported optional parameters, the upgraded version supports KUBERNETES_API_SERVER (kubernetes-master as per Hazelcast) and KUBERNETES_API_SERVER_TOKEN (api-token as per Hazelcast). Additionally, we can provide support for KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT_HTTPS (alternatively, KUBERNETES_API_SERVER can be set via KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT_HTTPS). Therefore, with this PR, make these four parameters configurable.

Related Issue :
https://github.com/wso2/product-is/issues/20189