### PR TITLE
Bump apache commons io version from 2.11.0.wso2v1 to 2.17.0.wso2v1

### DIFF
--- a/distribution/product/modules/distribution/LICENSE.txt
+++ b/distribution/product/modules/distribution/LICENSE.txt
@@ -135,7 +135,7 @@ org.wso2.carbon.core.common_4.9.0.jar                                           
 org.eclipse.equinox.frameworkadmin_2.0.300.v20160504-1450.jar                                       bundle         epl1
 org.wso2.carbon.queuing_4.9.0.jar                                                                   bundle         apache2
 commons-lang_2.6.0.wso2v1.jar                                                                       bundle         apache2
-commons-io_2.11.0.wso2v1.jar                                                                        bundle         apache2
+commons-io_2.17.0.wso2v1.jar                                                                        bundle         apache2
 org.wso2.carbon.securevault_4.9.0.jar                                                               bundle         apache2
 tomcat-catalina-ha_9.0.58.wso2v1.jar                                                                bundle         apache2
 org.wso2.carbon.server.admin_4.9.0.jar                                                              bundle         apache2

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -480,7 +480,7 @@
         <orbit.version.poi.ooxml>5.2.3.wso2v1</orbit.version.poi.ooxml>
         <orbit.version.commons.lang>2.6.0.wso2v1</orbit.version.commons.lang>
         <orbit.version.commons.collection>3.2.2.wso2v1</orbit.version.commons.collection>
-        <orbit.version.commons.io>2.11.0.wso2v1</orbit.version.commons.io>
+        <orbit.version.commons.io>2.17.0.wso2v1</orbit.version.commons.io>
         <orbit.version.smack>3.0.4.wso2v1</orbit.version.smack>
         <orbit.version.apacheds>1.5.7-wso2v1</orbit.version.apacheds>
         <orbit.version.geronimo-jms_1.1_spec>1.1.1.wso2v1</orbit.version.geronimo-jms_1.1_spec>


### PR DESCRIPTION
## Purpose
> Bump apache commons-io version

The apache commons-io orbit is updated to vulnerability fixed version https://github.com/wso2/orbit/tree/master/commons-io/2.17.0.wso2v1. Hence we can bump to the latest orbit released version in order to avoid security issues.