### PR TITLE
Remove unncessary cache clearing when tenant is loaded to the cache

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/tenant/TenantCache.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/tenant/TenantCache.java
@@ -76,9 +76,6 @@ public class TenantCache {
             carbonContext.setTenantId(MultitenantConstants.SUPER_TENANT_ID);
             carbonContext.setTenantDomain(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
 
-            // Element already in the cache. Remove it first
-            clearCacheEntry(key);
-
             Cache<TenantIdKey, T> cache = getTenantCache();
             if (cache != null) {
                 cache.put(key, entry);


### PR DESCRIPTION
## Purpose

When a resource not exist in the cache, and a request come to add the resource to the cache, it should be new resource or existing resource fetched from the database due to possible cache miss. In such cases cache invalidation requests are not required to be sent.

When a resource exist in the cache, and a request come to add the resource to cache occurs when the original resource has been updated. That msg has to be sent to other nodes.

### Related Issues
- https://github.com/wso2/product-is/issues/21330