### PR TITLE
Apply select with update lock only for MSSQL for updatePropertyWithID method

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCUserStoreManager.java
@@ -2436,6 +2436,13 @@ public class UniqueIDJDBCUserStoreManager extends JDBCUserStoreManager {
             throw new UserStoreException("The sql statement for add user property sql is null.");
         }
 
+        // Select and update lock the rows to be updated in a particular order before the actual update operation to
+        // prevent the deadlock scenario.
+        // Currently, this issue is only reproduced in SQL Server.
+        if (isMSSQLDB(dbConnection)) {
+            selectRowsForUpdate(dbConnection, userID);
+        }
+
         if (sqlStmt.contains(UserCoreConstants.UM_TENANT_COLUMN)) {
             updateStringValuesToDatabase(dbConnection, sqlStmt, value, userID, tenantId, propertyName, profileName,
                     tenantId);


### PR DESCRIPTION
## Purpose
> The related PR added a change where an update lock is applied to the relevant user attribute rows before being updated. It was noted that this deadlock scenario occurs only in SQL Server, and this syntax of using lock hints `WITH (UPDLOCK)` is only supported in MSSQL. The deadlock scenario is not reproduced in H2. Therefore this PR excludes other types of DBs from being affected by this fix.

## Related PRs
- https://github.com/wso2/carbon-kernel/pull/3751
- https://github.com/wso2/carbon-kernel/pull/3748

## Related Issues
- 
