### PR TITLE
Improve circuit breaker related configs

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/UserStoreConfigConstants.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/UserStoreConfigConstants.java
@@ -178,8 +178,8 @@ public class UserStoreConfigConstants {
     public static final String CONNECTION_RETRY_DELAY_DESCRIPTION = "Specifies waiting time in milliseconds"
             + " inorder to establish the connection after couple of failure attempts.";
     public static final int DEFAULT_CONNECTION_RETRY_DELAY_IN_MILLISECONDS = 120000;
-    public static final String MAX_CONNECTION_RETRY_DELAY_IN_MILLISECONDS =
-            "UserStore.maxConnectionRetryDelayInMilliSeconds";
+    public static final String MIN_CONNECTION_RETRY_DELAY_IN_MILLISECONDS =
+            "UserStore.minConnectionRetryDelayInMilliSeconds";
 
     public static final String OBJECT_GUID = "objectGuid";
 

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/ReadOnlyLDAPUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/ReadOnlyLDAPUserStoreManager.java
@@ -4875,8 +4875,7 @@ public class ReadOnlyLDAPUserStoreManager extends AbstractUserStoreManager {
 
             long circuitOpenDuration = System.currentTimeMillis() - this.connectionSource.getThresholdStartTime();
             if (CIRCUIT_STATE_OPEN.equals(this.connectionSource.getCircuitBreakerState())
-                    && circuitOpenDuration <=  this.connectionSource.getValidatedThresholdTimeoutInMilliseconds
-                    (connectionSource.getThresholdTimeoutInMilliseconds())) {
+                    && circuitOpenDuration <=  this.connectionSource.getThresholdTimeoutInMilliseconds()) {
                 log.warn("LDAP connection circuit breaker is in open state for " + circuitOpenDuration
                         + "ms and has not reach the threshold timeout: "
                         + this.connectionSource.getThresholdTimeoutInMilliseconds() + "ms. " +

--- a/distribution/kernel/carbon-home/repository/resources/conf/default.json
+++ b/distribution/kernel/carbon-home/repository/resources/conf/default.json
@@ -233,7 +233,7 @@
   "jdbc_user_store.enable_optimized_jdbc_search": false,
   "user_store_commons.enable_circuit_breaker_for_user_stores": true,
   "user_store_commons.max_connection_retry_count": "5",
-  "user_store_commons.max_connection_retry_delay_in_milli_seconds": "300000",
+  "user_store_commons.min_connection_retry_delay_in_milli_seconds": "60000",
   "clustering.agent": "org.wso2.carbon.hazelcast.HazelcastClusteringAgent",
   "database.registry_db.url" : "jdbc:h2:async:./repository/database/WSO2CARBON_DB;DB_CLOSE_ON_EXIT=FALSE",
   "database.registry_db.username" : "wso2carbon",

--- a/distribution/kernel/carbon-home/repository/resources/conf/templates/repository/conf/carbon.xml.j2
+++ b/distribution/kernel/carbon-home/repository/resources/conf/templates/repository/conf/carbon.xml.j2
@@ -860,6 +860,6 @@
     <UserStore>
         <enableCircuitBreakerForUserStores>{{user_store_commons.enable_circuit_breaker_for_user_stores}}</enableCircuitBreakerForUserStores>
         <maxConnectionRetryCount>{{user_store_commons.max_connection_retry_count}}</maxConnectionRetryCount>
-        <maxConnectionRetryDelayInMilliSeconds>{{user_store_commons.max_connection_retry_delay_in_milli_seconds}}</maxConnectionRetryDelayInMilliSeconds>
+        <minConnectionRetryDelayInMilliSeconds>{{user_store_commons.min_connection_retry_delay_in_milli_seconds}}</minConnectionRetryDelayInMilliSeconds>
     </UserStore>
 </Server>


### PR DESCRIPTION
## Purpose
From https://github.com/wso2/carbon-kernel/pull/3632,  we have introduced circuit breaker implementation for corrupted userstores. From this fix,

- changed the max retry delay config to min retry delay config since we need this config as a server wide configuration to reduce server load in case of userstore level configurations are misused.
- improved the existing logics related to min retry delay and max retry count configs.

Issue - https://github.com/wso2/product-is/issues/8535