### PR TITLE
[Impersonation] Single Point of Contact for Audit log dynamic logging

### DIFF
--- a/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/CarbonConstants.java
+++ b/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/CarbonConstants.java
@@ -16,8 +16,8 @@
 package org.wso2.carbon;
 
 import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.base.ServerConfiguration;
+import org.wso2.carbon.utils.logging.CarbonAuditLog;
 import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 
 import java.io.File;
@@ -31,7 +31,7 @@ public final class CarbonConstants {
 	    //disable external instantiation
 	}
 
-    public static final Log AUDIT_LOG = LogFactory.getLog("AUDIT_LOG");
+    public static final Log AUDIT_LOG = new CarbonAuditLog();
     public static final String AUDIT_MESSAGE = "Initiator : %s | Action : %s | Target : %s | Data : { %s } | Result : %s ";
     public static final String DISABLE_LEGACY_AUDIT_LOGS = "disableLegacyAuditLogs";
     public enum DiagnosticLogMode {

--- a/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/logging/CarbonAuditLog.java
+++ b/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/logging/CarbonAuditLog.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.utils.logging;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.slf4j.MDC;
+
+/**
+ * CarbonAuditLog is a wrapper implementation of the Log interface from Apache Commons Logging.
+ * This class is used to provide a standardized way to log audit messages, with additional
+ * context information appended to each log entry.
+ *
+ * The class ensures to append MDC (Mapped Diagnostic Context) properties to each log message before passing it
+ * to the underlying logger. The MDC properties allow you to add context-specific information to log messages.
+ * In this implementation, impersonation details are appended to the log messages if available.
+ *
+ * Usage:
+ *  - Instantiate the CarbonAuditLog class and use its methods to log messages.
+ *  - The class uses a static Log instance named AUDIT_LOG to log messages with the "AUDIT_LOG" name.
+ *  - MDC properties can be appended to log messages to include additional context information.
+ */
+public class CarbonAuditLog implements Log {
+
+    private static final String IMPERSONATOR = "impersonator";
+    public static final Log AUDIT_LOG = LogFactory.getLog("AUDIT_LOG");
+
+    @Override
+    public void debug(Object o) {
+
+        if (o != null) {
+            String message = appendMDCProperties(o.toString());
+            AUDIT_LOG.debug(message);
+        }
+    }
+
+    @Override
+    public void debug(Object o, Throwable throwable) {
+
+        if (o != null) {
+            String message = appendMDCProperties(o.toString());
+            AUDIT_LOG.debug(message, throwable);
+        }
+    }
+
+    @Override
+    public void error(Object o) {
+
+        if (o != null) {
+            String message = appendMDCProperties(o.toString());
+            AUDIT_LOG.error(message);
+        }
+    }
+
+    @Override
+    public void error(Object o, Throwable throwable) {
+
+        if (o != null) {
+            String message = appendMDCProperties(o.toString());
+            AUDIT_LOG.error(message, throwable);
+        }
+    }
+
+    @Override
+    public void fatal(Object o) {
+
+        if (o != null) {
+            String message = appendMDCProperties(o.toString());
+            AUDIT_LOG.fatal(message);
+        }
+    }
+
+    @Override
+    public void fatal(Object o, Throwable throwable) {
+
+        if (o != null) {
+            String message = appendMDCProperties(o.toString());
+            AUDIT_LOG.fatal(message, throwable);
+        }
+    }
+
+    @Override
+    public void info(Object o) {
+
+        if (o != null) {
+            String message = appendMDCProperties(o.toString());
+            AUDIT_LOG.info(message);
+        }
+    }
+
+    @Override
+    public void info(Object o, Throwable throwable) {
+
+        if (o != null) {
+            String message = appendMDCProperties(o.toString());
+            AUDIT_LOG.info(message,throwable);
+        }
+    }
+
+    @Override
+    public boolean isDebugEnabled() {
+
+        return AUDIT_LOG.isDebugEnabled();
+    }
+
+    @Override
+    public boolean isErrorEnabled() {
+
+        return AUDIT_LOG.isErrorEnabled();
+    }
+
+    @Override
+    public boolean isFatalEnabled() {
+
+        return AUDIT_LOG.isFatalEnabled();
+    }
+
+    @Override
+    public boolean isInfoEnabled() {
+
+        return AUDIT_LOG.isInfoEnabled();
+    }
+
+    @Override
+    public boolean isTraceEnabled() {
+
+        return AUDIT_LOG.isTraceEnabled();
+    }
+
+    @Override
+    public boolean isWarnEnabled() {
+
+        return AUDIT_LOG.isWarnEnabled();
+    }
+
+    @Override
+    public void trace(Object o) {
+
+        if (o != null) {
+            String message = appendMDCProperties(o.toString());
+            AUDIT_LOG.trace(message);
+        }
+    }
+
+    @Override
+    public void trace(Object o, Throwable throwable) {
+
+        if (o != null) {
+            String message = appendMDCProperties(o.toString());
+            AUDIT_LOG.trace(message,throwable);
+        }
+    }
+
+    @Override
+    public void warn(Object o) {
+
+        if (o != null) {
+            String message = appendMDCProperties(o.toString());
+            AUDIT_LOG.warn(message);
+        }
+    }
+
+    @Override
+    public void warn(Object o, Throwable throwable) {
+
+        if (o != null) {
+            String message = appendMDCProperties(o.toString());
+            AUDIT_LOG.warn(message,throwable);
+        }
+    }
+
+    /**
+     * Appends additional MDC (Mapped Diagnostic Context) properties to the given message.
+     * This method constructs a new message by appending MDC details, if any, to the provided message.
+     *
+     * @param message The original message to which MDC properties will be appended.
+     * @return The message with appended MDC properties.
+     */
+    private String appendMDCProperties(String message) {
+
+        StringBuilder auditLogBuilder = new StringBuilder(message);
+        auditLogBuilder.append(appendImpersonationDetails());
+        return auditLogBuilder.toString();
+    }
+
+    /**
+     * Retrieves and formats impersonation details from the MDC.
+     * This method checks the MDC for an impersonator entry. If an impersonator is found,
+     * it returns a formatted string containing the impersonator details.
+     *
+     * @return A formatted string with impersonator details or null if no impersonator is found.
+     */
+    private String appendImpersonationDetails() {
+
+        String impersonator = MDC.get(IMPERSONATOR);
+        if (impersonator != null) {
+            return " | Impersonator : " + impersonator ;
+        }
+        return "";
+    }
+
+}


### PR DESCRIPTION
Related Issue: https://github.com/wso2/product-is/issues/20066
## Purpose
Current audit log format is
```
"Initiator : %s | Action : %s | Target : %s | Data : { %s } | Result : %s "
```
If we want to add dynamic values or extend this format we need to change every audit logs which is not extensible.


## Approach
use a custom wrapper around Audit log and append required properties before logging

Ex: for Impersonation Scenario

Earlier
```
TID: [-1234] [2024-05-30 15:08:23,274] [ecf61266-62d6-47e9-abb9-ab237f0f561b]  INFO {AUDIT_LOG} - Initiator=8122e3de-0f3b-4b0e-a43a-d0c237451b7a Action=Set-User-Claim-Values Target=s****e Data={"ServiceProviderName":"POSTMAN_SBA","Claims":{"http://wso2.org/claims/modified":"2*************************Z","profileConfiguration":"d*****t"},"Impersonator":"d9982d93-4e73-4565-b7ac-3605e8d05f80"} Outcome=Success 
```

Now
```
TID: [-1234] [2024-05-30 15:08:23,274] [ecf61266-62d6-47e9-abb9-ab237f0f561b]  INFO {AUDIT_LOG} - Initiator=8122e3de-0f3b-4b0e-a43a-d0c237451b7a Action=Set-User-Claim-Values Target=s****e Data={"ServiceProviderName":"POSTMAN_SBA","Claims":{"http://wso2.org/claims/modified":"2*************************Z","profileConfiguration":"d*****t"},"Impersonator":"d9982d93-4e73-4565-b7ac-3605e8d05f80"} Outcome=Success Impersonator : d9982d93-4e73-4565-b7ac-3605e8d05f80
```
