### PR TITLE
Add a config to support case-insensitive user attributes for JDBC userstores

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/UserStoreConfigConstants.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/UserStoreConfigConstants.java
@@ -183,6 +183,9 @@ public class UserStoreConfigConstants {
     // Property for specify case insensitivity for User stores.
     public static final String CASE_INSENSITIVE_USERNAME = "CaseInsensitiveUsername";
     public static final String CASE_INSENSITIVE_USERNAME_DESCRIPTION = "Whether the username is case sensitive or not";
+    public static final String CASE_INSENSITIVE_ATTRIBUTES = "CaseInsensitiveAttributes";
+    public static final String CASE_INSENSITIVE_ATTRIBUTES_DESCRIPTION = "Comma-separated list of user store maintained " +
+            "case insensitive attributes";
 
     // Property for specify whether case-sensitive username can be used as the cache key.
     public static final String USE_CASE_SENSITIVE_USERNAME_FOR_CACHE_KEYS = "UseCaseSensitiveUsernameForCacheKeys";

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/JDBCUserStoreConstants.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/JDBCUserStoreConstants.java
@@ -111,6 +111,9 @@ public class JDBCUserStoreConstants {
         setProperty(UserStoreConfigConstants.CASE_INSENSITIVE_USERNAME, "Case Insensitive Username", "false",
                 UserStoreConfigConstants.CASE_INSENSITIVE_USERNAME_DESCRIPTION,
                 new Property[] { USER.getProperty(), BOOLEAN.getProperty(), FALSE.getProperty() });
+        setProperty(UserStoreConfigConstants.CASE_INSENSITIVE_ATTRIBUTES, "Case Insensitive Attributes", "",
+                UserStoreConfigConstants.CASE_INSENSITIVE_ATTRIBUTES_DESCRIPTION,
+                new Property[] { USER.getProperty(), STRING.getProperty(), FALSE.getProperty() });
         setProperty(UserStoreConfigConstants.USE_CASE_SENSITIVE_USERNAME_FOR_CACHE_KEYS,
                 "Use Case Sensitive Username for Cache Keys", "true",
                 UserStoreConfigConstants.USE_CASE_SENSITIVE_USERNAME_FOR_CACHE_KEYS_DESCRIPTION,

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCUserStoreManager.java
@@ -3118,13 +3118,14 @@ public class UniqueIDJDBCUserStoreManager extends JDBCUserStoreManager {
 
     private boolean isCaseInsensitiveProperty(String property) {
 
-        String caseInsentisitveAttributesProperty = realmConfig.getUserStoreProperty(
+        String caseInsensitiveAttributesProperty = realmConfig.getUserStoreProperty(
                 UserStoreConfigConstants.CASE_INSENSITIVE_ATTRIBUTES);
-        if (StringUtils.isBlank(caseInsentisitveAttributesProperty)) {
+        if (StringUtils.isBlank(caseInsensitiveAttributesProperty)) {
             return false;
         }
-        String[] caseInsentisitveAttributes = StringUtils.split(caseInsentisitveAttributesProperty, ",");
-        return ArrayUtils.contains(caseInsentisitveAttributes, property);
+        String[] caseInsensitiveAttributes = Arrays.stream(caseInsensitiveAttributesProperty.split(","))
+                .map(String::trim).toArray(String[]::new);
+        return ArrayUtils.contains(caseInsensitiveAttributes, property);
     }
 
     @Override

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCUserStoreManager.java
@@ -20,6 +20,7 @@ package org.wso2.carbon.user.core.jdbc;
 
 import org.apache.axiom.om.util.Base64;
 import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -32,6 +33,7 @@ import org.wso2.carbon.user.core.NotImplementedException;
 import org.wso2.carbon.user.core.UserCoreConstants;
 import org.wso2.carbon.user.core.UserRealm;
 import org.wso2.carbon.user.core.UserStoreClientException;
+import org.wso2.carbon.user.core.UserStoreConfigConstants;
 import org.wso2.carbon.user.core.UserStoreException;
 import org.wso2.carbon.user.core.UserStoreManager;
 import org.wso2.carbon.user.core.claim.ClaimManager;
@@ -2549,7 +2551,7 @@ public class UniqueIDJDBCUserStoreManager extends JDBCUserStoreManager {
                     sqlStmt = realmConfig.getUserStoreProperty(JDBCRealmConstants.GET_USERS_FOR_USERNAME);
                 }
             } else {
-                if (!isCaseSensitiveUsername() && UID.equals(property)) {
+                if ((!isCaseSensitiveUsername() && UID.equals(property)) || isCaseInsensitiveProperty(property)) {
                     sqlStmt = realmConfig.getUserStoreProperty(JDBCCaseInsensitiveConstants.
                             GET_USERS_FOR_PROP_WITH_ID_CASE_INSENSITIVE);
                 } else {
@@ -2565,7 +2567,7 @@ public class UniqueIDJDBCUserStoreManager extends JDBCUserStoreManager {
                     sqlStmt = realmConfig.getUserStoreProperty(JDBCRealmConstants.GET_USER_FOR_USERNAME);
                 }
             } else {
-                if (!isCaseSensitiveUsername() && UID.equals(property)) {
+                if ((!isCaseSensitiveUsername() && UID.equals(property)) || isCaseInsensitiveProperty(property)) {
                     sqlStmt = realmConfig.getUserStoreProperty(JDBCCaseInsensitiveConstants.
                             GET_USERS_FOR_CLAIM_VALUE_WITH_ID_CASE_INSENSITIVE);
                 } else {
@@ -3112,6 +3114,17 @@ public class UniqueIDJDBCUserStoreManager extends JDBCUserStoreManager {
 
         String isUsernameCaseInsensitiveString = realmConfig.getUserStoreProperty(CASE_INSENSITIVE_USERNAME);
         return !Boolean.parseBoolean(isUsernameCaseInsensitiveString);
+    }
+
+    private boolean isCaseInsensitiveProperty(String property) {
+
+        String caseInsentisitveAttributesProperty = realmConfig.getUserStoreProperty(
+                UserStoreConfigConstants.CASE_INSENSITIVE_ATTRIBUTES);
+        if (StringUtils.isBlank(caseInsentisitveAttributesProperty)) {
+            return false;
+        }
+        String[] caseInsentisitveAttributes = StringUtils.split(caseInsentisitveAttributesProperty, ",");
+        return ArrayUtils.contains(caseInsentisitveAttributes, property);
     }
 
     @Override


### PR DESCRIPTION
### Description 
Add a config to support case-insensitive user attributes such as email address, first name, last name for JDBC userstores. 

Added a userstore configuration for JDBC secondary userstores. Add claim names separated by commas.


Add the following config to `deployment.toml` to enable it to primary JDBC userstore.

```
[user_store.properties]
CaseInsensitiveAttributes = "mail,givenName,familyName"
```

### Related issue
https://github.com/wso2/product-is/issues/12815