### PR TITLE
Fix Concurrent user reads leading to constraint violation in `UM_UUID_DOMAIN_MAPPER`

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
@@ -8301,7 +8301,7 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
                                 // If we found a domain name for the give user id, update the domain resolver with
                                 // the name.
                                 domainName = entry.getKey();
-                                userUniqueIDDomainResolver.setDomainForUserId(userId, domainName, tenantId);
+                                userUniqueIDDomainResolver.setDomainForUserIdIfNotExists(userId, domainName, tenantId);
                                 break;
                             }
                         } catch (UserStoreException e) {
@@ -8318,7 +8318,7 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
                             if (abstractUserStoreManager.getUserListFromProperties(claimManager.getAttributeName(entry
                                     .getKey(), USER_ID_CLAIM_URI), userId, null).length > 0) {
                                 domainName = entry.getKey();
-                                userUniqueIDDomainResolver.setDomainForUserId(userId, domainName, tenantId);
+                                userUniqueIDDomainResolver.setDomainForUserIdIfNotExists(userId, domainName, tenantId);
                                 break;
                             }
                         } catch (org.wso2.carbon.user.api.UserStoreException e) {
@@ -13527,7 +13527,7 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
 
         if (StringUtils.isNotEmpty(userID) &&
                 StringUtils.isEmpty(userUniqueIDDomainResolver.getDomainForUserId(userID, tenantId))) {
-            userUniqueIDDomainResolver.setDomainForUserId(userID, domain, tenantId);
+            userUniqueIDDomainResolver.setDomainForUserIdIfNotExists(userID, domain, tenantId);
         }
         return user;
     }


### PR DESCRIPTION
### Purpose
- Introduce a new method setDomainForUserIdIfNotExists to check if the Domain already exists for a User ID in `UM_UUID_DOMAIN_MAPPER` before trying to set the User ID to fix the constraint violation when in concurrent user reads.
- We check an SQLException has been thrown to identify if the error is DB related and retry.
- Based on the similar fix
https://github.com/wso2/carbon-identity-framework/pull/3645

### Related Issue
- https://github.com/wso2/product-is/issues/20474