### PR TITLE
Remove domain from username for non-unique id secondary userstores

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
@@ -6597,6 +6597,9 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
 
         try {
             if (!isUniqueUserIdEnabled()) {
+                if (index > 0) {
+                    filter = filter.substring(index + 1);
+                }
                 userList = doListUsers(filter, maxItemLimit);
             } else {
                 userList = doListUsersWithID(filter, maxItemLimit)


### PR DESCRIPTION
### Description
Remove domain from username claim for non-unique id secondary userstores, when calling SCIM endpoint


### Related Issue
- https://github.com/wso2/product-is/issues/20443