### PR TITLE
Use BC provider for Keystore instance

### DIFF
--- a/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/util/KeyStoreManager.java
+++ b/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/util/KeyStoreManager.java
@@ -447,8 +447,7 @@ public class KeyStoreManager {
                         new File(config
                                 .getFirstProperty(RegistryResources.SecurityManagement.SERVER_REGISTRY_KEYSTORE_FILE))
                                 .getAbsolutePath();
-                KeyStore store = KeystoreUtils
-                        .getKeystoreInstance(config
+                KeyStore store = KeystoreUtils.getKeystoreInstance(config
                                 .getFirstProperty(RegistryResources.SecurityManagement.SERVER_REGISTRY_KEYSTORE_TYPE));
                 String password = config
                         .getFirstProperty(RegistryResources.SecurityManagement.SERVER_REGISTRY_KEYSTORE_PASSWORD);

--- a/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/util/KeyStoreManager.java
+++ b/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/util/KeyStoreManager.java
@@ -33,6 +33,7 @@ import org.wso2.carbon.registry.core.exceptions.ResourceNotFoundException;
 import org.wso2.carbon.registry.core.service.RegistryService;
 import org.wso2.carbon.utils.CarbonUtils;
 import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
+import org.wso2.carbon.utils.security.KeystoreUtils;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -328,8 +329,7 @@ public class KeyStoreManager {
                         new File(config
                                 .getFirstProperty(RegistryResources.SecurityManagement.SERVER_PRIMARY_KEYSTORE_FILE))
                                 .getAbsolutePath();
-                KeyStore store = KeyStore
-                        .getInstance(config
+                KeyStore store = KeystoreUtils.getKeystoreInstance(config
                                 .getFirstProperty(RegistryResources.SecurityManagement.SERVER_PRIMARY_KEYSTORE_TYPE));
                 String password = config
                         .getFirstProperty(RegistryResources.SecurityManagement.SERVER_PRIMARY_KEYSTORE_PASSWORD);
@@ -371,7 +371,7 @@ public class KeyStoreManager {
         if (registry.resourceExists(path)) {
             org.wso2.carbon.registry.api.Resource resource = registry.get(path);
             byte[] bytes = (byte[]) resource.getContent();
-            KeyStore keyStore = KeyStore.getInstance(resource
+            KeyStore keyStore = KeystoreUtils.getKeystoreInstance(resource
                     .getProperty(RegistryResources.SecurityManagement.PROP_TYPE));
             CryptoUtil cryptoUtil = CryptoUtil.getDefaultCryptoUtil();
             String encryptedPassword = resource
@@ -412,7 +412,7 @@ public class KeyStoreManager {
                 String file = new File(config
                         .getFirstProperty(RegistryResources.SecurityManagement.SERVER_INTERNAL_KEYSTORE_FILE))
                         .getAbsolutePath();
-                KeyStore store = KeyStore.getInstance(config
+                KeyStore store = KeystoreUtils.getKeystoreInstance(config
                         .getFirstProperty(RegistryResources.SecurityManagement.SERVER_INTERNAL_KEYSTORE_TYPE));
                 String password = config
                         .getFirstProperty(RegistryResources.SecurityManagement.SERVER_INTERNAL_KEYSTORE_PASSWORD);
@@ -447,8 +447,8 @@ public class KeyStoreManager {
                         new File(config
                                 .getFirstProperty(RegistryResources.SecurityManagement.SERVER_REGISTRY_KEYSTORE_FILE))
                                 .getAbsolutePath();
-                KeyStore store = KeyStore
-                        .getInstance(config
+                KeyStore store = KeystoreUtils
+                        .getKeystoreInstance(config
                                 .getFirstProperty(RegistryResources.SecurityManagement.SERVER_REGISTRY_KEYSTORE_TYPE));
                 String password = config
                         .getFirstProperty(RegistryResources.SecurityManagement.SERVER_REGISTRY_KEYSTORE_PASSWORD);
@@ -558,7 +558,7 @@ public class KeyStoreManager {
             byte[] bytes = (byte[]) resource.getContent();
             String keyStorePassword = new String(cryptoUtil.base64DecodeAndDecrypt(resource.getProperty(
                     RegistryResources.SecurityManagement.PROP_PASSWORD)));
-            keyStore = KeyStore.getInstance(resource
+            keyStore = KeystoreUtils.getKeystoreInstance(resource
                     .getProperty(RegistryResources.SecurityManagement.PROP_TYPE));
             ByteArrayInputStream stream = new ByteArrayInputStream(bytes);
             keyStore.load(stream, keyStorePassword.toCharArray());
@@ -716,7 +716,7 @@ public class KeyStoreManager {
         String absolutePath = new File(keyStorePath).getAbsolutePath();
         FileInputStream inputStream = null;
         try {
-            KeyStore store = KeyStore.getInstance(type);
+            KeyStore store = KeystoreUtils.getKeystoreInstance(type);
             inputStream = new FileInputStream(absolutePath);
             store.load(inputStream, password.toCharArray());
             return store;

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/config/UserStoreConfigXMLProcessor.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/config/UserStoreConfigXMLProcessor.java
@@ -46,6 +46,7 @@ import org.wso2.carbon.user.core.tracker.UserStoreManagerRegistry;
 import org.wso2.carbon.user.core.util.UserCoreUtil;
 import org.wso2.carbon.utils.CarbonUtils;
 import org.wso2.carbon.utils.ServerConstants;
+import org.wso2.carbon.utils.security.KeystoreUtils;
 import org.wso2.securevault.SecretResolver;
 import org.wso2.securevault.SecretResolverFactory;
 import org.wso2.securevault.commons.MiscellaneousUtil;
@@ -396,7 +397,7 @@ public class UserStoreConfigXMLProcessor {
         String keyAlias = serverConfigurationService.getFirstProperty(keyAliasXPath);
 
         try {
-            KeyStore store = KeyStore.getInstance(serverConfigurationService.getFirstProperty(typeXPath));
+            KeyStore store = KeystoreUtils.getKeystoreInstance(serverConfigurationService.getFirstProperty(typeXPath));
             String file = new File(serverConfigurationService.getFirstProperty(locationXPath)).getAbsolutePath();
             in = new FileInputStream(file);
             store.load(in, password.toCharArray());

--- a/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/security/KeyImporter.java
+++ b/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/security/KeyImporter.java
@@ -57,11 +57,11 @@ public class KeyImporter {
         try (FileOutputStream fileOutputStream = new FileOutputStream(new File(targetStorePath).getAbsolutePath());
              FileInputStream fis = new FileInputStream(new File(sourceStorePath).getAbsolutePath());) {
 
-            KeyStore sourceStore = KeyStore.getInstance(getFileType(sourceStorePath));
+            KeyStore sourceStore = KeystoreUtils.getKeystoreInstance(getFileType(sourceStorePath));
             sourceStore.load(fis, sourceStorePass.toCharArray());
 
             Certificate cert = sourceStore.getCertificateChain(keyAlias)[0];
-            KeyStore targetStore = KeyStore.getInstance(getFileType(targetStorePath));
+            KeyStore targetStore = KeystoreUtils.getKeystoreInstance(getFileType(targetStorePath));
 
             File targetStoreFile = new File(targetStorePath);
             if (targetStoreFile.exists()) {

--- a/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/security/KeystoreUtils.java
+++ b/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/security/KeystoreUtils.java
@@ -22,11 +22,17 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.CarbonException;
+import org.wso2.carbon.base.ServerConfiguration;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.context.RegistryType;
 import org.wso2.carbon.registry.api.RegistryException;
 import org.wso2.carbon.utils.CarbonUtils;
+import org.wso2.carbon.utils.ServerConstants;
 import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
+
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchProviderException;
 
 /**
  * A collection of key store and trust store related utility methods.
@@ -214,5 +220,23 @@ public class KeystoreUtils {
             LOG.error(msg + e.getMessage());
         }
         return isKeyStoreExists;
+    }
+
+    public static KeyStore getKeystoreInstance(String keyStoreType) throws KeyStoreException, NoSuchProviderException {
+
+        if (StoreFileType.defaultFileType.equals(keyStoreType)) {
+            return KeyStore.getInstance(keyStoreType, getJCEProvider());
+        } else {
+            return KeyStore.getInstance(keyStoreType);
+        }
+    }
+
+    private static String getJCEProvider() {
+
+        String provider = ServerConfiguration.getInstance().getFirstProperty(ServerConstants.JCE_PROVIDER);
+        if (!StringUtils.isBlank(provider)) {
+            return provider;
+        }
+        return ServerConstants.JCE_PROVIDER_BC;
     }
 }

--- a/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/security/KeystoreUtils.java
+++ b/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/security/KeystoreUtils.java
@@ -222,6 +222,15 @@ public class KeystoreUtils {
         return isKeyStoreExists;
     }
 
+    /**
+     * Returns a {@link KeyStore} instance for the given type.
+     * Uses the BouncyCastle provider for the default file type, otherwise the default JCE provider.
+     *
+     * @param keyStoreType  The type of the keystore.
+     * @return              {@link KeyStore} instance.
+     * @throws KeyStoreException If the keystore type is unavailable.
+     * @throws NoSuchProviderException If the security provider is unavailable.
+     */
     public static KeyStore getKeystoreInstance(String keyStoreType) throws KeyStoreException, NoSuchProviderException {
 
         if (StoreFileType.defaultFileType.equals(keyStoreType)) {

--- a/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/security/KeystoreUtils.java
+++ b/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/security/KeystoreUtils.java
@@ -224,7 +224,7 @@ public class KeystoreUtils {
 
     /**
      * Returns a {@link KeyStore} instance for the given type.
-     * Uses the BouncyCastle provider for the default file type, otherwise the default JCE provider.
+     * Uses the BouncyCastle provider for the p12 file type, otherwise the default JCE provider.
      *
      * @param keyStoreType  The type of the keystore.
      * @return              {@link KeyStore} instance.


### PR DESCRIPTION
## Purpose
- Use BC provider for PKCS12 Keystore instance to reduce the performance impact making https://github.com/wso2/product-is/issues/18466
- Related to https://github.com/wso2/product-is/issues/19506