### PR TITLE
Filter tenants based on domains name

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/tenant/JDBCTenantManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/tenant/JDBCTenantManager.java
@@ -575,7 +575,7 @@ public class JDBCTenantManager implements TenantManager {
              ResultSet resultSet = getTenantQueryResultSet(dbConnection, sortedOrder, offset, limit, domainName)) {
             List<Tenant> tenantList = populateTenantList(resultSet);
             tenantSearchResult.setTenantList(tenantList);
-            tenantSearchResult.setTotalTenantCount(getCountOfTenants(domainName));
+            tenantSearchResult.setTotalTenantCount(getTenantResultCount(domainName));
             tenantSearchResult.setLimit(limit);
             tenantSearchResult.setOffSet(offset);
             tenantSearchResult.setSortBy(sortBy);
@@ -1282,7 +1282,7 @@ public class JDBCTenantManager implements TenantManager {
      * @return number of tenant count.
      * @throws UserStoreException Error when getting count of tenants.
      */
-    private int getCountOfTenants(String domainName) throws UserStoreException {
+    private int getTenantResultCount(String domainName) throws UserStoreException {
 
         String sqlFilter = StringUtils.EMPTY;
         if (StringUtils.isNotBlank(domainName)) {

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/tenant/JDBCTenantManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/tenant/JDBCTenantManager.java
@@ -1381,7 +1381,7 @@ public class JDBCTenantManager implements TenantManager {
                 String filterAttribute = filterArgs[0];
                 String operation = filterArgs[1];
                 String attributeValue = filterArgs[2];
-                if (StringUtils.equalsIgnoreCase(filterAttribute, "DOMAIN")) {
+                if (StringUtils.equalsIgnoreCase(filterAttribute, "domainName")) {
                     return generateFilterString(operation, attributeValue);
                 }
             }

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/tenant/TenantConstants.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/tenant/TenantConstants.java
@@ -74,8 +74,8 @@ public class TenantConstants {
             "UM_ORG_UUID IN (SELECT UM_ID FROM UM_ORG WHERE UM_PARENT_ID IS NULL) ) WHERE rn BETWEEN ? AND ?";
     public static final String LIST_TENANTS_MSSQL_TAIL = "ORDER BY %s OFFSET ? ROWS FETCH NEXT ? ROWS ONLY";
     public static final String LIST_TENANTS_ORACLE_TAIL = "ORDER BY %s) WHERE rownum <= ?) WHERE rnum > ?";
-    public static final String LIST_TENANTS_DOMAIN_FILTER_LIKE = "AND UM_DOMAIN_NAME LIKE ? ";
-    public static final String LIST_TENANTS_DOMAIN_FILTER_EQUAL = "AND UM_DOMAIN_NAME=? ";
+    public static final String LIST_TENANTS_DOMAIN_FILTER_LIKE = "%s UM_DOMAIN_NAME LIKE ? ";
+    public static final String LIST_TENANTS_DOMAIN_FILTER_EQUAL = "%s UM_DOMAIN_NAME=? ";
     public static final String GET_DOMAIN_SQL = "SELECT UM_DOMAIN_NAME FROM UM_TENANT WHERE UM_ID=?";
     public static final String GET_TENANT_ID_SQL = "SELECT UM_ID FROM UM_TENANT WHERE UM_DOMAIN_NAME=?";
     public static final String ACTIVATE_SQL = "UPDATE UM_TENANT SET UM_ACTIVE='1' WHERE UM_ID=?";

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/tenant/TenantConstants.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/tenant/TenantConstants.java
@@ -74,6 +74,8 @@ public class TenantConstants {
             "UM_ORG_UUID IN (SELECT UM_ID FROM UM_ORG WHERE UM_PARENT_ID IS NULL) ) WHERE rn BETWEEN ? AND ?";
     public static final String LIST_TENANTS_MSSQL_TAIL = "ORDER BY %s OFFSET ? ROWS FETCH NEXT ? ROWS ONLY";
     public static final String LIST_TENANTS_ORACLE_TAIL = "ORDER BY %s) WHERE rownum <= ?) WHERE rnum > ?";
+    public static final String LIST_TENANTS_DOMAIN_FILTER_LIKE = "AND UM_DOMAIN_NAME LIKE ? ";
+    public static final String LIST_TENANTS_DOMAIN_FILTER_EQUAL = "AND UM_DOMAIN_NAME=? ";
     public static final String GET_DOMAIN_SQL = "SELECT UM_DOMAIN_NAME FROM UM_TENANT WHERE UM_ID=?";
     public static final String GET_TENANT_ID_SQL = "SELECT UM_ID FROM UM_TENANT WHERE UM_DOMAIN_NAME=?";
     public static final String ACTIVATE_SQL = "UPDATE UM_TENANT SET UM_ACTIVE='1' WHERE UM_ID=?";


### PR DESCRIPTION
### Purpose

This pull request introduces enhancements to the tenant search functionality by adding support for filtering tenants based on domain names. The most important changes include modifying the `getTenantQueryResultSet` method to accept a filter parameter, updating SQL queries to incorporate this filter, and adding new constants for SQL filters.

### Related issue

- https://github.com/wso2/product-is/issues/21374

## Related PRs
- https://github.com/wso2/identity-api-server/pull/723
- https://github.com/wso2/carbon-commons/pull/497
