### PR TITLE
[Impersonation] Log v2 for impersonation

### DIFF
--- a/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/AuditLog.java
+++ b/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/AuditLog.java
@@ -33,7 +33,7 @@ import static org.wso2.carbon.CarbonConstants.LogEventConstants.CORRELATION_ID_M
  */
 public class AuditLog {
 
-    public static final String IMPERSONATOR = "impersonator";
+    public static final String IMPERSONATOR_ID = "impersonator";
 
     private final String id;
     private final String recordedAt;
@@ -180,7 +180,7 @@ public class AuditLog {
                 recordedAt = Instant.now().toString();
             }
             if (this.impersonatorId == null) {
-                impersonatorId = MDC.get(IMPERSONATOR);
+                impersonatorId = MDC.get(IMPERSONATOR_ID);
             }
             if (this.requestId == null) {
                 requestId = MDC.get(CORRELATION_ID_MDC);

--- a/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/AuditLog.java
+++ b/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/AuditLog.java
@@ -179,10 +179,8 @@ public class AuditLog {
             if (this.recordedAt == null) {
                 recordedAt = Instant.now().toString();
             }
-            String impersonator = MDC.get(IMPERSONATOR);
-            if (this.impersonatorId == null && StringUtils.isNotEmpty(impersonator)) {
-
-                impersonatorId = impersonator;
+            if (this.impersonatorId == null) {
+                impersonatorId = MDC.get(IMPERSONATOR);
             }
             if (this.requestId == null) {
                 requestId = MDC.get(CORRELATION_ID_MDC);

--- a/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/AuditLog.java
+++ b/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/AuditLog.java
@@ -33,6 +33,8 @@ import static org.wso2.carbon.CarbonConstants.LogEventConstants.CORRELATION_ID_M
  */
 public class AuditLog {
 
+    public static final String IMPERSONATOR = "impersonator";
+
     private final String id;
     private final String recordedAt;
     private final String requestId;
@@ -41,6 +43,7 @@ public class AuditLog {
     private final String targetId;
     private final String targetType;
     private final String action;
+    private final String impersonatorId;
     private final Map<String, Object> data;
 
     private AuditLog(AuditLogBuilder auditLogBuilder) {
@@ -53,6 +56,7 @@ public class AuditLog {
         this.targetId = auditLogBuilder.targetId;
         this.targetType = auditLogBuilder.targetType;
         this.action = auditLogBuilder.action;
+        this.impersonatorId = auditLogBuilder.impersonatorId;
         this.data = auditLogBuilder.data;
     }
 
@@ -96,6 +100,11 @@ public class AuditLog {
         return action;
     }
 
+    public String getImpersonatorId() {
+
+        return impersonatorId;
+    }
+
     public Map<String, Object> getData() {
 
         return data;
@@ -110,6 +119,7 @@ public class AuditLog {
         private String id;
         private String recordedAt;
         private String requestId;
+        private String impersonatorId;
         private final String initiatorId;
         private final String targetId;
         private final String initiatorType;
@@ -168,6 +178,11 @@ public class AuditLog {
             }
             if (this.recordedAt == null) {
                 recordedAt = Instant.now().toString();
+            }
+            String impersonator = MDC.get(IMPERSONATOR);
+            if (this.impersonatorId == null && StringUtils.isNotEmpty(impersonator)) {
+
+                impersonatorId = impersonator;
             }
             if (this.requestId == null) {
                 requestId = MDC.get(CORRELATION_ID_MDC);


### PR DESCRIPTION
## Purpose
Issue: https://github.com/wso2/product-is/issues/20066
When resource modification happens, it's a requirement to add impersonator Id in the audit log. Rather than adding in a data model of audit log, it would be nice to add as a first class object which will later can be used for filtering and UX purposes. 

MDC id will be added via auth-rest value.

sample log:

TID: [-1234] [2024-07-17 15:27:50,441] [8a2f587d-a336-41ff-970f-730f53bc94b1]  WARN {AUDIT_LOG} - {"id":"acfb6e64-fe9f-4273-9557-8f1119a09eea","recordedAt":"2024-07-17T09:57:50.440737Z","requestId":"8a2f587d-a336-41ff-970f-730f53bc94b1","initiatorId":"15facf4f-1164-4ec2-b5f2-77bc9fbfd229","initiatorType":"User","targetId":"15facf4f-1164-4ec2-b5f2-77bc9fbfd229","targetType":"User","action":"set-user-claim-values","impersonatorId":"2c0af015-ff1c-423e-b259-3418fc0aad1a","data":{"Claims":{"http://wso2.org/claims/country":"S***n","http://wso2.org/claims/modified":"2*************************Z","profileConfiguration":