### PR TITLE
Upgrade commons-text version

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -444,7 +444,7 @@
         <version.axiom>1.2.11-wso2v25</version.axiom>
         <axiom.osgi.version>1.2.11-wso2v25</axiom.osgi.version>
         <axiom.osgi.version.range>[1.2.11, 1.3.0)</axiom.osgi.version.range>
-        <commons-text.orbit.version>1.6.wso2v1</commons-text.orbit.version>
+        <commons-text.orbit.version>1.10.0.wso2v2</commons-text.orbit.version>
         <commons-lang3.orbit.version>3.4.0.wso2v1</commons-lang3.orbit.version>
 
 


### PR DESCRIPTION
### Purpose

Upgrades commons-text version from 1.6.0.wso2v1 to 1.10.0.wso2v2.