### PR TITLE
Resolve absolute path for admin console.

### DIFF
--- a/core/org.wso2.carbon.ui/src/main/java/org/wso2/carbon/ui/CarbonSecuredHttpContext.java
+++ b/core/org.wso2.carbon.ui/src/main/java/org/wso2/carbon/ui/CarbonSecuredHttpContext.java
@@ -251,16 +251,18 @@ public class CarbonSecuredHttpContext extends SecuredComponentEntryHttpContext {
 
         if (requestedURI.endsWith("/carbon/")) {
             if (skipLoginPage) {
-                response.sendRedirect(contextPath + indexPageURL + "?skipLoginPage=true");
+                response.sendRedirect(CarbonUIUtil.resolveAdminConsoleBaseURL(contextPath, indexPageURL +
+                        "?skipLoginPage=true", request));
             } else {
-                response.sendRedirect(contextPath + indexPageURL);
+                response.sendRedirect(CarbonUIUtil.resolveAdminConsoleBaseURL(contextPath, indexPageURL, request));
             }
             return false;
         } else if (requestedURI.indexOf("/registry/atom") == -1 && requestedURI.endsWith("/carbon")) {
             if (skipLoginPage) {
-                response.sendRedirect(contextPath + indexPageURL + "?skipLoginPage=true");
+                response.sendRedirect(CarbonUIUtil.resolveAdminConsoleBaseURL(contextPath, indexPageURL +
+                        "?skipLoginPage=true", request));
             } else {
-                response.sendRedirect(contextPath + indexPageURL);
+                response.sendRedirect(CarbonUIUtil.resolveAdminConsoleBaseURL(contextPath, indexPageURL, request));
             }
             return false;
         } else if (CarbonUILoginUtil.letRequestedUrlIn(requestedURI, tempUrl)) {
@@ -280,9 +282,11 @@ public class CarbonSecuredHttpContext extends SecuredComponentEntryHttpContext {
         }
         if (request.getSession().isNew()) {
             if (skipLoginPage) {
-                response.sendRedirect(contextPath + "/carbon/admin/login_action.jsp");
+                response.sendRedirect(CarbonUIUtil.resolveAdminConsoleBaseURL(contextPath,
+                        "/carbon/admin/login_action.jsp", request));
             } else {
-                response.sendRedirect(contextPath + "/carbon/admin/login.jsp");
+                response.sendRedirect(CarbonUIUtil.resolveAdminConsoleBaseURL(contextPath, "/carbon/admin/login.jsp",
+                        request));
 
             }
             return false;

--- a/core/org.wso2.carbon.ui/src/main/java/org/wso2/carbon/ui/CarbonUILoginUtil.java
+++ b/core/org.wso2.carbon.ui/src/main/java/org/wso2/carbon/ui/CarbonUILoginUtil.java
@@ -155,15 +155,18 @@ public final class CarbonUILoginUtil {
 
         if (request.getAttribute(MultitenantConstants.TENANT_DOMAIN) != null) {
             if (skipLoginPage) {
-                response.sendRedirect("../admin/login_action.jsp");
+                response.sendRedirect(CarbonUIUtil.resolveAdminConsoleBaseURL(
+                        "","../admin/login_action.jsp", request));
             } else {
-                response.sendRedirect("../admin/login.jsp");
+                response.sendRedirect(CarbonUIUtil.resolveAdminConsoleBaseURL("", "../admin/login.jsp", request));
             }
         } else {
             if (skipLoginPage) {
-                response.sendRedirect(contextPath + "/carbon/admin/login_action.jsp");
+                response.sendRedirect(CarbonUIUtil.resolveAdminConsoleBaseURL(contextPath,
+                        "/carbon/admin/login_action.jsp", request));
             } else {
-                response.sendRedirect(contextPath + "/carbon/admin/login.jsp");
+                response.sendRedirect(CarbonUIUtil.resolveAdminConsoleBaseURL(contextPath,
+                        "/carbon/admin/login.jsp", request));
 
             }
         }
@@ -273,7 +276,7 @@ public final class CarbonUILoginUtil {
             }
         } catch (Exception e) {
             log.error(e.getMessage(), e);
-            response.sendRedirect("../admin/login.jsp");
+            response.sendRedirect(CarbonUIUtil.resolveAdminConsoleBaseURL("", "../admin/login.jsp", request));
             return false;
         }
 
@@ -295,7 +298,8 @@ public final class CarbonUILoginUtil {
                     }
                 }
             }
-            response.sendRedirect("../../carbon/admin/login.jsp");
+            response.sendRedirect(CarbonUIUtil.resolveAdminConsoleBaseURL(
+                    "","../../carbon/admin/login.jsp", request));
             return false;
         }
 
@@ -336,7 +340,7 @@ public final class CarbonUILoginUtil {
                     }
                 }
             }
-            response.sendRedirect("../.." + indexPageURL);
+            response.sendRedirect(CarbonUIUtil.resolveAdminConsoleBaseURL("", "../.." + indexPageURL, request));
             return false;
         }
 
@@ -346,7 +350,8 @@ public final class CarbonUILoginUtil {
         // This condition is evaluated when users are logged out in SAML2 based SSO
         if (request.getAttribute("logoutRequest") != null) {
         	log.debug("Loging out from SSO session");
-            response.sendRedirect(contextPath + "/carbon/sso-acs/redirect_ajaxprocessor.jsp?logout=true");
+            response.sendRedirect(CarbonUIUtil.resolveAdminConsoleBaseURL(contextPath,
+                    "/carbon/sso-acs/redirect_ajaxprocessor.jsp?logout=true", request));
             return false;
         }
 
@@ -370,7 +375,7 @@ public final class CarbonUILoginUtil {
         rmeCookie.setHttpOnly(true);
         rmeCookie.setMaxAge(0);
         response.addCookie(rmeCookie);
-        response.sendRedirect(contextPath + indexPageURL);
+        response.sendRedirect(CarbonUIUtil.resolveAdminConsoleBaseURL(contextPath, indexPageURL, request));
         return false;
     }
 
@@ -406,7 +411,8 @@ public final class CarbonUILoginUtil {
                     && idpSessionIndex != null && !"".equals(idpSessionIndex)) {
                 session.setAttribute(CarbonSecuredHttpContext.LOGGED_USER, request.getParameter("username"));
                 session.setAttribute("idpSessionIndex", idpSessionIndex);
-                response.sendRedirect(contextPath + "/carbon/sso-acs/redirect_ajaxprocessor.jsp?logout=true");
+                response.sendRedirect(CarbonUIUtil.resolveAdminConsoleBaseURL(contextPath,
+                        "/carbon/sso-acs/redirect_ajaxprocessor.jsp?logout=true", request));
                 return false;
             }
 
@@ -460,8 +466,8 @@ public final class CarbonUILoginUtil {
                     response.addCookie(rmeCookie);
                 }
             } catch (Exception e) {
-                response.sendRedirect(contextPath + indexPageURL
-                        + (indexPageURL.indexOf('?') == -1 ? "?" : "&") + "loginStatus=false");
+                response.sendRedirect(CarbonUIUtil.resolveAdminConsoleBaseURL(contextPath, indexPageURL
+                        + (indexPageURL.indexOf('?') == -1 ? "?" : "&") + "loginStatus=false", request));
 				if (log.isDebugEnabled()) {
 					log.debug("Security check failed for login request for " + userName);
 				}
@@ -470,7 +476,8 @@ public final class CarbonUILoginUtil {
 
             if (relayState != null && relayState.endsWith("-logout")) {
                 session.setAttribute(CarbonSecuredHttpContext.LOGGED_USER, request.getParameter("username"));
-                response.sendRedirect("/carbon/admin/logout_action.jsp");
+                response.sendRedirect( CarbonUIUtil.resolveAdminConsoleBaseURL("",
+                         "/carbon/admin/logout_action.jsp", request));
                 return false;
             }
 
@@ -479,8 +486,8 @@ public final class CarbonUILoginUtil {
                     indexPageURL = indexPageURL.substring(5);
                 }
 
-                response.sendRedirect(contextPath + indexPageURL
-                        + (indexPageURL.indexOf('?') == -1 ? "?" : "&") + "loginStatus=true");
+                response.sendRedirect(CarbonUIUtil.resolveAdminConsoleBaseURL(contextPath, indexPageURL
+                        + (indexPageURL.indexOf('?') == -1 ? "?" : "&") + "loginStatus=true", request));
             }
 
         } catch (AuthenticationException e) {
@@ -497,14 +504,17 @@ public final class CarbonUILoginUtil {
                 if (isLoginFailureReasonEnabled()) {
                     if (e.getCause().getMessage().contains(ACCOUNT_LOCK_ERROR_CODE) || e.getCause().getMessage()
                             .contains(ACCOUNT_LOCK_ERROR_MESSAGE)) {
-                        response.sendRedirect(contextPath + "/carbon/admin/login.jsp?loginStatus=false&errorCode=error" +
-                                ".code.17003");
+                        response.sendRedirect(CarbonUIUtil.resolveAdminConsoleBaseURL(contextPath,
+                                "/carbon/admin/login.jsp?loginStatus=false&errorCode=error" +
+                                ".code.17003", request));
                         return false;
                     } else if (e.getCause().getMessage().contains(USER_NOT_FOUND_ERROR_CODE)) {
-                        response.sendRedirect(contextPath + "/carbon/admin/login.jsp?loginStatus=false&errorCode=error.code.17001");
+                        response.sendRedirect(CarbonUIUtil.resolveAdminConsoleBaseURL(contextPath,
+                                "/carbon/admin/login.jsp?loginStatus=false&errorCode=error.code.17001", request));
                         return false;
                     } else if (e.getCause().getMessage().contains(INVALID_CREDENTIALS_ERROR_CODE)) {
-                        response.sendRedirect(contextPath + "/carbon/admin/login.jsp?loginStatus=false&errorCode=error.code.17002");
+                        response.sendRedirect(CarbonUIUtil.resolveAdminConsoleBaseURL(contextPath,
+                                "/carbon/admin/login.jsp?loginStatus=false&errorCode=error.code.17002", request));
                         return false;
                     }
                 }
@@ -512,7 +522,8 @@ public final class CarbonUILoginUtil {
                     response.sendRedirect(httpLogin + "?loginStatus=false");
                     return false;
                 } else {
-                    response.sendRedirect(contextPath + "/carbon/admin/login.jsp?loginStatus=false");
+                    response.sendRedirect(CarbonUIUtil.resolveAdminConsoleBaseURL(contextPath,
+                            "/carbon/admin/login.jsp?loginStatus=false", request));
                     return false;
                 }
             } catch (Exception e1) {
@@ -521,7 +532,8 @@ public final class CarbonUILoginUtil {
 
         } catch (Exception e) {
             log.error("error occurred while login", e);
-            response.sendRedirect("../../carbon/admin/login.jsp?loginStatus=failed");
+            response.sendRedirect(CarbonUIUtil.resolveAdminConsoleBaseURL("",
+                    "carbon/admin/login.jsp?loginStatus=failed", request));
         }
 
         return false;
@@ -598,11 +610,13 @@ public final class CarbonUILoginUtil {
                 	log.debug("User already authenticated. Redirecting to " + indexPageURL);
                 }
                 // redirect relative to the servlet container root
-                response.sendRedirect(context + "/carbon/admin/index.jsp");
+                response.sendRedirect(CarbonUIUtil.resolveAdminConsoleBaseURL(context, "/carbon/admin/index.jsp",
+                        request));
                 return RETURN_FALSE;
             } else if ((isTryIt || isFileDownload) && !authenticated) {
                 if (isFileDownload) {
-                    response.sendRedirect(context + "/carbon/admin/index.jsp");
+                    response.sendRedirect(CarbonUIUtil.resolveAdminConsoleBaseURL(context, "/carbon/admin/index.jsp",
+                            request));
                 }
                 return RETURN_FALSE;
             } else if (requestedURI.indexOf("login_action.jsp") > -1 && !authenticated) {
@@ -644,7 +658,8 @@ public final class CarbonUILoginUtil {
             // a tenant requesting login.jsp while not being authenticated
             // redirecting the tenant login page request to the root /carbon/admin/login.jsp
             // instead of tenant-aware login page
-            response.sendRedirect(context + "/carbon/admin/login.jsp");
+
+            response.sendRedirect(CarbonUIUtil.getAdminConsoleURL(context) + "/admin/login.jsp");
            	log.debug("Redirecting to /carbon/admin/login.jsp");
             return false;
         }

--- a/core/org.wso2.carbon.ui/src/main/java/org/wso2/carbon/ui/CarbonUIUtil.java
+++ b/core/org.wso2.carbon.ui/src/main/java/org/wso2/carbon/ui/CarbonUIUtil.java
@@ -18,6 +18,7 @@ package org.wso2.carbon.ui;
 
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -42,6 +43,9 @@ import org.wso2.carbon.utils.CarbonUtils;
 import org.wso2.carbon.utils.ConfigurationContextService;
 import org.wso2.carbon.utils.NetworkUtils;
 import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
+
+import static org.wso2.carbon.CarbonConstants.DEFAULT_HTTPS_PROXY_PORT;
+import static org.wso2.carbon.CarbonConstants.DEFAULT_HTTP_PROXY_PORT;
 
 /**
  * Utility class for Carbon UI
@@ -198,6 +202,17 @@ public class CarbonUIUtil {
      * @return The URL of the Admin Console
      */
     public static String getAdminConsoleURL(String context) {
+
+        return getAdminConsoleBaseURL(context) + "/carbon/";
+    }
+
+    /**
+     * Returns base URL to admin console.
+     *
+     * @param context Webapp context root of the Carbon webapp
+     * @return The base URL of the Admin Console
+     */
+    private static String getAdminConsoleBaseURL(String context) {
         // Hostname
         String hostName = "localhost";
         try {
@@ -238,14 +253,32 @@ public class CarbonUIUtil {
 
         String proxyContextPath = CarbonUtils.getProxyContextPath(false);
 
-        String adminConsoleURL =  "https://" + hostName + ":" + (httpsProxyPort != -1 ? httpsProxyPort : httpsPort) +
-                proxyContextPath + context + "/carbon/";
+        String adminConsoleURL =  "https://" + hostName + resolvePortForURLs(httpsProxyPort, httpsPort) +
+                proxyContextPath + context;
 
         if(log.isDebugEnabled()){
             log.debug("Generated admin console URL: " + adminConsoleURL);
         }
 
         return adminConsoleURL;
+    }
+
+    /**
+     * Get a port to added to the URL.
+     *
+     * @param httpsProxyPort    Https proxy port.
+     * @param httpsPort         Https port.
+     * @return return the port to be added to the URL.
+     */
+    private static String resolvePortForURLs(int httpsProxyPort, int httpsPort) {
+
+        if (httpsProxyPort == DEFAULT_HTTP_PROXY_PORT || httpsProxyPort == DEFAULT_HTTPS_PROXY_PORT) {
+            return "";
+        }
+        if (httpsProxyPort != -1) {
+            return ":" + httpsProxyPort;
+        }
+        return ":" + httpsPort;
     }
 
     /**
@@ -509,5 +542,72 @@ public class CarbonUIUtil {
 
     private static Object getDefaultHomePageProductParam() {
         return getProductParam(CarbonConstants.PRODUCT_XML_WSO2CARBON + CarbonConstants.DEFAULT_HOME_PAGE);
+    }
+
+
+    /**
+     * Returns absolute URL of admin console webapp for given relative path
+     * if IS_RESOLVE_ABSOLUTE_URLS_ENABLED config is enabled.
+     *
+     * @param context       Webapp context root of the Carbon webapp.
+     * @param relativePath  Relative path of the Carbon webapp
+     * @param request       Request that used to redirect.
+     * @return absolute URL of admin console webapp for given relative path.
+     */
+    public static String resolveAdminConsoleBaseURL(String context, String relativePath, HttpServletRequest request) {
+
+        if (isResolveAbsoluteURLsEnabled()) {
+
+            // Removing any tailing "/" in the context.
+            context = getAdminConsoleBaseURL(context);
+            if (context.endsWith("/")) {
+                context = context.substring(0, context.length() - 1);
+            }
+
+            // Remove any tailing "/carbon" in context to build base URL.
+            if (context.endsWith("/carbon")) {
+                context = context.substring(0, context.length() - 7);
+            }
+
+            // Build relative path starting from root context.
+            List<String> splitPathList = new ArrayList<>(Arrays.asList(
+                    request.getContextPath().concat(request.getServletPath()).split("/")));
+            splitPathList.remove(0);
+            // If the request is a base URL, add the carbon as the root context.
+            if (splitPathList.isEmpty()) {
+                splitPathList.add("carbon");
+            }
+
+            // Replace ".." with the node of path directory.
+            int index = 0;
+            while (relativePath.contains("..")) {
+                relativePath = relativePath.replaceFirst("..", splitPathList.get(index));
+                index++;
+            }
+
+            // Add "/", if relative path is not starting with.
+            if (relativePath.charAt(0) != '/') {
+                relativePath = "/" + relativePath;
+            }
+        }
+
+        return context + relativePath;
+    }
+
+    /**
+     * Returns whether resolving absolute URL config is enabled or not.
+     *
+     * @return Resolving absolute URL config is enabled.
+     */
+    public static boolean isResolveAbsoluteURLsEnabled() {
+
+        String  isResolveAbsoluteURLsEnabled = CarbonUIServiceComponent.getServerConfiguration()
+                .getFirstProperty(CarbonConstants.IS_RESOLVE_ABSOLUTE_URLS_ENABLED);
+
+        if (isResolveAbsoluteURLsEnabled == null) {
+            return false;
+        }
+
+        return Boolean.parseBoolean(isResolveAbsoluteURLsEnabled);
     }
 }

--- a/core/org.wso2.carbon.ui/src/main/java/org/wso2/carbon/ui/transports/fileupload/AbstractFileUploadExecutor.java
+++ b/core/org.wso2.carbon.ui/src/main/java/org/wso2/carbon/ui/transports/fileupload/AbstractFileUploadExecutor.java
@@ -29,6 +29,7 @@ import org.wso2.carbon.CarbonException;
 import org.wso2.carbon.base.ServerConfiguration;
 import org.wso2.carbon.core.common.UploadedFileItem;
 import org.wso2.carbon.ui.CarbonUIMessage;
+import org.wso2.carbon.ui.CarbonUIUtil;
 import org.wso2.carbon.ui.clients.FileUploadServiceClient;
 import org.wso2.carbon.ui.internal.CarbonUIServiceComponent;
 import org.wso2.carbon.utils.CarbonUtils;
@@ -481,9 +482,9 @@ public abstract class AbstractFileUploadExecutor {
 
                     }
                 }
-                response.sendRedirect(getContextRoot(request) + "/carbon/service-mgt/index.jsp?message=Files have been uploaded "
+                response.sendRedirect(CarbonUIUtil.resolveAdminConsoleBaseURL(getContextRoot(request), "/carbon/service-mgt/index.jsp?message=Files have been uploaded "
                                       + "successfully. This page will be auto refreshed shortly with "
-                                      + "the status of the created " + utilityString + " service"); //TODO: why do we redirect to service-mgt ???
+                                      + "the status of the created " + utilityString + " service", request)); //TODO: why do we redirect to service-mgt ???
                 return true;
             } catch (RuntimeException e) {
                 throw e;
@@ -530,7 +531,7 @@ public abstract class AbstractFileUploadExecutor {
     }
 
     protected String getContextRoot(HttpServletRequest request) {
-        String contextPath = (request.getContextPath().equals("")) ? "" : request.getContextPath();
+            String contextPath = (request.getContextPath().equals("")) ? "" : request.getContextPath();
         int index;
         if (contextPath.equals("/fileupload")) {
             contextPath = "";

--- a/core/org.wso2.carbon.ui/src/main/java/org/wso2/carbon/ui/transports/fileupload/AbstractFileUploadExecutor.java
+++ b/core/org.wso2.carbon.ui/src/main/java/org/wso2/carbon/ui/transports/fileupload/AbstractFileUploadExecutor.java
@@ -531,7 +531,7 @@ public abstract class AbstractFileUploadExecutor {
     }
 
     protected String getContextRoot(HttpServletRequest request) {
-            String contextPath = (request.getContextPath().equals("")) ? "" : request.getContextPath();
+        String contextPath = (request.getContextPath().equals("")) ? "" : request.getContextPath();
         int index;
         if (contextPath.equals("/fileupload")) {
             contextPath = "";

--- a/core/org.wso2.carbon.ui/src/main/resources/web/admin/index.jsp
+++ b/core/org.wso2.carbon.ui/src/main/resources/web/admin/index.jsp
@@ -28,6 +28,7 @@
 <fmt:bundle basename="org.wso2.carbon.i18n.Resources">
 
 <%
+                String baseCarbonURL = CarbonUIUtil.resolveAdminConsoleBaseURL("", "../", request);
                 Object param = session.getAttribute("authenticated");
 				String passwordExpires = (String) session
 						.getAttribute(ServerConstants.PASSWORD_EXPIRATION);
@@ -39,7 +40,8 @@
 						.isContextRegistered(config, "/server-admin/");
 				
 				if (CharacterEncoder.getSafeText(request.getParameter("skipLoginPage"))!=null){
-					response.sendRedirect("../admin/login_action.jsp");
+					response.sendRedirect(CarbonUIUtil.resolveAdminConsoleBaseURL(
+					    "", "../admin/login_action.jsp", request));
 					return;
 				}
 %>
@@ -77,11 +79,11 @@
                 jQuery.noConflict();
                 var refresh;
                 function refreshStats() {
-                    var url = "../server-admin/system_status_ajaxprocessor.jsp";
+                    var url = baseCarbonURL + "server-admin/system_status_ajaxprocessor.jsp";
                     var data = null;
                     try {
                         jQuery.ajax({
-                            url: "../admin/jsp/session-validate.jsp",
+                            url: baseCarbonURL + "admin/jsp/session-validate.jsp",
                             type: "GET",
                             dataType: "html",
                             data: data,

--- a/core/org.wso2.carbon.ui/src/main/resources/web/admin/login.jsp
+++ b/core/org.wso2.carbon.ui/src/main/resources/web/admin/login.jsp
@@ -61,6 +61,9 @@ String mailinglistURL =
 String issuetrackerURL =
         (String) config.getServletContext().getAttribute(CarbonConstants.PRODUCT_XML_WSO2CARBON +
                                                          CarbonConstants.PRODUCT_XML_ISSUETRACKER);
+
+String absoluteAdminLoginURL = CarbonUIUtil.resolveAdminConsoleBaseURL("", "../admin/login_action.jsp", request);
+
 if(userForumURL == null){
 	userForumURL = "#";
 }
@@ -75,7 +78,7 @@ if(issuetrackerURL == null){
 }
 
 if (CharacterEncoder.getSafeText(request.getParameter("skipLoginPage"))!=null){
-	response.sendRedirect("../admin/login_action.jsp");
+	response.sendRedirect(absoluteAdminLoginURL);
 	return;
 }
 String backendServerURL = CarbonUIUtil.getServerURL(config.getServletContext(), session);
@@ -225,7 +228,7 @@ String bannerContent = adminConfig.getBannerContent();
                     <div id="loginbox">
                         <h2><fmt:message key="sign.in"/></h2>
 
-                        <form action='../admin/login_action.jsp' method="POST" onsubmit="return doValidation();" target="_self" onsubmit="checkInputs()">
+                        <form action= "<%=absoluteAdminLoginURL%>" method="POST" onsubmit="return doValidation();" target="_self" onsubmit="checkInputs()">
                             <table>
                                 <%if (enableBanner) { %>
                                 <tr>

--- a/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/CarbonConstants.java
+++ b/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/CarbonConstants.java
@@ -348,6 +348,11 @@ public final class CarbonConstants {
     public static final String CARBON_FAULTY_SERVICE_DUE_TO_MODULE =
             "This service is cannot be started due to missing modules";
 
+    public static final String IS_RESOLVE_ABSOLUTE_URLS_ENABLED = "AdminConsole.ResolveAbsoluteURLs.Enable";
+
+    public static final int DEFAULT_HTTP_PROXY_PORT = 80;
+    public static final int DEFAULT_HTTPS_PROXY_PORT = 443;
+
     public static class CarbonManifestHeaders {
         public static final String AXIS2_MODULE = "Axis2Module";
         public static final String AXIS2_DEPLOYER = "Axis2Deployer";

--- a/distribution/kernel/carbon-home/repository/resources/conf/default.json
+++ b/distribution/kernel/carbon-home/repository/resources/conf/default.json
@@ -244,5 +244,6 @@
   "database.registry_db.pool_options.testOnBorrow" : "true",
   "database.registry_db.pool_options.validationQuery" : "SELECT 1",
   "database.registry_db.pool_options.validationInterval" : "30000",
-  "database.registry_db.pool_options.defaultAutoCommit" : "true"
+  "database.registry_db.pool_options.defaultAutoCommit" : "true",
+  "admin_console.resolve_absolute_urls.enable": true
 }

--- a/distribution/kernel/carbon-home/repository/resources/conf/templates/repository/conf/carbon.xml.j2
+++ b/distribution/kernel/carbon-home/repository/resources/conf/templates/repository/conf/carbon.xml.j2
@@ -763,6 +763,12 @@
     <!-- Enable accessing Admin Console via HTTP -->
     <!-- EnableHTTPAdminConsole>true</EnableHTTPAdminConsole -->
 
+    <!-- Enable resolving absolute URLs for Admin Console -->
+    <AdminConsole>
+        <ResolveAbsoluteURLs>
+            <Enable>{{admin_console.resolve_absolute_urls.enable}}</Enable>
+        </ResolveAbsoluteURLs>
+    </AdminConsole>
     <!--
        Default Feature Repository of WSO2 Carbon.
     -->

--- a/distribution/kernel/carbon-home/repository/resources/conf/templates/repository/conf/security/Owasp.CsrfGuard.Carbon.properties.j2
+++ b/distribution/kernel/carbon-home/repository/resources/conf/templates/repository/conf/security/Owasp.CsrfGuard.Carbon.properties.j2
@@ -467,6 +467,7 @@ org.owasp.csrfguard.domainOrigin = {{owasp.csrfguard.domain_origin}}
 
 # please remove the below entry to enable protection for services.
 org.owasp.csrfguard.unprotected.Services=%servletContext%/services/*
+org.owasp.csrfguard.unprotected.carbonLogin=%servletContext%/carbon/admin/login_action.jsp
 org.owasp.csrfguard.unprotected.commonauth=%servletContext%/commonauth/*
 org.owasp.csrfguard.unprotected.samlsso=%servletContext%/samlsso/*
 org.owasp.csrfguard.unprotected.authenticationendpoint=%servletContext%/authenticationendpoint/*


### PR DESCRIPTION
Issue: 
- https://github.com/wso2/product-is/issues/20416

Improve code based to absolute Urls for Admin Management Console, if the `AdminConsole.ResolveAbsoluteURLs.Enable`  config is enabled.

Config can be enabled/diasbled adding following config to the deployment.toml
```
[admin_console.resolve_absolute_urls]
enable = true
```