### PR TITLE
[APIM-4.4.0] Bump the bouncycastle version to 1.78.1

### DIFF
--- a/features/org.wso2.carbon.core.server.feature/pom.xml
+++ b/features/org.wso2.carbon.core.server.feature/pom.xml
@@ -70,9 +70,9 @@
                                 </bundleDef>
                                 <bundleDef>org.wso2.carbon:org.wso2.carbon.admin.advisory.mgt:${carbon.kernel.version}
                                 </bundleDef>
-                                <bundleDef>org.wso2.orbit.org.bouncycastle:bcprov-jdk18on:${bouncycastle.provider.version}
+                                <bundleDef>org.wso2.orbit.org.bouncycastle:bcprov-jdk18on:${bouncycastle.version}
                                 </bundleDef>
-                                <bundleDef>org.wso2.orbit.org.bouncycastle:bcpkix-jdk18on:${bouncycastle.pkix.version}
+                                <bundleDef>org.wso2.orbit.org.bouncycastle:bcpkix-jdk18on:${bouncycastle.version}
                                 </bundleDef>
                                 <bundleDef>org.wso2.orbit.org.apache.poi:poi-ooxml:${orbit.version.poi.ooxml}
                                 </bundleDef>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -502,8 +502,7 @@
         <hibernate.orbit.version>3.2.5.ga-wso2v1</hibernate.orbit.version>
 
         <!-- bouncycastle -->
-        <bouncycastle.pkix.version>1.77.0.wso2v2</bouncycastle.pkix.version>
-        <bouncycastle.provider.version>1.77.0.wso2v1</bouncycastle.provider.version>
+        <bouncycastle.version>1.78.1.wso2v1</bouncycastle.version>
         <imp.pkg.version.bcp>[1.0.0, 2.0.0)</imp.pkg.version.bcp>
 
         <!--BPS specific-->
@@ -983,12 +982,12 @@
             <dependency>
                 <groupId>org.wso2.orbit.org.bouncycastle</groupId>
                 <artifactId>bcprov-jdk18on</artifactId>
-                <version>${bouncycastle.provider.version}</version>
+                <version>${bouncycastle.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.wso2.orbit.org.bouncycastle</groupId>
                 <artifactId>bcpkix-jdk18on</artifactId>
-                <version>${bouncycastle.pkix.version}</version>
+                <version>${bouncycastle.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.compass-project.wso2</groupId>


### PR DESCRIPTION
### Purpose

This PR bumps the bouncycastle version to bcprov-jdk18on 1.78.1.

#### Related PRs:

carbon-multitenancy PR: https://github.com/wso2/carbon-multitenancy/pull/270
wso2-synapse PR: https://github.com/wso2/wso2-synapse/pull/2217
carbon-apimgt PR: https://github.com/wso2/carbon-apimgt/pull/12567
product-apim PR: https://github.com/wso2/product-apim/pull/13532