### PR TITLE
Fix javax.xml.parsers.DocumentBuilderFactory property is not honoured and leads to DOM Element node adoption failed error 

### DIFF
--- a/distribution/kernel/carbon-home/bin/wso2server.sh
+++ b/distribution/kernel/carbon-home/bin/wso2server.sh
@@ -330,6 +330,7 @@ do
     -Dfile.encoding=UTF8 \
     -Djava.net.preferIPv4Stack=true \
     -Djdk.util.zip.disableZip64ExtraFieldValidation=true \
+    -Djavax.xml.parsers.DocumentBuilderFactory=org.apache.xerces.jaxp.DocumentBuilderFactoryImpl \
     -Djdk.nio.zipfs.allowDotZipEntry=true \
     -Dcom.ibm.cacheLocalHost=true \
     -DworkerNode=false \


### PR DESCRIPTION
## Purpose
> $Subject

## Issue
> https://github.com/wso2/product-is/issues/20441
