### PR TITLE
[4.9.x] Fixing UI issue in main and config tabs

### DIFF
--- a/core/org.wso2.carbon.ui/src/main/resources/web/admin/js/template.js
+++ b/core/org.wso2.carbon.ui/src/main/resources/web/admin/js/template.js
@@ -279,10 +279,16 @@ YAHOO.util.Event.onAvailable('menu-panel-button_dummy',
                  for(var i=0;i<elmsX.length;i++){
                      elmsX[i].style.display = "";
                  }
+
                  hideSection("region1_configure_menu");
                  hideSection("region4_monitor_menu");
                  hideSection("region5_tools_menu");
                  hideSection("region3_extensions_menu");
+                 
+                 showSection('region1_identity_menu');
+                 showSection('region1_manage_menu');
+                 showSection('region3_registry_menu');
+
                  selectTab(menuSlider1);
 
              }else if(get_cookie('menuPanelType') == "monitor"){
@@ -291,6 +297,7 @@ YAHOO.util.Event.onAvailable('menu-panel-button_dummy',
                  for(var i=0;i<elmsX.length;i++){
                      elmsX[i].style.display = "none";
                  }
+
                  showSection("region4_monitor_menu");
                  hideSection("region1_configure_menu");
                  hideSection("region5_tools_menu");
@@ -302,10 +309,17 @@ YAHOO.util.Event.onAvailable('menu-panel-button_dummy',
                  for(var i=0;i<elmsX.length;i++){
                      elmsX[i].style.display = "none";
                  }
+
                  showSection("region1_configure_menu");
+                 
+                 hideSection('region1_identity_menu');
+                 hideSection('region1_manage_menu');
+                 hideSection('region3_registry_menu');
+                 
                  hideSection("region4_monitor_menu");
                  hideSection("region5_tools_menu");
                  hideSection("region3_extensions_menu");
+                 
                  selectTab(menuSlider3);
              }else if(get_cookie('menuPanelType') == "tools"){
                 //hide the config section
@@ -367,6 +381,10 @@ YAHOO.util.Event.onAvailable('menu-panel-button_dummy',
                 hideSection('region5_tools_menu');
                 hideSection('region3_extensions_menu');
 
+                showSection('region1_identity_menu');
+                showSection('region1_manage_menu');
+                showSection('region3_registry_menu');
+
                 setMainMenus();
                 selectTab(menuSlider1);
 
@@ -411,6 +429,12 @@ YAHOO.util.Event.onAvailable('menu-panel-button_dummy',
                  for(var i=0;i<elmsX.length;i++){
                      elmsX[i].style.display = "none";
                  }
+                 
+                
+                hideSection('region1_identity_menu');
+                hideSection('region1_manage_menu');
+                hideSection('region3_registry_menu');
+
                 showSection('region1_configure_menu');
                 setMainMenus();
                 selectTab(menuSlider3);


### PR DESCRIPTION
## Purpose
> To fix https://github.com/wso2/api-manager/issues/2817

## Goals
> Isolate the cause of the issue and fix the UI glitch in the Management console

## Approach
> When using the updated YUI library, it is necessary to hide unnecessary UI elements when switching between menu action items. This change ensures that only the required UI elements for the main and config tabs in the menu list are shown or hidden as needed. In this change the following regions are manipulated in template.js file.

region1_identity_menu
<img width="237" alt="image" src="https://github.com/user-attachments/assets/f72c30ce-4d42-40d6-93a6-b495a48fa222">

region1_manage_menu
<img width="238" alt="image" src="https://github.com/user-attachments/assets/cecbc5e1-208b-4749-a870-054842242e4f">

region3_registry_menu
<img width="233" alt="image" src="https://github.com/user-attachments/assets/d3ca20b0-91c6-49e5-a290-aa75fc3182f7">


## Release note
> Isolate the cause of the issue and fix the UI glitch in the Management console