### PR TITLE
Optimize user count retrieval logic in user filter operation to reduce extensive DB calls

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/UniqueIDPaginatedUsernameSearchResult.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/UniqueIDPaginatedUsernameSearchResult.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.user.core.common;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Class to model paginated username search result for unique id user stores.
+ */
+public class UniqueIDPaginatedUsernameSearchResult {
+
+    private List<String> users;
+    private PaginatedSearchResult paginatedSearchResult;
+
+    // This variable is set only when users.length = 0. When filtered user count is zero for a given user store, it is
+    // required to know how many users skipped in that user store to identify the start index of next user store.
+    private int skippedUserCount;
+
+    public List<String> getUsers() {
+
+        if (users == null) {
+            return Collections.emptyList();
+        }
+        return users;
+    }
+
+    public void setUsers(List<String> users) {
+
+        this.users = users;
+    }
+
+    public int getSkippedUserCount() {
+
+        return skippedUserCount;
+    }
+
+    public void setSkippedUserCount(int skippedUserCount) {
+
+        this.skippedUserCount = skippedUserCount;
+    }
+
+    public PaginatedSearchResult getPaginatedSearchResult() {
+
+        return paginatedSearchResult;
+    }
+
+    public void setPaginatedSearchResult(PaginatedSearchResult paginatedSearchResult) {
+
+        this.paginatedSearchResult = paginatedSearchResult;
+    }
+}

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/UniqueIDReadOnlyLDAPUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/UniqueIDReadOnlyLDAPUserStoreManager.java
@@ -43,6 +43,7 @@ import org.wso2.carbon.user.core.common.LoginIdentifier;
 import org.wso2.carbon.user.core.common.PaginatedSearchResult;
 import org.wso2.carbon.user.core.common.RoleContext;
 import org.wso2.carbon.user.core.common.UniqueIDPaginatedSearchResult;
+import org.wso2.carbon.user.core.common.UniqueIDPaginatedUsernameSearchResult;
 import org.wso2.carbon.user.core.common.User;
 import org.wso2.carbon.user.core.internal.UserStoreMgtDSComponent;
 import org.wso2.carbon.user.core.model.Condition;
@@ -1553,6 +1554,27 @@ public class UniqueIDReadOnlyLDAPUserStoreManager extends ReadOnlyLDAPUserStoreM
             JNDIUtil.closeContext(dirContext);
             JNDIUtil.closeContext(ldapContext);
         }
+    }
+
+    @Override
+    protected UniqueIDPaginatedUsernameSearchResult doGetUsernameListWithID(Condition condition, String profileName,
+                                                                            int limit, int offset, String sortBy,
+                                                                            String sortOrder)
+            throws UserStoreException {
+
+        UniqueIDPaginatedUsernameSearchResult result = new UniqueIDPaginatedUsernameSearchResult();
+        UniqueIDPaginatedSearchResult uniqueIDPaginatedSearchResult =
+                doGetUserListWithID(condition, profileName, limit, offset, sortBy, sortOrder);
+        List<String> usernames = new ArrayList<>();
+        uniqueIDPaginatedSearchResult.getUsers().forEach(user -> {
+            addToUserIDCache(user.getUserID(), user.getUsername(), getMyDomainName());
+            addToUserNameCache(user.getUserID(), user.getUsername(), getMyDomainName());
+            usernames.add(user.getDomainQualifiedUsername());
+        });
+        result.setUsers(usernames);
+        result.setSkippedUserCount(uniqueIDPaginatedSearchResult.getSkippedUserCount());
+        result.setPaginatedSearchResult(uniqueIDPaginatedSearchResult.getPaginatedSearchResult());
+        return result;
     }
 
     @Override


### PR DESCRIPTION
## Purpose
When listing users with a filter, we observed some queries are executed more times than the final resulted users. This PR will remove those unnecessary db calls by improving the filtering methods.

- Properly utilise the single query which uses to list non identity claim filtering by updating caches
- Removing finding user domain for users who are not include in the final result. This is done by finding the usernames related to final result and using this usernames, building the user object.

## Related PRs
- https://github.com/wso2/product-is/issues/20548