### PR TITLE
Prevent loading unsupported claim attributes for Non-JDBC primary user stores

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/DefaultRealm.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/DefaultRealm.java
@@ -30,6 +30,7 @@ import org.wso2.carbon.user.core.UserStoreManager;
 import org.wso2.carbon.user.core.claim.ClaimManager;
 import org.wso2.carbon.user.core.claim.ClaimMapping;
 import org.wso2.carbon.user.core.claim.DefaultClaimManager;
+import org.wso2.carbon.user.core.claim.inmemory.FileBasedClaimBuilder;
 import org.wso2.carbon.user.core.claim.inmemory.InMemoryClaimManager;
 import org.wso2.carbon.user.core.claim.builder.ClaimBuilder;
 import org.wso2.carbon.user.core.claim.builder.ClaimBuilderException;
@@ -124,6 +125,7 @@ public class DefaultRealm implements UserRealm {
         Map<String, ProfileConfiguration> profileConfigs = new HashMap<String, ProfileConfiguration>();
 
         if (Boolean.parseBoolean(realmConfig.getRealmProperty(UserCoreClaimConstants.INITIALIZE_NEW_CLAIM_MANAGER))) {
+            FileBasedClaimBuilder.setUserStoreClass(realmConfig.getUserStoreClass());
             if (UserStoreMgtDSComponent.getClaimManagerFactory() != null) {
                 claimMan = UserStoreMgtDSComponent.getClaimManagerFactory().createClaimManager(tenantId);
             } else {

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/DefaultRealmService.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/DefaultRealmService.java
@@ -268,6 +268,7 @@ public class DefaultRealmService implements RealmService {
     public UserRealm initializeRealm(RealmConfiguration realmConfig, int tenantId)
             throws UserStoreException {
         ClaimBuilder.setBundleContext(bc);
+        ClaimBuilder.setUserStoreClass(realmConfig.getUserStoreClass());
         ProfileConfigurationBuilder.setBundleContext(bc);
         UserRealm userRealm = null;
         try {

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/util/UserCoreUtil.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/util/UserCoreUtil.java
@@ -916,6 +916,17 @@ public final class UserCoreUtil {
         }
     }
 
+    /**
+     * Checks if the given user store class is a JDBC user store class.
+     *
+     * @return `true` if the given user store class is a JDBC user store class, `false` otherwise.
+     */
+    public static boolean isPrimaryUSMJDBCUSM(String userStoreClass) {
+
+        return org.wso2.carbon.user.core.jdbc.UniqueIDJDBCUserStoreManager.class.getName()
+                    .equals(userStoreClass);
+    }
+
     public static void persistDomain(String domain, int tenantId, DataSource dataSource) throws UserStoreException {
         Connection dbConnection = null;
         try {


### PR DESCRIPTION
## Purpose
Currently, when a tenant is created, claim attribute mappings from claim-config.xml are saved to the database for the primary user store domain. When a new user store is added, the mappings from the primary user store domain are used unless the admin explicitly creates new attribute mappings.

With this PR, we aim to avoid potential conflicts arising from unsupported attributes in non-JDBC primary user stores. Specifically, if the primary user store is LDAP or another unsupported user store, new attributes that aren't natively supported should not be loaded. Admin should set these mappings manually, providing better stability and reducing errors.

## Related Issues
- https://github.com/wso2/product-is/issues/19991