### PR TITLE
Introduce KeyStore Persistence Manager and Registry KeyStore Persistence Manager implementations

### DIFF
--- a/core/org.wso2.carbon.core/pom.xml
+++ b/core/org.wso2.carbon.core/pom.xml
@@ -225,10 +225,11 @@
                         <Bundle-SymbolicName>org.wso2.carbon.core</Bundle-SymbolicName>
                         <Bundle-Activator>org.wso2.carbon.core.internal.CarbonCoreActivator</Bundle-Activator>
                         <Private-Package>
-                            org.wso2.carbon.core.internal, org.wso2.carbon.core.encryption
+                            org.wso2.carbon.core.internal, org.wso2.carbon.core.encryption, org.wso2.carbon.core.keystore.persistence
                         </Private-Package>
                         <Export-Package>
                             !org.wso2.carbon.core.internal,
+                            !org.wso2.carbon.core.keystore.persistence,
                             org.wso2.carbon.core.*; version="${carbon.kernel.exp.pkg.version}",
                         </Export-Package>
                         <Import-Package>

--- a/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/keystore/persistence/KeyStorePersistenceManager.java
+++ b/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/keystore/persistence/KeyStorePersistenceManager.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.core.keystore.persistence;
+
+import org.wso2.carbon.core.security.KeyStoreMetadata;
+
+import java.security.KeyStore;
+import java.util.Date;
+import java.util.List;
+
+/**
+ * This interface supports the persistence/storage related logics of key stores.
+ */
+public interface KeyStorePersistenceManager {
+
+    /**
+     * Add the key store to the data storage.
+     *
+     * @param keyStoreName           Name of the key store.
+     * @param keystoreContent        Content of the key store.
+     * @param provider               Provider of the key store.
+     * @param keyStorePasswordChar   Key Store Password as a character string.
+     * @param privateKeyPasswordChar Private key password as a character string.
+     * @param tenantId               Tenant ID.
+     * @throws SecurityException If an error occurs while adding the key store.
+     */
+    void addKeystore(String keyStoreName, byte[] keystoreContent, String provider, String type,
+                     char[] keyStorePasswordChar, char[] privateKeyPasswordChar, int tenantId);
+
+    /**
+     * Get the key store from the data storage.
+     *
+     * @param keyStoreName Name of the key store.
+     * @param tenantId     Tenant Id.
+     * @return Key store.
+     * @throws SecurityException If an error occurs while getting the key store.
+     */
+    KeyStore getKeyStore(String keyStoreName, int tenantId) throws SecurityException;
+
+    /**
+     * Method to retrieve list of keystore metadata of all the keystores in a tenant.
+     *
+     * @param tenantId tenantId.
+     * @return List of KeyStoreMetaData objects.
+     * @throws SecurityException If an error occurs while retrieving the keystore data.
+     */
+    List<KeyStoreMetadata> listKeyStores(int tenantId) throws SecurityException;
+
+    /**
+     * Update the key store in the data storage.
+     *
+     * @param keyStoreName Key store name.
+     * @param keyStore     Updated key store.
+     * @param tenantId     Tenant Id.
+     */
+    void updateKeyStore(String keyStoreName, KeyStore keyStore, int tenantId);
+
+    /**
+     * Delete the key store from the data storage.
+     *
+     * @param keyStoreName Name of the key store.
+     * @param tenantId     Tenant Id.
+     * @throws SecurityException If an error occurs while deleting the key store.
+     */
+    void deleteKeyStore(String keyStoreName, int tenantId) throws SecurityException;
+
+    /**
+     * Get the last modified date of the key store.
+     *
+     * @param keyStoreName Key store name.
+     * @return Last modified date of the key store.
+     */
+    Date getKeyStoreLastModifiedDate(String keyStoreName, int tenantId);
+
+    /**
+     * Get the password as a character array for the given key store name.
+     *
+     * @param keyStoreName key store name.
+     * @param tenantId     Tenant Id.
+     * @return KeyStore Password as a character array.
+     * @throws SecurityException If there is an error while getting the key store password.
+     */
+    char[] getKeyStorePassword(String keyStoreName, int tenantId) throws SecurityException;
+
+    /**
+     * Get the private key password as a character array for the given key store name.
+     *
+     * @param keyStoreName Key store name.
+     * @param tenantId     Tenant Id.
+     * @return Private key password as a character array.
+     * @throws SecurityException If an error occurs while getting the private key password.
+     */
+    char[] getPrivateKeyPassword(String keyStoreName, int tenantId) throws SecurityException;
+}

--- a/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/keystore/persistence/RegistryKeyStorePersistenceManager.java
+++ b/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/keystore/persistence/RegistryKeyStorePersistenceManager.java
@@ -1,0 +1,438 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.core.keystore.persistence;
+
+import org.apache.axiom.om.util.UUIDGenerator;
+import org.apache.commons.lang.ArrayUtils;
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.core.RegistryResources;
+import org.wso2.carbon.core.internal.CarbonCoreDataHolder;
+import org.wso2.carbon.core.security.KeyStoreMetadata;
+import org.wso2.carbon.core.util.CryptoException;
+import org.wso2.carbon.core.util.CryptoUtil;
+import org.wso2.carbon.core.util.KeyStoreUtil;
+import org.wso2.carbon.registry.api.Association;
+import org.wso2.carbon.registry.api.Registry;
+import org.wso2.carbon.registry.api.RegistryException;
+import org.wso2.carbon.registry.api.Resource;
+import org.wso2.carbon.registry.core.Collection;
+import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
+import org.wso2.carbon.utils.security.KeystoreUtils;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
+import java.security.UnrecoverableKeyException;
+import java.security.cert.CertificateEncodingException;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+
+/**
+ * This implementation handles the keystore storage/persistence related logics in the Registry.
+ */
+public class RegistryKeyStorePersistenceManager implements KeyStorePersistenceManager {
+
+    private static final Log LOG = LogFactory.getLog(RegistryKeyStorePersistenceManager.class);
+    private static final String REGISTRY_PATH_SEPARATOR = "/";
+    private static final String ASSOCIATION_TENANT_KS_PUB_KEY = "assoc.tenant.ks.pub.key";
+    private static final String PROP_TENANT_PUB_KEY_FILE_NAME_APPENDER = "tenant.pub.key.file.name.appender";
+
+    /**
+     * Add the key store to the registry.
+     *
+     * @param keyStoreName           Name of the key store.
+     * @param keystoreContent        Content of the key store.
+     * @param provider               Provider of the key store.
+     * @param keyStorePasswordChar   Key Store Password as a character array.
+     * @param privateKeyPasswordChar Private key password as a character array.
+     * @param tenantId               Tenant ID.
+     * @throws SecurityException If an error occurs while adding the key store.
+     */
+    public void addKeystore(String keyStoreName, byte[] keystoreContent, String provider, String type,
+                            char[] keyStorePasswordChar, char[] privateKeyPasswordChar, int tenantId)
+            throws SecurityException {
+
+        Registry registry = getGovernanceRegistry(tenantId);
+        if (isKeyStoreExistsInRegistry(keyStoreName, registry)) {
+            throw new SecurityException("Key store " + keyStoreName + " already available");
+        }
+
+        boolean isTenantPrimaryKeyStore = false;
+        try (InputStream inputStream = new ByteArrayInputStream(keystoreContent)) {
+            if (tenantId != MultitenantConstants.SUPER_TENANT_ID &&
+                    !registry.resourceExists(RegistryResources.SecurityManagement.KEY_STORES)) {
+                isTenantPrimaryKeyStore = true;
+            }
+
+            KeyStore keyStore = KeystoreUtils.getKeystoreInstance(type);
+            keyStore.load(inputStream, keyStorePasswordChar);
+            String pvtKeyAlias = KeyStoreUtil.getPrivateKeyAlias(keyStore);
+
+            Resource resource = registry.newResource();
+            resource.addProperty(RegistryResources.SecurityManagement.PROP_PASSWORD,
+                    encryptPassword(keyStorePasswordChar));
+            resource.addProperty(RegistryResources.SecurityManagement.PROP_PROVIDER, provider);
+            resource.addProperty(RegistryResources.SecurityManagement.PROP_TYPE, keyStore.getType());
+            resource.setContent(keystoreContent);
+
+            if (StringUtils.isNotBlank(pvtKeyAlias)) {
+                resource.addProperty(RegistryResources.SecurityManagement.PROP_PRIVATE_KEY_ALIAS, pvtKeyAlias);
+                if (ArrayUtils.isNotEmpty(privateKeyPasswordChar)) {
+                    resource.addProperty(RegistryResources.SecurityManagement.PROP_PRIVATE_KEY_PASS,
+                            encryptPassword(privateKeyPasswordChar));
+                    // Check weather private key password is correct.
+                    keyStore.getKey(pvtKeyAlias, privateKeyPasswordChar);
+                }
+            }
+            registry.put(getKeyStorePath(keyStoreName), resource);
+
+            if (isTenantPrimaryKeyStore) {
+                // Create the public key resource for tenant's primary keystore.
+                addTenantPublicKey(keyStoreName, (X509Certificate) keyStore.getCertificate(pvtKeyAlias), registry);
+            }
+        } catch (IOException | KeyStoreException | NoSuchAlgorithmException | NoSuchProviderException |
+                 UnrecoverableKeyException | CertificateException | RegistryException e) {
+            throw new SecurityException("Error adding key store " + keyStoreName, e);
+        }
+    }
+
+    /**
+     * Add tenant's public certificate to the database.
+     *
+     * @param keyStoreName Name of the key store.
+     * @param publicCert   Public certificate of the tenant.
+     * @throws SecurityException If an error occurs while adding the tenant's public certificate.
+     */
+    private void addTenantPublicKey(String keyStoreName, X509Certificate publicCert, Registry registry)
+            throws SecurityException {
+
+        try {
+            // Create the public key resource.
+            Resource pubKeyResource = registry.newResource();
+            pubKeyResource.setContent(publicCert.getEncoded());
+            pubKeyResource.addProperty(PROP_TENANT_PUB_KEY_FILE_NAME_APPENDER, generatePublicCertId());
+            registry.put(RegistryResources.SecurityManagement.TENANT_PUBKEY_RESOURCE, pubKeyResource);
+
+            // Associate the public key with the keystore.
+            registry.addAssociation(
+                    RegistryResources.SecurityManagement.KEY_STORES + REGISTRY_PATH_SEPARATOR + keyStoreName,
+                    RegistryResources.SecurityManagement.TENANT_PUBKEY_RESOURCE, ASSOCIATION_TENANT_KS_PUB_KEY);
+        } catch (RegistryException | CertificateEncodingException e) {
+            throw new SecurityException("Error when writing the keystore public cert to registry for keystore: " +
+                    keyStoreName, e);
+        }
+    }
+
+    /**
+     * Generates an ID for the public certificate, which is used as a file name suffix for the certificate.
+     * e.g. If keystore name is 'example-com.jks', public cert name will be 'example-com-343743.cert'.
+     *
+     * @return generated id to be used as a file name appender.
+     */
+    private static String generatePublicCertId() {
+
+        String uuid = UUIDGenerator.getUUID();
+        return uuid.substring(uuid.length() - 6, uuid.length() - 1);
+    }
+
+    /**
+     * Get the key store from the registry.
+     *
+     * @param keyStoreName Name of the key store.
+     * @param tenantId     Tenant Id.
+     * @return Key store.
+     * @throws SecurityException If an error occurs while getting the key store.
+     */
+    public KeyStore getKeyStore(String keyStoreName, int tenantId) throws SecurityException {
+
+        Registry registry = getGovernanceRegistry(tenantId);
+        if (!isKeyStoreExistsInRegistry(keyStoreName, registry)) {
+            throw new SecurityException("Key Store with a name: " + keyStoreName + " does not exist.");
+        }
+
+        char[] passwordChar = new char[0];
+        try {
+            Resource resource = registry.get(getKeyStorePath(keyStoreName));
+            byte[] bytes = (byte[]) resource.getContent();
+            KeyStore keyStore = KeystoreUtils.getKeystoreInstance(resource
+                    .getProperty(RegistryResources.SecurityManagement.PROP_TYPE));
+            passwordChar = getKeyStorePasswordFromRegistryResource(resource, keyStoreName);
+            ByteArrayInputStream stream = new ByteArrayInputStream(bytes);
+            keyStore.load(stream, passwordChar);
+            resource.discard();
+            return keyStore;
+        } catch (RegistryException | KeyStoreException | NoSuchProviderException | IOException | CertificateException |
+                 NoSuchAlgorithmException e) {
+            throw new SecurityException("Error getting key store: " + keyStoreName, e);
+        } finally {
+            clearPasswordCharArray(passwordChar);
+        }
+    }
+
+    private String getKeyStorePath(String keyStoreName) {
+
+        return RegistryResources.SecurityManagement.KEY_STORES + REGISTRY_PATH_SEPARATOR + keyStoreName;
+    }
+
+    /**
+     * Method to retrieve list of keystore metadata of all the keystores in a tenant.
+     *
+     * @param tenantId Tenant Id.
+     * @return List of KeyStoreMetaData objects.
+     * @throws SecurityException If an error occurs while retrieving the keystore data.
+     */
+    public List<KeyStoreMetadata> listKeyStores(int tenantId) throws SecurityException {
+
+        Registry registry = getGovernanceRegistry(tenantId);
+        List<KeyStoreMetadata> metadataList = new ArrayList<>();
+        try {
+            if (!registry.resourceExists(RegistryResources.SecurityManagement.KEY_STORES)) {
+                return metadataList;
+            }
+
+            Collection keyStoreCollection = (Collection) registry.get(RegistryResources.SecurityManagement.KEY_STORES);
+            String[] keyStorePaths = keyStoreCollection.getChildren();
+
+            for (String keyStorePath : keyStorePaths) {
+                if (RegistryResources.SecurityManagement.PRIMARY_KEYSTORE_PHANTOM_RESOURCE.equals(keyStorePath)) {
+                    continue;
+                }
+                metadataList.add(getKeyStoreMetadata(keyStorePath, registry, tenantId));
+            }
+            return metadataList;
+        } catch (RegistryException e) {
+            throw new SecurityException("Error when getting keyStore metadata.", e);
+        }
+    }
+
+    private KeyStoreMetadata getKeyStoreMetadata(String keyStorePath, Registry registry, int tenantId)
+            throws RegistryException {
+
+        Resource keyStoreResource = registry.get(keyStorePath);
+        int lastIndex = keyStorePath.lastIndexOf(REGISTRY_PATH_SEPARATOR);
+        String name = keyStorePath.substring(lastIndex + 1);
+        String type = keyStoreResource.getProperty(RegistryResources.SecurityManagement.PROP_TYPE);
+        String provider = keyStoreResource.getProperty(RegistryResources.SecurityManagement.PROP_PROVIDER);
+        String alias = keyStoreResource.getProperty(RegistryResources.SecurityManagement.PROP_PRIVATE_KEY_ALIAS);
+
+        KeyStoreMetadata keyStoreMetadata = new KeyStoreMetadata();
+        keyStoreMetadata.setKeyStoreName(name);
+        keyStoreMetadata.setKeyStoreType(type);
+        keyStoreMetadata.setProvider(provider);
+        keyStoreMetadata.setPrivateStore(alias != null);
+
+        if (tenantId != MultitenantConstants.SUPER_TENANT_ID) {
+            Association[] associations = registry.getAssociations(keyStorePath, ASSOCIATION_TENANT_KS_PUB_KEY);
+            if (associations != null && associations.length > 0) {
+                Resource pubKeyResource = registry.get(associations[0].getDestinationPath());
+                keyStoreMetadata.setPublicCertId(pubKeyResource.getProperty(PROP_TENANT_PUB_KEY_FILE_NAME_APPENDER));
+                keyStoreMetadata.setPublicCert((byte[]) pubKeyResource.getContent());
+            }
+        }
+
+        return keyStoreMetadata;
+    }
+
+    /**
+     * Update the key store in the registry.
+     *
+     * @param keyStoreName Key store name.
+     * @param keyStore     Updated key store.
+     * @param tenantId     Tenant Id.
+     */
+    public void updateKeyStore(String keyStoreName, KeyStore keyStore, int tenantId) {
+
+        Registry registry = getGovernanceRegistry(tenantId);
+        char[] passwordChar = new char[0];
+        try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
+            String path = getKeyStorePath(keyStoreName);
+            Resource resource = registry.get(path);
+            passwordChar = getKeyStorePasswordFromRegistryResource(resource, keyStoreName);
+            keyStore.store(outputStream, passwordChar);
+            outputStream.flush();
+            resource.setContent(outputStream.toByteArray());
+            registry.put(path, resource);
+            resource.discard();
+        } catch (IOException | KeyStoreException | NoSuchAlgorithmException | CertificateException |
+                 RegistryException e) {
+            throw new SecurityException("Error updating tenanted key store: " + keyStoreName, e);
+        } finally {
+            clearPasswordCharArray(passwordChar);
+        }
+    }
+
+    /**
+     * Delete the key store from the registry.
+     *
+     * @param keyStoreName Name of the key store.
+     * @param tenantId     Tenant Id.
+     * @throws SecurityException If an error occurs while deleting the key store.
+     */
+    public void deleteKeyStore(String keyStoreName, int tenantId) throws SecurityException {
+
+        Registry registry = getGovernanceRegistry(tenantId);
+        try {
+            String path = getKeyStorePath(keyStoreName);
+            Association[] allAssociations = registry.getAllAssociations(path);
+            if (allAssociations != null && allAssociations.length > 0) {
+                throw new SecurityException("Key store: " + keyStoreName + " is already in use and can't be deleted");
+            }
+            registry.delete(path);
+        } catch (RegistryException e) {
+            throw new SecurityException("Error deleting key store: " + keyStoreName, e);
+        }
+    }
+
+    /**
+     * Get the last modified date of the key store.
+     *
+     * @param keyStoreName Key store name.
+     * @param tenantId     Tenant Id.
+     * @return Last modified date of the key store.
+     */
+    public Date getKeyStoreLastModifiedDate(String keyStoreName, int tenantId) {
+
+        Registry registry = getGovernanceRegistry(tenantId);
+        try {
+            return registry.get(getKeyStorePath(keyStoreName)).getLastModified();
+        } catch (RegistryException e) {
+            LOG.error("Error while getting the last modified date of the key store: " + keyStoreName, e);
+            return null;
+        }
+    }
+
+    /**
+     * Get the password for the given key store name.
+     *
+     * @param keyStoreName Key store name.
+     * @return KeyStore Password.
+     * @throws SecurityException If there is an error while getting the key store password.
+     */
+    public char[] getKeyStorePassword(String keyStoreName, int tenantId) throws SecurityException {
+
+        Registry registry = getGovernanceRegistry(tenantId);
+        if (!isKeyStoreExistsInRegistry(keyStoreName, registry)) {
+            throw new SecurityException("Key Store with a name: " + keyStoreName + " does not exist.");
+        }
+
+        try {
+            Resource resource = registry.get(getKeyStorePath(keyStoreName));
+            return getKeyStorePasswordFromRegistryResource(resource, keyStoreName);
+        } catch (RegistryException e) {
+            throw new SecurityException("Error getting password for key store: " + keyStoreName, e);
+        }
+    }
+
+    /**
+     * Get the private key password as a character array for the given key store name.
+     *
+     * @param keyStoreName Key store name.
+     * @param tenantId     Tenant Id.
+     * @return Private key password as a character array.
+     * @throws SecurityException If an error occurs while getting the private key password.
+     */
+    public char[] getPrivateKeyPassword(String keyStoreName, int tenantId) throws SecurityException {
+
+        Registry registry = getGovernanceRegistry(tenantId);
+        try {
+            Resource resource = registry.get(getKeyStorePath(keyStoreName));
+            String encryptedPassword = resource.getProperty(RegistryResources.SecurityManagement.PROP_PRIVATE_KEY_PASS);
+            if (encryptedPassword == null) {
+                throw new SecurityException("Private Key Password of " + keyStoreName + " does not exist.");
+            }
+            return decryptPassword(encryptedPassword);
+        } catch (RegistryException e) {
+            throw new SecurityException("Error getting private key password for key store: " + keyStoreName, e);
+        }
+    }
+
+    private boolean isKeyStoreExistsInRegistry(String keyStoreName, Registry registry) throws SecurityException {
+
+        try {
+            return registry.resourceExists(getKeyStorePath(keyStoreName));
+        } catch (RegistryException e) {
+            throw new SecurityException("Error checking the existence of key store: " + keyStoreName, e);
+        }
+    }
+
+    private char[] getKeyStorePasswordFromRegistryResource(Resource resource, String keyStoreName) {
+
+        String encryptedPassword = resource.getProperty(RegistryResources.SecurityManagement.PROP_PASSWORD);
+        if (encryptedPassword == null) {
+            throw new SecurityException("Key Store Password of " + keyStoreName + " does not exist.");
+        }
+        return decryptPassword(encryptedPassword);
+    }
+
+    private Registry getGovernanceRegistry(int tenantId) {
+
+        try {
+            return CarbonCoreDataHolder.getInstance().getRegistryService().getGovernanceSystemRegistry(tenantId);
+        } catch (Exception e) {
+            throw new SecurityException("Error while getting the registry for tenant: " + tenantId, e);
+        }
+    }
+
+    /**
+     * This method encrypts the given passwordChar using the default crypto util.
+     *
+     * @param passwordChar Password to be encrypted as a character array.
+     * @return encrypted password.
+     */
+    private String encryptPassword(char[] passwordChar) {
+
+        try {
+            return CryptoUtil.getDefaultCryptoUtil().encryptAndBase64Encode(String.valueOf(passwordChar).getBytes());
+        } catch (CryptoException e) {
+            throw new SecurityException("Error encrypting the passwordChar", e);
+        }
+    }
+
+    /**
+     * This method decrypts the given encrypted password using the default crypto util.
+     *
+     * @param encryptedPassword Encrypted password.
+     * @return decrypted password as a character array.
+     */
+    private char[] decryptPassword(String encryptedPassword) {
+
+        try {
+            CryptoUtil cryptoUtil = CryptoUtil.getDefaultCryptoUtil();
+            return new String(cryptoUtil.base64DecodeAndDecrypt(encryptedPassword)).toCharArray();
+        } catch (CryptoException e) {
+            throw new SecurityException("Error decrypting the password", e);
+        }
+    }
+
+    private static void clearPasswordCharArray(char[] passwordChar) {
+
+        Arrays.fill(passwordChar, '\0');
+    }
+}

--- a/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/util/KeyStoreManager.java
+++ b/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/util/KeyStoreManager.java
@@ -18,7 +18,6 @@
 package org.wso2.carbon.core.util;
 
 import org.apache.axiom.om.OMElement;
-import org.apache.axiom.om.util.UUIDGenerator;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -27,24 +26,17 @@ import org.wso2.carbon.base.ServerConfiguration;
 import org.wso2.carbon.base.api.ServerConfigurationService;
 import org.wso2.carbon.core.RegistryResources;
 import org.wso2.carbon.core.internal.CarbonCoreDataHolder;
+import org.wso2.carbon.core.keystore.persistence.RegistryKeyStorePersistenceManager;
 import org.wso2.carbon.core.security.KeyStoreMetadata;
-import org.wso2.carbon.registry.api.Registry;
-import org.wso2.carbon.registry.api.RegistryException;
-import org.wso2.carbon.registry.api.Resource;
-import org.wso2.carbon.registry.core.Collection;
-import org.wso2.carbon.registry.core.exceptions.ResourceNotFoundException;
 import org.wso2.carbon.registry.core.service.RegistryService;
 import org.wso2.carbon.utils.CarbonUtils;
 import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 import org.wso2.carbon.utils.security.KeystoreUtils;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.security.Key;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
@@ -53,10 +45,9 @@ import java.security.NoSuchProviderException;
 import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.security.cert.Certificate;
-import java.security.cert.CertificateEncodingException;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
@@ -76,7 +67,7 @@ public class KeyStoreManager {
             new ConcurrentHashMap<String, KeyStoreManager>();
     private static Log log = LogFactory.getLog(KeyStoreManager.class);
 
-    private Registry registry = null;
+    private final RegistryKeyStorePersistenceManager registryKeyStorePersistenceManager;
     private ConcurrentHashMap<String, KeyStoreBean> tenantKeyStores = null;
     private ConcurrentHashMap<String, KeyStore> customKeyStores = null;
     private int tenantId = MultitenantConstants.SUPER_TENANT_ID;
@@ -88,8 +79,6 @@ public class KeyStoreManager {
     private static final String KEY_STORE_NAME_NULL_ERROR = "Key store name is null or empty.";
     private static final String PERMISSION_DENIED_ERROR = "Permission denied for accessing %s. The %s is " +
             "available only for the super tenant.";
-    private static final String ASSOCIATION_TENANT_KS_PUB_KEY = "assoc.tenant.ks.pub.key";
-    private static final String PROP_TENANT_PUB_KEY_FILE_NAME_APPENDER = "tenant.pub.key.file.name.appender";
 
     /**
      * Private Constructor of the KeyStoreManager
@@ -100,24 +89,26 @@ public class KeyStoreManager {
      */
     private KeyStoreManager(int tenantId, ServerConfigurationService serverConfigService,
                             RegistryService registryService) {
+
         this.serverConfigService = serverConfigService;
         this.registryService = registryService;
+        this.registryKeyStorePersistenceManager = new RegistryKeyStorePersistenceManager();
         tenantKeyStores = new ConcurrentHashMap<String, KeyStoreBean>();
         customKeyStores = new ConcurrentHashMap<String, KeyStore>();
         this.tenantId = tenantId;
-        try {
-            registry = registryService.getGovernanceSystemRegistry(tenantId);
-        } catch (RegistryException e) {
-            String message = "Error when retrieving the system governance registry";
-            log.error(message, e);
-            throw new SecurityException(message, e);
-        }
     }
 
     public ServerConfigurationService getServerConfigService() {
         return serverConfigService;
     }
 
+    /**
+     * Get the instance of the RegistryService
+     *
+     * @return RegistryService instance
+     * @deprecated Use CryptoUtil#lookupRegistryService() instead.
+     */
+    @Deprecated
     public RegistryService getRegistryService() {
         return registryService;
     }
@@ -132,14 +123,34 @@ public class KeyStoreManager {
      */
     public static KeyStoreManager getInstance(int tenantId) {
 
-        log.debug("KeyStoreManager Instace created for teant id: " + tenantId);
-        return getInstance(tenantId, CarbonCoreDataHolder.getInstance().
-                getServerConfigurationService(), CryptoUtil.lookupRegistryService());
+        return initializeKeyStoreManager(tenantId, CarbonCoreDataHolder.getInstance().getServerConfigurationService(),
+                CryptoUtil.lookupRegistryService());
     }
 
+    /**
+     * Get a KeyStoreManager instance for that tenant. This method will return an KeyStoreManager
+     * instance if exists, or creates a new one. Only use this at runtime, or else,
+     * use KeyStoreManager#getInstance(UserRegistry, ServerConfigurationService).
+     *
+     * @param tenantId            id of the corresponding tenant.
+     * @param serverConfigService ServerConfigurationService instance.
+     * @param registryService     RegistryService instance.
+     * @return KeyStoreManager instance for that tenant.
+     * @deprecated Use KeyStoreManager#getInstance(int) instead.
+     */
+    @Deprecated
     public static KeyStoreManager getInstance(int tenantId,
                                               ServerConfigurationService serverConfigService,
                                               RegistryService registryService) {
+
+        return initializeKeyStoreManager(tenantId, serverConfigService, registryService);
+    }
+
+    private static KeyStoreManager initializeKeyStoreManager(int tenantId,
+                                                             ServerConfigurationService serverConfigService,
+                                                             RegistryService registryService) {
+
+        log.debug("KeyStoreManager Instance created for tenant id: " + tenantId);
         CarbonUtils.checkSecurity();
         String tenantIdStr = Integer.toString(tenantId);
         if (!mtKeyStoreManagers.containsKey(tenantIdStr)) {
@@ -150,7 +161,7 @@ public class KeyStoreManager {
     }
 
     /**
-     * Add new key store to the registry.
+     * Add new key store.
      *
      * @param keystoreContent   Key store object.
      * @param filename          File name of the key store.
@@ -159,9 +170,44 @@ public class KeyStoreManager {
      * @param type              Keys store type (JKS, PKCS12, etc).
      * @param privateKeyPass    Password of the private key.
      * @throws SecurityException  If an error occurs while adding the key store.
+     * @deprecated Use {@link #addKeyStore(byte[], String, char[], String, String, char[])} instead.
      */
+    @Deprecated
     public void addKeyStore(byte[] keystoreContent, String filename, String password, String provider,
                             String type, String privateKeyPass) throws SecurityException {
+
+        char[] passwordChar = new char[0];
+        char[] privateKeyPasswordChar = new char[0];
+        try {
+            if (password == null) {
+                throw new SecurityException("Key store password can't be null");
+            } else if (privateKeyPass == null) {
+                passwordChar = password.toCharArray();
+                addKeyStore(keystoreContent, filename, passwordChar, provider, type, null);
+            } else {
+                passwordChar = password.toCharArray();
+                privateKeyPasswordChar = privateKeyPass.toCharArray();
+                addKeyStore(keystoreContent, filename, passwordChar, provider, type, privateKeyPasswordChar);
+            }
+        } finally {
+            Arrays.fill(passwordChar, '\0');
+            Arrays.fill(privateKeyPasswordChar, '\0');
+        }
+    }
+
+    /**
+     * Add new key store.
+     *
+     * @param keystoreContent        Key store object.
+     * @param filename               File name of the key store.
+     * @param passwordChar           Password of the key store as a character array.
+     * @param provider               Provider of the key store.
+     * @param type                   Keys store type (JKS, PKCS12, etc).
+     * @param privateKeyPasswordChar Password of the private key as a character array.
+     * @throws SecurityException If an error occurs while adding the key store.
+     */
+    public void addKeyStore(byte[] keystoreContent, String filename, char[] passwordChar, String provider, String type,
+                            char[] privateKeyPasswordChar) throws SecurityException {
 
         if (StringUtils.isBlank(filename)) {
             throw new SecurityException(KEY_STORE_NAME_NULL_ERROR);
@@ -169,104 +215,12 @@ public class KeyStoreManager {
         if (KeyStoreUtil.isPrimaryStore(filename) || KeyStoreUtil.isTrustStore(filename)) {
             throw new SecurityException("Key store " + filename + " already available");
         }
-        addKeystore(filename, keystoreContent, password, provider, type, privateKeyPass);
-    }
-
-    private void addKeystore(String filename, byte[] keystoreContent, String password, String provider,
-                             String type, String privateKeyPass) {
-
-        String path = RegistryResources.SecurityManagement.KEY_STORES + "/" + filename;
-        boolean isTenantPrimaryKeyStore = false;
-        try (InputStream inputStream = new ByteArrayInputStream(keystoreContent)) {
-            if (registry.resourceExists(path)) {
-                throw new SecurityException("Key store " + filename + " already available");
-            }
-            if (tenantId != MultitenantConstants.SUPER_TENANT_ID &&
-                    !registry.resourceExists(RegistryResources.SecurityManagement.KEY_STORES)) {
-                isTenantPrimaryKeyStore = true;
-            }
-            KeyStore keyStore = KeystoreUtils.getKeystoreInstance(type);
-            keyStore.load(inputStream, password.toCharArray());
-
-            Resource resource = registry.newResource();
-            resource.addProperty(RegistryResources.SecurityManagement.PROP_PASSWORD, encryptPassword(password));
-            resource.addProperty(RegistryResources.SecurityManagement.PROP_PROVIDER, provider);
-            resource.addProperty(RegistryResources.SecurityManagement.PROP_TYPE, type);
-
-            String pvtKeyAlias = KeyStoreUtil.getPrivateKeyAlias(keyStore);
-            if (StringUtils.isNotBlank(pvtKeyAlias)) {
-                resource.addProperty(RegistryResources.SecurityManagement.PROP_PRIVATE_KEY_ALIAS, pvtKeyAlias);
-                if (StringUtils.isNotBlank(privateKeyPass)) {
-                    resource.addProperty(RegistryResources.SecurityManagement.PROP_PRIVATE_KEY_PASS,
-                            encryptPassword(privateKeyPass));
-                    // Check weather private key password is correct.
-                    keyStore.getKey(pvtKeyAlias, privateKeyPass.toCharArray());
-                }
-            }
-            resource.setContent(keystoreContent);
-            registry.put(path, resource);
-
-            if (isTenantPrimaryKeyStore) {
-                // Create the public key resource for tenant's primary keystore.
-                addTenantPublicKey(filename, (X509Certificate) keyStore.getCertificate(pvtKeyAlias));
-            }
-        } catch (Exception e) {
-            throw new SecurityException("Error adding key store " + filename, e);
-        }
-    }
-
-    private String encryptPassword(String password) {
-
-        try {
-            return CryptoUtil.getDefaultCryptoUtil().encryptAndBase64Encode(password.getBytes());
-        } catch (CryptoException e) {
-            throw new SecurityException("Error encrypting the password", e);
-        }
+        registryKeyStorePersistenceManager.addKeystore(filename, keystoreContent, provider, type, passwordChar,
+                privateKeyPasswordChar, tenantId);
     }
 
     /**
-     * Add tenant's public certificate to the database.
-     *
-     * @param keyStoreName Name of the key store.
-     * @param publicCert   Public certificate of the tenant.
-     * @throws SecurityException If an error occurs while adding the tenant's public certificate.
-     */
-    private void addTenantPublicKey(String keyStoreName, X509Certificate publicCert) throws SecurityException {
-
-        if (StringUtils.isBlank(keyStoreName)) {
-            throw new SecurityException(KEY_STORE_NAME_NULL_ERROR);
-        }
-
-        try {
-            // Create the public key resource.
-            Resource pubKeyResource = registry.newResource();
-            pubKeyResource.setContent(publicCert.getEncoded());
-            pubKeyResource.addProperty(PROP_TENANT_PUB_KEY_FILE_NAME_APPENDER, generatePublicCertId());
-            registry.put(RegistryResources.SecurityManagement.TENANT_PUBKEY_RESOURCE, pubKeyResource);
-
-            // Associate the public key with the keystore.
-            registry.addAssociation(RegistryResources.SecurityManagement.KEY_STORES + "/" + keyStoreName,
-                    RegistryResources.SecurityManagement.TENANT_PUBKEY_RESOURCE, ASSOCIATION_TENANT_KS_PUB_KEY);
-        } catch (RegistryException | CertificateEncodingException e) {
-            String msg = "Error when writing the keystore public cert to registry for keystore: " + keyStoreName;
-            throw new SecurityException(msg, e);
-        }
-    }
-
-    /**
-     * Generates an ID for the public certificate, which is used as a file name suffix for the certificate.
-     * e.g. If keystore name is 'example-com.jks', public cert name will be 'example-com-343743.cert'.
-     *
-     * @return generated id to be used as a file name appender.
-     */
-    private String generatePublicCertId() {
-
-        String uuid = UUIDGenerator.getUUID();
-        return uuid.substring(uuid.length() - 6, uuid.length() - 1);
-    }
-
-    /**
-     * Delete the key store from the registry.
+     * Delete the given key store.
      *
      * @param keyStoreName  Name of the key store.
      * @throws SecurityException  If an error occurs while deleting the key store.
@@ -282,17 +236,8 @@ public class KeyStoreManager {
         if (KeyStoreUtil.isTrustStore(keyStoreName)) {
             throw new SecurityException("Not allowed to delete the trust store : " + keyStoreName);
         }
-        String path = RegistryResources.SecurityManagement.KEY_STORES + "/" + keyStoreName;
-        try {
-            org.wso2.carbon.registry.api.Association[] assocs = registry.getAllAssociations(path);
-            if (assocs.length > 0) {
-                throw new SecurityException("Key store : " + keyStoreName + " is already in use and can't be deleted");
-            }
-            registry.delete(path);
-            deleteKeyStoreFromCache(keyStoreName);
-        } catch (org.wso2.carbon.registry.api.RegistryException e) {
-            throw new SecurityException("Error deleting key store : " + keyStoreName, e);
-        }
+        registryKeyStorePersistenceManager.deleteKeyStore(keyStoreName, tenantId);
+        deleteKeyStoreFromCache(keyStoreName);
     }
 
     /**
@@ -329,58 +274,11 @@ public class KeyStoreManager {
     public KeyStoreMetadata[] getKeyStoresMetadata(boolean isSuperTenant) throws SecurityException {
 
         CarbonUtils.checkSecurity();
-        List<KeyStoreMetadata> metadataList = new ArrayList<>();
-
-        try {
-            if (!registry.resourceExists(RegistryResources.SecurityManagement.KEY_STORES)) {
-                return new KeyStoreMetadata[0];
-            }
-            Collection keyStoreCollection = (Collection) registry.get(RegistryResources.SecurityManagement.KEY_STORES);
-            String[] keyStoreFullnames = keyStoreCollection.getChildren();
-
-            for (String keyStoreFullname : keyStoreFullnames) {
-                if (RegistryResources.SecurityManagement.PRIMARY_KEYSTORE_PHANTOM_RESOURCE.equals(keyStoreFullname)) {
-                    continue;
-                }
-                metadataList.add(getKeyStoreMetadata(keyStoreFullname, isSuperTenant));
-            }
-            if (isSuperTenant) {
-                metadataList.add(getPrimaryKeyStoreMetadata());
-            }
-            return metadataList.toArray(new KeyStoreMetadata[0]);
-        } catch (RegistryException e) {
-            String msg = "Error when getting keyStore metadata.";
-            throw new SecurityException(msg, e);
+        List<KeyStoreMetadata> metadataList = registryKeyStorePersistenceManager.listKeyStores(tenantId);
+        if (isSuperTenant) {
+            metadataList.add(getPrimaryKeyStoreMetadata());
         }
-    }
-
-    private KeyStoreMetadata getKeyStoreMetadata(String keyStoreFullname, boolean isSuperTenant)
-            throws RegistryException {
-
-        Resource keyStoreResource = registry.get(keyStoreFullname);
-        int lastIndex = keyStoreFullname.lastIndexOf("/");
-        String name = keyStoreFullname.substring(lastIndex + 1);
-        String type = keyStoreResource.getProperty(RegistryResources.SecurityManagement.PROP_TYPE);
-        String provider = keyStoreResource.getProperty(RegistryResources.SecurityManagement.PROP_PROVIDER);
-        String alias = keyStoreResource.getProperty(RegistryResources.SecurityManagement.PROP_PRIVATE_KEY_ALIAS);
-
-        KeyStoreMetadata keyStoreMetadata = new KeyStoreMetadata();
-        keyStoreMetadata.setKeyStoreName(name);
-        keyStoreMetadata.setKeyStoreType(type);
-        keyStoreMetadata.setProvider(provider);
-        keyStoreMetadata.setPrivateStore(alias != null);
-
-        if (!isSuperTenant) {
-            org.wso2.carbon.registry.api.Association[] associations =
-                    registry.getAssociations(keyStoreFullname, ASSOCIATION_TENANT_KS_PUB_KEY);
-
-            if (associations != null && associations.length > 0) {
-                Resource pubKeyResource = registry.get(associations[0].getDestinationPath());
-                keyStoreMetadata.setPublicCertId(pubKeyResource.getProperty(PROP_TENANT_PUB_KEY_FILE_NAME_APPENDER));
-                keyStoreMetadata.setPublicCert((byte[]) pubKeyResource.getContent());
-            }
-        }
-        return keyStoreMetadata;
+        return metadataList.toArray(new KeyStoreMetadata[0]);
     }
 
     private KeyStoreMetadata getPrimaryKeyStoreMetadata() {
@@ -468,7 +366,9 @@ public class KeyStoreManager {
      * @param resource key store resource
      * @return password of the key store
      * @throws Exception Error when reading the registry resource of decrypting the password
+     * @deprecated Use KeyStoreRegistryPersistenceManager#gePrivateKeyPassword(String) instead.
      */
+    @Deprecated
     public String getPassword(org.wso2.carbon.registry.core.Resource resource) throws Exception {
         CryptoUtil cryptoUtil = CryptoUtil.getDefaultCryptoUtil();
         String encryptedPassword = resource
@@ -487,20 +387,7 @@ public class KeyStoreManager {
      */
     public String getKeyStorePassword(String keyStoreName) throws Exception {
 
-        String path = RegistryResources.SecurityManagement.KEY_STORES + "/" + keyStoreName;
-        if (registry.resourceExists(path)) {
-            Resource resource = registry.get(path);
-            CryptoUtil cryptoUtil = CryptoUtil.getDefaultCryptoUtil();
-            String encryptedPassword = resource
-                    .getProperty(RegistryResources.SecurityManagement.PROP_PASSWORD);
-            if(encryptedPassword != null){
-                return new String(cryptoUtil.base64DecodeAndDecrypt(encryptedPassword));
-            } else {
-                throw new SecurityException("Key Store Password of " + keyStoreName + " does not exist.");                
-            }
-        } else {
-            throw new SecurityException("Key Store with a name : " + keyStoreName + " does not exist.");
-        }
+        return String.valueOf(registryKeyStorePersistenceManager.getKeyStorePassword(keyStoreName, tenantId));
     }
 
     /**
@@ -560,24 +447,8 @@ public class KeyStoreManager {
 
     private void updateTenantKeyStore(String keyStoreName, KeyStore keyStore) {
 
-        String path = RegistryResources.SecurityManagement.KEY_STORES + "/" + keyStoreName;
-        CryptoUtil cryptoUtil = CryptoUtil.getDefaultCryptoUtil();
-        try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
-            Resource resource = registry.get(path);
-            String encryptedPassword = resource
-                    .getProperty(RegistryResources.SecurityManagement.PROP_PASSWORD);
-            String password = new String(cryptoUtil.base64DecodeAndDecrypt(encryptedPassword));
-            keyStore.store(outputStream, password.toCharArray());
-            outputStream.flush();
-            outputStream.close();
-            resource.setContent(outputStream.toByteArray());
-            registry.put(path, resource);
-            resource.discard();
-            updateTenantKeyStoreCache(keyStoreName, new KeyStoreBean(keyStore, new Date()));
-        } catch (IOException | CryptoException | KeyStoreException | NoSuchAlgorithmException | CertificateException |
-                 RegistryException e) {
-            throw new SecurityException("Error updating tenanted key store : " + keyStoreName, e);
-        }
+        registryKeyStorePersistenceManager.updateKeyStore(keyStoreName, keyStore, tenantId);
+        updateTenantKeyStoreCache(keyStoreName, new KeyStoreBean(keyStore, new Date()));
     }
 
     /**
@@ -616,7 +487,7 @@ public class KeyStoreManager {
     }
 
     /**
-     * Load the requested tenant keystore from registry.
+     * Load the requested tenant keystore.
      *
      * @param keyStoreName  Name of the Tenant KeyStore.
      * @return Key store object.
@@ -631,26 +502,11 @@ public class KeyStoreManager {
             return tenantKeyStores.get(keyStoreName).getKeyStore();
         }
 
-        String path = RegistryResources.SecurityManagement.KEY_STORES + "/" + keyStoreName;
-        if (registry.resourceExists(path)) {
-            Resource resource = registry.get(path);
-            byte[] bytes = (byte[]) resource.getContent();
-            KeyStore keyStore = KeystoreUtils.getKeystoreInstance(resource
-                    .getProperty(RegistryResources.SecurityManagement.PROP_TYPE));
-            CryptoUtil cryptoUtil = CryptoUtil.getDefaultCryptoUtil();
-            String encryptedPassword = resource
-                    .getProperty(RegistryResources.SecurityManagement.PROP_PASSWORD);
-            String password = new String(cryptoUtil.base64DecodeAndDecrypt(encryptedPassword));
-            ByteArrayInputStream stream = new ByteArrayInputStream(bytes);
-            keyStore.load(stream, password.toCharArray());
-            KeyStoreBean keyStoreBean = new KeyStoreBean(keyStore, resource.getLastModified());
-            resource.discard();
-
-            updateTenantKeyStoreCache(keyStoreName, keyStoreBean);
-            return keyStore;
-        } else {
-            throw new SecurityException("Key Store with a name : " + keyStoreName + " does not exist.");
-        }
+        KeyStore keyStore = registryKeyStorePersistenceManager.getKeyStore(keyStoreName, tenantId);
+        KeyStoreBean keyStoreBean = new KeyStoreBean(keyStore,
+                registryKeyStorePersistenceManager.getKeyStoreLastModifiedDate(keyStoreName, tenantId));
+        updateTenantKeyStoreCache(keyStoreName, keyStoreBean);
+        return keyStore;
     }
 
     /**
@@ -825,40 +681,18 @@ public class KeyStoreManager {
      */
     private PrivateKey getTenantPrivateKey(String keyStoreName, String alias) throws Exception {
 
+
         if (log.isDebugEnabled()) {
             log.debug("Loading private key from tenant key store : " + keyStoreName + " alias: " + alias);
         }
-        String path = RegistryResources.SecurityManagement.KEY_STORES + "/" + keyStoreName;
-        Resource resource;
-        KeyStore keyStore;
-
-        if (registry.resourceExists(path)) {
-            resource = registry.get(path);
-        } else {
-            throw new SecurityException("Given Key store is not available in registry : " + keyStoreName);
+        char[] privateKeyPasswordChar = new char[0];
+        try {
+            KeyStore keyStore = getTenantKeyStore(keyStoreName);
+            privateKeyPasswordChar = registryKeyStorePersistenceManager.getPrivateKeyPassword(keyStoreName, tenantId);
+            return (PrivateKey) keyStore.getKey(alias, privateKeyPasswordChar);
+        } finally {
+            Arrays.fill(privateKeyPasswordChar, '\0');
         }
-
-        CryptoUtil cryptoUtil = CryptoUtil.getDefaultCryptoUtil();
-        String encryptedPassword = resource
-                .getProperty(RegistryResources.SecurityManagement.PROP_PRIVATE_KEY_PASS);
-        String privateKeyPasswd = new String(cryptoUtil.base64DecodeAndDecrypt(encryptedPassword));
-
-        if (isCachedTenantKeyStoreValid(keyStoreName)) {
-            keyStore = tenantKeyStores.get(keyStoreName).getKeyStore();
-        } else {
-            byte[] bytes = (byte[]) resource.getContent();
-            String keyStorePassword = new String(cryptoUtil.base64DecodeAndDecrypt(resource.getProperty(
-                    RegistryResources.SecurityManagement.PROP_PASSWORD)));
-            keyStore = KeystoreUtils.getKeystoreInstance(resource
-                    .getProperty(RegistryResources.SecurityManagement.PROP_TYPE));
-            ByteArrayInputStream stream = new ByteArrayInputStream(bytes);
-            keyStore.load(stream, keyStorePassword.toCharArray());
-
-            KeyStoreBean keyStoreBean = new KeyStoreBean(keyStore, resource.getLastModified());
-            updateTenantKeyStoreCache(keyStoreName, keyStoreBean);
-        }
-
-        return (PrivateKey) keyStore.getKey(alias, privateKeyPasswd.toCharArray());
     }
 
     /**
@@ -965,30 +799,14 @@ public class KeyStoreManager {
 
     private boolean isCachedTenantKeyStoreValid(String keyStoreName) {
 
-        String path = RegistryResources.SecurityManagement.KEY_STORES + "/" + keyStoreName;
-        boolean cachedKeyStoreValid = false;
-        try {
-            if (tenantKeyStores.containsKey(keyStoreName)) {
-                Resource metaDataResource = registry.get(path);
-                KeyStoreBean keyStoreBean = tenantKeyStores.get(keyStoreName);
-                if (keyStoreBean.getLastModifiedDate().equals(metaDataResource.getLastModified())) {
-                    cachedKeyStoreValid = true;
-                }
-            }
-        } catch (org.wso2.carbon.registry.api.RegistryException e) {
-            String errorMsg = "Error reading key store meta data from registry.";
-            if (e instanceof ResourceNotFoundException) {
-                if (log.isDebugEnabled()) {
-                    log.debug(errorMsg, e);
-                }
-                return false;
-            }
-            log.error(errorMsg, e);
-            throw new SecurityException(errorMsg, e);
+        if (tenantKeyStores.containsKey(keyStoreName)) {
+            Date keyStoreLastModifiedDateFromStorage =
+                    registryKeyStorePersistenceManager.getKeyStoreLastModifiedDate(keyStoreName, tenantId);
+            KeyStoreBean keyStoreBean = tenantKeyStores.get(keyStoreName);
+            return keyStoreBean.getLastModifiedDate().equals(keyStoreLastModifiedDateFromStorage);
         }
-        return cachedKeyStoreValid;
+        return false;
     }
-
     private void deleteKeyStoreFromCache(String keyStoreName) {
 
         tenantKeyStores.remove(keyStoreName);

--- a/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/util/KeyStoreUtil.java
+++ b/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/util/KeyStoreUtil.java
@@ -32,10 +32,12 @@ import org.wso2.securevault.commons.MiscellaneousUtil;
 
 import java.io.File;
 import java.security.KeyStore;
+import java.security.KeyStoreException;
 import java.security.cert.Certificate;
 import java.util.Arrays;
 import java.util.Enumeration;
 import java.util.Iterator;
+
 import javax.xml.namespace.QName;
 
 public class KeyStoreUtil {
@@ -46,7 +48,7 @@ public class KeyStoreUtil {
      * @param store - keyStore
      * @return
      */
-    public static String getPrivateKeyAlias(KeyStore store) throws Exception {
+    public static String getPrivateKeyAlias(KeyStore store) throws KeyStoreException {
         String alias = null;
         Enumeration<String> enums = store.aliases();
         while(enums.hasMoreElements()){

--- a/core/org.wso2.carbon.core/src/test/java/org/wso2/carbon/core/util/KeyStoreManagerTest.java
+++ b/core/org.wso2.carbon.core/src/test/java/org/wso2/carbon/core/util/KeyStoreManagerTest.java
@@ -25,6 +25,7 @@ import org.wso2.carbon.base.CarbonBaseConstants;
 import org.wso2.carbon.base.MultitenantConstants;
 import org.wso2.carbon.base.ServerConfiguration;
 import org.wso2.carbon.core.RegistryResources;
+import org.wso2.carbon.core.internal.CarbonCoreDataHolder;
 import org.wso2.carbon.registry.core.Association;
 import org.wso2.carbon.registry.core.Resource;
 import org.wso2.carbon.registry.core.exceptions.RegistryException;
@@ -79,6 +80,7 @@ public class KeyStoreManagerTest {
         System.setProperty(CarbonBaseConstants.CARBON_HOME,
                 Paths.get(System.getProperty("user.dir"), "src", "test", "resources").toString());
 
+        CarbonCoreDataHolder.getInstance().setRegistryService(this.registryService);
         when(this.registryService.getGovernanceSystemRegistry(anyInt())).thenReturn(this.registry);
         keyStoreManager = KeyStoreManager.getInstance(
                 MultitenantConstants.SUPER_TENANT_ID, serverConfiguration, registryService);
@@ -89,11 +91,8 @@ public class KeyStoreManagerTest {
     public void testGetPrimaryKeyStore() throws Exception {
 
         try (MockedStatic<ServerConfiguration> serverConfiguration = mockStatic(ServerConfiguration.class);
-             MockedStatic<CryptoUtil>cryptoUtil = mockStatic(CryptoUtil.class);
              MockedStatic<KeyStoreManager> keyStoreManager = mockStatic(KeyStoreManager.class);
              MockedStatic<KeystoreUtils> keystoreUtils = mockStatic(KeystoreUtils.class)) {
-
-            cryptoUtil.when(CryptoUtil::lookupRegistryService).thenReturn(this.registryService);
 
             keystoreUtils.when(() -> KeystoreUtils.getKeystoreInstance(anyString())).thenReturn(this.keyStore);
 
@@ -117,11 +116,8 @@ public class KeyStoreManagerTest {
     public void testGetTrustStore() throws Exception {
 
         try (MockedStatic<ServerConfiguration> serverConfiguration = mockStatic(ServerConfiguration.class);
-             MockedStatic<CryptoUtil>cryptoUtil = mockStatic(CryptoUtil.class);
              MockedStatic<KeyStoreManager> keyStoreManager = mockStatic(KeyStoreManager.class);
              MockedStatic<KeystoreUtils> keystoreUtils = mockStatic(KeystoreUtils.class)) {
-
-            cryptoUtil.when(CryptoUtil::lookupRegistryService).thenReturn(this.registryService);
 
             keystoreUtils.when(() -> KeystoreUtils.getKeystoreInstance(anyString())).thenReturn(this.keyStore);
 
@@ -150,8 +146,6 @@ public class KeyStoreManagerTest {
              MockedStatic<KeystoreUtils> keystoreUtils = mockStatic(KeystoreUtils.class);
              MockedStatic<KeyStoreUtil> keyStoreUtil = mockStatic(KeyStoreUtil.class)) {
 
-            cryptoUtil.when(CryptoUtil::lookupRegistryService).thenReturn(this.registryService);
-
             keyStoreManager.when(() -> KeyStoreManager.getInstance(anyInt())).thenReturn(this.keyStoreManager);
 
             keyStoreUtil.when(() -> KeyStoreUtil.isPrimaryStore(any())).thenReturn(false);
@@ -166,8 +160,8 @@ public class KeyStoreManagerTest {
             cryptoUtil.when(CryptoUtil::getDefaultCryptoUtil).thenReturn(this.cryptoUtil);
             when(this.cryptoUtil.encryptAndBase64Encode(any())).thenReturn("encryptedPassword");
 
-            this.keyStoreManager.addKeyStore(keyStoreContent, "new_keystore.jks", KEYSTORE_PASSWORD,
-                    " ", KEYSTORE_TYPE, KEYSTORE_PASSWORD);
+            this.keyStoreManager.addKeyStore(keyStoreContent, "new_keystore.jks",
+                    KEYSTORE_PASSWORD.toCharArray(), " ", KEYSTORE_TYPE, KEYSTORE_PASSWORD.toCharArray());
         }
     }
 


### PR DESCRIPTION
## Purpose
Introduce KeyStore Persistence Manager Interface.
- addKeystore
- getKeyStore
- listKeyStores
- updateKeyStore
- deleteKeyStore
- getKeyStoreLastModifiedDate
- getKeyStorePassword
- getPrivateKeyPassword


Introduce KeyStore Registry Persistence Manager implementations

Part of: https://github.com/wso2/product-is/issues/21206
Previously Reviewed PR: https://github.com/wso2/carbon-kernel/pull/4109