### PR TITLE
Fix sending Identity claim attributes to the userstores to fetch data

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/constants/UserCoreErrorConstants.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/constants/UserCoreErrorConstants.java
@@ -72,6 +72,7 @@ public class UserCoreErrorConstants {
         ERROR_CODE_ERROR_WHILE_GETTING_CLAIM_URI("33001", "Un-expected error while getting claim uri, %s"),
         ERROR_CODE_ERROR_WHILE_GETTING_CLAIM_VALUES("33002", "Un-expected error while getting claim values, %s"),
         ERROR_CODE_ERROR_IN_POST_GET_CLAIM_VALUES("33003", "Un-expected error during post get claim values, %s"),
+        ERROR_CODE_ERROR_IN_PRE_GET_CLAIM_VALUES("33005", "Un-expected error during pre get claim values, %s"),
 
         // Error code related with Add ClaimValues
         ERROR_CODE_DUPLICATE_ERROR_WHILE_ADDING_CLAIM_MAPPINGS("33004", "Duplicate entries are found when adding " +


### PR DESCRIPTION
## Purpose
In the current implementation, all the local claims configured are resolved for attributes and sent to the user stores to fetch data. This includes Identity claims which should not be sent if an Identity Database is configured. Here we use config [1],

```
[event.default_listener.governance_identity_store] 
enable_hybrid_data_store = false 
```

to stop sending identity claims to the user store.

### Related issue
- https://github.com/wso2/product-is/issues/20490