### PR TITLE
Add null checks for userIDs

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
@@ -13739,6 +13739,9 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
 
         List<String> userNames = new ArrayList<>();
         for (String userID : userIDs) {
+            if (StringUtils.isBlank(userID)) {
+                continue;
+            }
             userNames.add(getUserNameFromUserID(userID));
         }
         return userNames;
@@ -17108,6 +17111,9 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
         Map<String, List<String>> domainAwareUsers = new HashMap<>();
         if (!userIDs.isEmpty()) {
             for (String userID : userIDs) {
+                if (StringUtils.isBlank(userID)) {
+                    continue;
+                }
                 try {
                     User user = getUser(userID, null);
                     String domainName = user.getUserStoreDomain();


### PR DESCRIPTION
### Purpose
- Add null checks for userIDs to fix NPEs thrown when `null` user ID is used to retrieve users.
- Fixes https://github.com/wso2-enterprise/wso2-iam-internal/issues/1492
