### PR TITLE
Improve user filtering by both identity and non identity claims

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/UniqueIDUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/UniqueIDUserStoreManager.java
@@ -22,6 +22,7 @@ import org.wso2.carbon.user.core.claim.Claim;
 import org.wso2.carbon.user.core.common.AuthenticationResult;
 import org.wso2.carbon.user.core.common.Group;
 import org.wso2.carbon.user.core.common.LoginIdentifier;
+import org.wso2.carbon.user.core.common.PaginatedUserResponse;
 import org.wso2.carbon.user.core.common.User;
 import org.wso2.carbon.user.core.model.Condition;
 import org.wso2.carbon.user.core.model.UniqueIDUserClaimSearchEntry;
@@ -431,6 +432,26 @@ public interface UniqueIDUserStoreManager extends UserStoreManager {
      */
     List<User> getUserListWithID(Condition condition, String domain, String profileName, int limit, int offset,
             String sortBy, String sortOrder) throws UserStoreException;
+
+    /**
+     * Retrieves response object containing the paginated users and total user count
+     *
+     * @param condition   Conditional filter.
+     * @param domain      User Store Domain.
+     * @param profileName User profile name.
+     * @param limit       No of search results. If the given value is greater than the system configured max limit
+     *                    it will be reset to the system configured max limit.
+     * @param offset      Start index of the user search.
+     * @return A PaginatedUserResponse object containing user list and total user count.
+     * @throws UserStoreException User Store Exception.
+     */
+    default PaginatedUserResponse getPaginatedUserListWithID(Condition condition, String domain, String profileName,
+                                                             int limit, int offset, String sortBy, String sortOrder)
+            throws UserStoreException {
+
+        return new PaginatedUserResponse(getUserListWithID(condition, domain, profileName, limit, offset,
+                sortBy, sortOrder));
+    }
 
     /**
      * Get claim values of users.

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/PaginatedUserResponse.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/PaginatedUserResponse.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.user.core.common;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * The class to manage paginated users and total results.
+ */
+public class PaginatedUserResponse {
+
+    private List<User> filteredUsers = new ArrayList<>();
+    private int totalResults = 0;
+
+    public PaginatedUserResponse() {
+
+    }
+
+    public PaginatedUserResponse(List<User> filteredUsers) {
+
+        this.filteredUsers = filteredUsers;
+    }
+
+    public List<User> getFilteredUsers() {
+
+        return filteredUsers;
+    }
+
+    public void setFilteredUsers(List<User> filteredUsers) {
+
+        this.filteredUsers = filteredUsers;
+    }
+
+    public int getTotalResults() {
+
+        return totalResults;
+    }
+
+    public void setTotalResults(int totalResults) {
+
+        this.totalResults = totalResults;
+    }
+}


### PR DESCRIPTION
## Purpose
#### Proposed changed from this PR

- [x] Refactor the user filtering by identity and non identity claims code based.
 >  Simplify the logic of user filtering by different types of claims and different situations.

- [x] Improve the user filtering by both identity and non identity claims when the both claims stored in separate data stores. (Identity claims in identity store)
> Proposed a new approach for identity and non identity filter aggregation.
> Previous approach

![image](https://github.com/user-attachments/assets/83e6bb1d-dcf8-4284-929d-9df6a582e37c)


> New Approach

![image](https://github.com/user-attachments/assets/e274dc96-9fe9-48eb-9e2b-0c6fc1e8d09f)

> Based on the performance analysis, with respect to CPU usage and memory usage, if the current approach leads to higher resource usage of server we will have to improve the logic to process data into 2 or 3 chunks without much sacrificing the performance of the filtering.

### Related Issues
- https://github.com/wso2-enterprise/wso2-iam-internal/issues/2233

### Public Fix
- https://github.com/wso2/carbon-kernel/pull/4095


### Related Issues
- https://github.com/wso2/product-is/issues/21242