### PR TITLE
Close the LDAP connection properly in case of an error

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/ActiveDirectoryUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/ActiveDirectoryUserStoreManager.java
@@ -171,6 +171,10 @@ public class ActiveDirectoryUserStoreManager extends ReadWriteLDAPUserStoreManag
         try {
             credentialObj = Secret.getSecret(credential);
         } catch (UnsupportedSecretTypeException e) {
+
+            // Close the context before throwing the exception
+            JNDIUtil.closeContext(dirContext);
+
             throw new UserStoreException("Unsupported credential type", e);
         }
 
@@ -324,6 +328,10 @@ public class ActiveDirectoryUserStoreManager extends ReadWriteLDAPUserStoreManag
         try {
             credentialObj = Secret.getSecret(newCredential);
         } catch (UnsupportedSecretTypeException e) {
+
+            // Close the context before throwing the exception
+            JNDIUtil.closeContext(dirContext);
+
             throw new UserStoreException("Unsupported credential type", e);
         }
 
@@ -580,6 +588,10 @@ public class ActiveDirectoryUserStoreManager extends ReadWriteLDAPUserStoreManag
             // Assume only one user is returned from the search.
             returnedUserEntry = returnedResultList.next().getName();
         } catch (NamingException e) {
+
+            // Close the context before throwing the exception
+            JNDIUtil.closeContext(dirContext);
+
             String errorMessage = "Results could not be retrieved from the directory context for user : " + userName;
             if (logger.isDebugEnabled()) {
                 logger.debug(errorMessage, e);
@@ -690,6 +702,10 @@ public class ActiveDirectoryUserStoreManager extends ReadWriteLDAPUserStoreManag
             // Assume only one group is returned from the search.
             returnedGroupEntry = returnedResultList.next().getName();
         } catch (NamingException e) {
+
+            // Close the context before throwing the exception
+            JNDIUtil.closeContext(groupDirContext);
+
             String errorMessage = "Results could not be retrieved from the directory context for user : " +
                     context.getRoleName();
             if (logger.isDebugEnabled()) {

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/ReadOnlyLDAPUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/ReadOnlyLDAPUserStoreManager.java
@@ -3347,11 +3347,16 @@ public class ReadOnlyLDAPUserStoreManager extends AbstractUserStoreManager {
                     }
                 }
             } catch (NamingException e) {
+
+                // Close context before throwing the exception
+                JNDIUtil.closeContext(dirContext);
+
                 log.error(String.format("Error in reading user information in the user store for the user %s, %s",
                         user, e.getMessage()));
                 throw new UserStoreException(e.getMessage(), e);
             }
         }
+        JNDIUtil.closeContext(dirContext);
         return userNameList;
     }
 

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/ReadWriteLDAPUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/ReadWriteLDAPUserStoreManager.java
@@ -842,6 +842,11 @@ public class ReadWriteLDAPUserStoreManager extends ReadOnlyLDAPUserStoreManager 
             }
 
         } catch (NamingException e) {
+
+            // Close the context before throwing the exception.
+            JNDIUtil.closeContext(subDirContext);
+            JNDIUtil.closeContext(dirContext);
+
             String errorMessage = "Results could not be retrieved from the directory context for user : " + userName;
 
             if (log.isDebugEnabled()) {
@@ -941,6 +946,11 @@ public class ReadWriteLDAPUserStoreManager extends ReadOnlyLDAPUserStoreManager 
                 handleLdapUserNameAttributeChanges(claimAttributesToReplace, subDirContext, returnedUserEntry);
             }
         } catch (NamingException e) {
+
+            // Close the context before throwing the exception.
+            JNDIUtil.closeContext(subDirContext);
+            JNDIUtil.closeContext(dirContext);
+
             String errorMessage = "Results could not be retrieved from the directory context for user : " + userName;
             if (log.isDebugEnabled()) {
                 log.debug(errorMessage, e);
@@ -1039,6 +1049,10 @@ public class ReadWriteLDAPUserStoreManager extends ReadOnlyLDAPUserStoreManager 
             returnedUserEntry = returnedResultList.next().getName();
 
         } catch (NamingException e) {
+
+            // Close the context before throwing the exception.
+            JNDIUtil.closeContext(dirContext);
+
             String errorMessage = "Results could not be retrieved from the directory context for user : " + userName;
 
             if (log.isDebugEnabled()) {
@@ -1096,6 +1110,10 @@ public class ReadWriteLDAPUserStoreManager extends ReadOnlyLDAPUserStoreManager 
             returnedUserEntry = returnedResultList.next().getName();
 
         } catch (NamingException e) {
+
+            // Close the context before throwing the exception.
+            JNDIUtil.closeContext(dirContext);
+
             String errorMessage = "Results could not be retrieved from the directory context for user : " + userName;
             if (log.isDebugEnabled()) {
                 log.debug(errorMessage, e);
@@ -1155,6 +1173,10 @@ public class ReadWriteLDAPUserStoreManager extends ReadOnlyLDAPUserStoreManager 
             returnedUserEntry = returnedResultList.next().getName();
 
         } catch (NamingException e) {
+
+            // Close the context before throwing the exception.
+            JNDIUtil.closeContext(dirContext);
+
             String errorMessage = "Results could not be retrieved from the directory context for user : " + userName;
             if (log.isDebugEnabled()) {
                 log.debug(errorMessage, e);


### PR DESCRIPTION
## Purpose
Fix the UserStore methods to prevent connection leaks, which currently do not close the connection in case of an error

## Issue
https://github.com/wso2/product-is/issues/20455