### PR TITLE
Clear tenantUniqueIdCache when activating/deactivating tenants via tenant id

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/tenant/JDBCTenantManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/tenant/JDBCTenantManager.java
@@ -1128,9 +1128,14 @@ public class JDBCTenantManager implements TenantManager {
     private void clearTenantCache(int tenantId) throws UserStoreException {
 
         String domain = getDomain(tenantId);
+        Tenant tenant = this.getTenant(tenantId);
         tenantDomainCache.clearCacheEntry(new TenantIdKey(tenantId));
         tenantIdCache.clearCacheEntry(new TenantDomainKey(domain));
         tenantCacheManager.clearCacheEntry(new TenantIdKey(tenantId));
+        if (tenant != null) {
+            String tenantUniqueID = tenant.getTenantUniqueID();
+            tenantUniqueIdCache.clearCacheEntry(new TenantUniqueIDKey(tenantUniqueID));
+        }
     }
 
     private void clearTenantCaches(String tenantUniqueID) throws UserStoreException {


### PR DESCRIPTION
## Purpose
If tenant activation/deactivation happens via the tenant id path and getting the tenant details happens via the tenant UUID path, updated tenant active status will not be reflected when getting the tenant details due to the `tenantUniqueIdCache` not being cleared properly

