### PR TITLE
Introduce ExcludedUserStores claim property

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/claim/inmemory/FileBasedClaimBuilder.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/claim/inmemory/FileBasedClaimBuilder.java
@@ -51,8 +51,8 @@ public class FileBasedClaimBuilder {
     public static final String LOCAL_NAME_CLAIM_URI = "ClaimURI";
     public static final String LOCAL_NAME_DESCRIPTION = "Description";
     public static final String LOCAL_NAME_ATTR_ID = "AttributeID";
-    public static final String LOCAL_NAME_EXCLUDED_USER_STORE_DOMAINS = "ExcludedUserStoreDomains";
-    public static final String LOCAL_NAME_USER_STORE_DOMAIN = "UserStoreDomain";
+    public static final String LOCAL_NAME_EXCLUDED_USER_STORES = "ExcludedUserStores";
+    public static final String LOCAL_NAME_USER_STORE = "UserStore";
     public static final String ATTR_DIALECT_URI = "dialectURI";
     public static final String ATTR_CLAIM_URI_REGEX = "claimURIRegex";
     private static final String CLAIM_CONFIG = "claim-config.xml";
@@ -130,17 +130,17 @@ public class FileBasedClaimBuilder {
                         OMElement metadata = (OMElement) metadataIterator.next();
                         String key = metadata.getQName().toString();
 
-                        if (LOCAL_NAME_EXCLUDED_USER_STORE_DOMAINS.equals(key)) {
+                        if (LOCAL_NAME_EXCLUDED_USER_STORES.equals(key)) {
                             Iterator userstoreIterator = metadata.getChildElements();
                             List<String> userStoreDomains = new ArrayList<>();
                             while (userstoreIterator.hasNext()) {
                                 OMElement userstore = (OMElement) userstoreIterator.next();
-                                if (LOCAL_NAME_USER_STORE_DOMAIN.equals(userstore.getLocalName())) {
+                                if (LOCAL_NAME_USER_STORE.equals(userstore.getLocalName())) {
                                     userStoreDomains.add(userstore.getText());
                                 }
                             }
                             String userStoresDomainsStr = String.join(",", userStoreDomains);
-                            properties.put(LOCAL_NAME_EXCLUDED_USER_STORE_DOMAINS, userStoresDomainsStr);
+                            properties.put(LOCAL_NAME_EXCLUDED_USER_STORES, userStoresDomainsStr);
                             continue;
                         }
 

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/claim/inmemory/FileBasedClaimBuilder.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/claim/inmemory/FileBasedClaimBuilder.java
@@ -35,8 +35,10 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import javax.xml.namespace.QName;
 import javax.xml.stream.XMLStreamException;
@@ -49,6 +51,8 @@ public class FileBasedClaimBuilder {
     public static final String LOCAL_NAME_CLAIM_URI = "ClaimURI";
     public static final String LOCAL_NAME_DESCRIPTION = "Description";
     public static final String LOCAL_NAME_ATTR_ID = "AttributeID";
+    public static final String LOCAL_NAME_EXCLUDED_USER_STORES = "ExcludedUserStores";
+    public static final String LOCAL_NAME_USER_STORE = "UserStore";
     public static final String ATTR_DIALECT_URI = "dialectURI";
     public static final String ATTR_CLAIM_URI_REGEX = "claimURIRegex";
     private static final String CLAIM_CONFIG = "claim-config.xml";
@@ -125,6 +129,21 @@ public class FileBasedClaimBuilder {
                     while (metadataIterator.hasNext()) {
                         OMElement metadata = (OMElement) metadataIterator.next();
                         String key = metadata.getQName().toString();
+
+                        if (LOCAL_NAME_EXCLUDED_USER_STORES.equals(key)) {
+                            Iterator userstoreIterator = metadata.getChildElements();
+                            List<String> userStoreDomains = new ArrayList<>();
+                            while (userstoreIterator.hasNext()) {
+                                OMElement userstore = (OMElement) userstoreIterator.next();
+                                if (LOCAL_NAME_USER_STORE.equals(userstore.getLocalName())) {
+                                    userStoreDomains.add(userstore.getText());
+                                }
+                            }
+                            String userStoresDomainsStr = String.join(",", userStoreDomains);
+                            properties.put(LOCAL_NAME_EXCLUDED_USER_STORES, userStoresDomainsStr);
+                            continue;
+                        }
+
                         String value = metadata.getText();
                         if (key.equals(LOCAL_NAME_CLAIM_URI)) {
                             claim.setClaimUri(value);

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/claim/inmemory/FileBasedClaimBuilder.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/claim/inmemory/FileBasedClaimBuilder.java
@@ -51,8 +51,8 @@ public class FileBasedClaimBuilder {
     public static final String LOCAL_NAME_CLAIM_URI = "ClaimURI";
     public static final String LOCAL_NAME_DESCRIPTION = "Description";
     public static final String LOCAL_NAME_ATTR_ID = "AttributeID";
-    public static final String LOCAL_NAME_EXCLUDED_USER_STORES = "ExcludedUserStores";
-    public static final String LOCAL_NAME_USER_STORE = "UserStore";
+    public static final String LOCAL_NAME_EXCLUDED_USER_STORE_DOMAINS = "ExcludedUserStoreDomains";
+    public static final String LOCAL_NAME_USER_STORE_DOMAIN = "UserStoreDomain";
     public static final String ATTR_DIALECT_URI = "dialectURI";
     public static final String ATTR_CLAIM_URI_REGEX = "claimURIRegex";
     private static final String CLAIM_CONFIG = "claim-config.xml";
@@ -130,17 +130,17 @@ public class FileBasedClaimBuilder {
                         OMElement metadata = (OMElement) metadataIterator.next();
                         String key = metadata.getQName().toString();
 
-                        if (LOCAL_NAME_EXCLUDED_USER_STORES.equals(key)) {
+                        if (LOCAL_NAME_EXCLUDED_USER_STORE_DOMAINS.equals(key)) {
                             Iterator userstoreIterator = metadata.getChildElements();
                             List<String> userStoreDomains = new ArrayList<>();
                             while (userstoreIterator.hasNext()) {
                                 OMElement userstore = (OMElement) userstoreIterator.next();
-                                if (LOCAL_NAME_USER_STORE.equals(userstore.getLocalName())) {
+                                if (LOCAL_NAME_USER_STORE_DOMAIN.equals(userstore.getLocalName())) {
                                     userStoreDomains.add(userstore.getText());
                                 }
                             }
                             String userStoresDomainsStr = String.join(",", userStoreDomains);
-                            properties.put(LOCAL_NAME_EXCLUDED_USER_STORES, userStoresDomainsStr);
+                            properties.put(LOCAL_NAME_EXCLUDED_USER_STORE_DOMAINS, userStoresDomainsStr);
                             continue;
                         }
 


### PR DESCRIPTION
## Purpose
Introduce a new claim property to exclude specific user stores from unsupported attribute updates. This enhancement aims to prevent errors that occur when default features attempt to update attributes not supported by certain user stores (e.g., LDAP user stores). By maintaining a list of excluded user stores, the system can bypass updating unsupported attributes for those stores, ensuring smoother operation and better error handling.

Eg: 
```
<Claim>
    <ClaimURI>http://wso2.org/claims/emailAddresses</ClaimURI>
    <DisplayName>Email Addresses</DisplayName>
    <AttributeID>emailAddresses</AttributeID>
    <Description>Claim to store email addresses of the user</Description>
    <ReadOnly>false</ReadOnly>
    <DisplayOrder>11</DisplayOrder>
    <SupportedByDefault />
    <ExcludedUserStores>
	<UserStore>LDAP1</UserStore>
	<UserStore>CUSTOM</UserStore>
    </ExcludedUserStores>
</Claim>
 ```

### Related Issues
- https://github.com/wso2/product-is/issues/19991

### Additional Context 
Multiple Emails and Mobile Numbers Feature: This improvement is particularly beneficial for features like multiple emails and mobile numbers per user. With this feature enabled, UIs display multiple claims instead of a single claim, treating one as the primary number. By excluding user stores that do not support certain attributes, we prevent errors when these features attempt to update unsupported attributes.