### PR TITLE
Introduce application resident organization in carbon context

### DIFF
--- a/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/context/PrivilegedCarbonContext.java
+++ b/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/context/PrivilegedCarbonContext.java
@@ -435,4 +435,26 @@ public class PrivilegedCarbonContext extends CarbonContext {
     public void setApplicationName(String applicationName) {
         getCarbonContextDataHolder().setApplicationName(applicationName);
     }
+
+    /**
+     * Set the organization id of the organization where the application is resident when the request comes in
+     * tenant perspective.
+     *
+     * @param applicationResidentOrgId Organization id of the organization where the application is resident.
+     */
+    public void setApplicationResidentOrganizationId(String applicationResidentOrgId) {
+
+        getCarbonContextDataHolder().setApplicationResidentOrganizationId(applicationResidentOrgId);
+    }
+
+    /**
+     * Get the organization id of the organization where the application resides. This will be set when the request
+     * comes in tenant perspective.
+     *
+     * @return Organization id of the organization where the application resides.
+     */
+    public String getApplicationResidentOrganizationId() {
+
+        return getCarbonContextDataHolder().getApplicationResidentOrganizationId();
+    }
 }

--- a/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/context/internal/CarbonContextDataHolder.java
+++ b/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/context/internal/CarbonContextDataHolder.java
@@ -147,6 +147,7 @@ public final class CarbonContextDataHolder {
     private String tenantDomain;
     private String organizationId;
     private String applicationName;
+    private String applicationResidentOrganizationId;
 
     private Map<String, Object> properties;
 
@@ -1509,6 +1510,27 @@ public final class CarbonContextDataHolder {
             allowChange = true;
         }
         return allowChange;
+    }
+
+    /**
+     * Set the application resident organization id when the request comes in tenant perspective.
+     *
+     * @param applicationResidentOrganizationId Organization id of organization where the application resides.
+     */
+    public void setApplicationResidentOrganizationId(String applicationResidentOrganizationId) {
+
+        CarbonUtils.checkSecurity();
+        this.applicationResidentOrganizationId = applicationResidentOrganizationId;
+    }
+
+    /**
+     * Get the application resident organization id. This is set when the request comes in tenant perspective.
+     *
+     * @return Organization id of organization where the application resides.
+     */
+    public String getApplicationResidentOrganizationId() {
+
+        return applicationResidentOrganizationId;
     }
 
     /**


### PR DESCRIPTION
## Purpose
- $subject
- Improvement for https://github.com/wso2/product-is/issues/21208
- Introducing a variable to the carbon context to store the application resident organization id when accessing the organization related resources from the tenant perspactive through the following format of API paths.
  - `/t/{tenant-domain}/o/{org-id}/...`