### PR TITLE
Modifying the maximum LTS JDK runtime

### DIFF
--- a/distribution/kernel/carbon-home/bin/wso2server.bat
+++ b/distribution/kernel/carbon-home/bin/wso2server.bat
@@ -131,19 +131,19 @@ rem find the version of the jdk
 
 set CMD=RUN %*
 
-:checkJdk17
+:checkJdk21
 PATH %PATH%;%JAVA_HOME%\bin\
 for /f tokens^=2-5^ delims^=.-_^" %%j in ('java -fullversion 2^>^&1') do set "JAVA_VERSION=%%j%%k"
 if %JAVA_VERSION% LSS 110 goto unknownJdk
-if %JAVA_VERSION% GTR 170 goto unknownJdk
-goto jdk17
+if %JAVA_VERSION% GTR 210 goto unknownJdk
+goto jdk21
 
 :unknownJdk
 echo Starting WSO2 Carbon (in unsupported JDK)
-echo [ERROR] CARBON is supported only between JDK 11 and JDK 17
-goto jdk17
+echo [ERROR] CARBON is supported only between JDK 11 and JDK 21
+goto jdk21
 
-:jdk17
+:jdk21
 goto runServer
 
 rem ----------------- Execute The Requested Command ----------------------------

--- a/distribution/kernel/carbon-home/bin/wso2server.sh
+++ b/distribution/kernel/carbon-home/bin/wso2server.sh
@@ -213,9 +213,9 @@ fi
 # ---------- Handle the SSL Issue with proper JDK version --------------------
 java_version=$("$JAVACMD" -version 2>&1 | awk -F '"' '/version/ {print $2}')
 java_version_formatted=$(echo "$java_version" | awk -F. '{printf("%02d%02d",$1,$2);}')
-if [ $java_version_formatted -lt 1100 ] || [ $java_version_formatted -gt 1700 ]; then
+if [ $java_version_formatted -lt 1100 ] || [ $java_version_formatted -gt 2100 ]; then
    echo " Starting WSO2 Carbon (in unsupported JDK)"
-   echo " [ERROR] CARBON is supported only between JDK 11 and JDK 17"
+   echo " [ERROR] CARBON is supported only between JDK 11 and JDK 21"
 fi
 
 CARBON_XBOOTCLASSPATH=""


### PR DESCRIPTION
Modifying the LTS maximum java version to incorporate the JDK 21 runtime support.

Related issue:

- https://github.com/wso2/product-is/issues/21158