### PR TITLE
Fix filtering service principal accounts

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/LDAPConstants.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/LDAPConstants.java
@@ -112,4 +112,6 @@ public class LDAPConstants {
      */
     public static final String DEFAULT_LDAP_TIME_FORMATS_PATTERN = "[uuuuMMddHHmmss[,SSS][.SSS]X]" +
             "[uuuuMMddHHmmss[,SS][.SS]X][uuuuMMddHHmm[,S][.S]X]";
+
+    public static final String LIST_SERVICE_PRINCIPAL_ENTITIES = "ListServicePrincipalEntities";
 }

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/UniqueIDReadOnlyLDAPUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/UniqueIDReadOnlyLDAPUserStoreManager.java
@@ -407,6 +407,7 @@ public class UniqueIDReadOnlyLDAPUserStoreManager extends ReadOnlyLDAPUserStoreM
         List<String> results = new ArrayList<>();
         String searchFilter;
         String userPropertyName = realmConfig.getUserStoreProperty(LDAPConstants.USER_NAME_ATTRIBUTE);
+        String userIdProperty = realmConfig.getUserStoreProperty(LDAPConstants.USER_ID_ATTRIBUTE);
         searchFilter = getSearchFilter(loginIdentifiers);
 
         DirContext dirContext = this.connectionSource.getContext();
@@ -416,7 +417,7 @@ public class UniqueIDReadOnlyLDAPUserStoreManager extends ReadOnlyLDAPUserStoreM
         if (debug) {
             log.debug("Listing users with SearchFilter: " + searchFilter);
         }
-        String[] returnedAttributes = new String[]{userPropertyName, serviceNameAttribute};
+        String[] returnedAttributes = new String[]{userPropertyName, serviceNameAttribute, userIdProperty};
         try {
             String searchBases = realmConfig.getUserStoreProperty(LDAPConstants.USER_SEARCH_BASE);
             String[] searchBaseArray = searchBases.split("#");
@@ -451,22 +452,36 @@ public class UniqueIDReadOnlyLDAPUserStoreManager extends ReadOnlyLDAPUserStoreM
                             }
                         }
                         String propertyValue = attrBuffer.toString();
+                        // Length needs to be more than userAttributeSeparator.length() for a valid
+                        // attribute, since we attach userAttributeSeparator.
+                        // attach userAttributeSeparator.
+                        if (StringUtils.isBlank(propertyValue)
+                                || propertyValue.trim().length() <= userAttributeSeparator.length()) {
+                            continue;
+                        }
                         Attribute serviceNameObject = attributes.get(serviceNameAttribute);
                         String serviceNameAttributeValue = null;
                         if (serviceNameObject != null) {
                             serviceNameAttributeValue = (String) serviceNameObject.get();
                         }
-                        // Length needs to be more than userAttributeSeparator.length() for a valid
-                        // attribute, since we
-                        // attach userAttributeSeparator.
-                        if (propertyValue != null && propertyValue.trim().length() > userAttributeSeparator.length()) {
-                            if (LDAPConstants.SERVER_PRINCIPAL_ATTRIBUTE_VALUE.equals(serviceNameAttributeValue)) {
-                                continue;
-                            }
-                            propertyValue = propertyValue
-                                    .substring(0, propertyValue.length() - userAttributeSeparator.length());
-                            results.add(propertyValue);
+                        Attribute userIdObject = attributes.get(userIdProperty);
+                        Object userIdAttributeValue = null;
+                        if (userIdObject != null) {
+                            userIdAttributeValue = userIdObject.get();
                         }
+
+                        /* Service Principals are not considered as users if the user store property
+                         * 'ListServicePrincipalEntities' is disabled. They are identified by the 'sn'
+                         * attribute. Even if the property is enabled, they are not returned if the user
+                         * id attribute is null.
+                         */
+                        if (LDAPConstants.SERVER_PRINCIPAL_ATTRIBUTE_VALUE.equals(serviceNameAttributeValue)
+                                && (shouldSkipServicePrincipals() || userIdAttributeValue == null)) {
+                            continue;
+                        }
+                        propertyValue = propertyValue
+                                .substring(0, propertyValue.length() - userAttributeSeparator.length());
+                        results.add(propertyValue);
                     }
                 }
             }
@@ -804,23 +819,29 @@ public class UniqueIDReadOnlyLDAPUserStoreManager extends ReadOnlyLDAPUserStoreM
                         log.debug("Result found ..");
                         Attribute userName = sr.getAttributes().get(userNameProperty);
                         Attribute userID = sr.getAttributes().get(userIDProperty);
-
-                        /*
-                         * If this is a service principle, just ignore and
-                         * iterate rest of the array. The entity is a service if
-                         * value of surname is Service
-                         */
                         Attribute attrSurname = sr.getAttributes().get(serviceNameAttribute);
+                        String serviceName = null;
 
                         if (attrSurname != null) {
                             if (log.isDebugEnabled()) {
                                 log.debug(serviceNameAttribute + " : " + attrSurname);
                             }
-                            String serviceName = (String) attrSurname.get();
-                            if (serviceName != null && serviceName
-                                    .equals(LDAPConstants.SERVER_PRINCIPAL_ATTRIBUTE_VALUE)) {
-                                continue;
-                            }
+                            serviceName = (String) attrSurname.get();
+                        }
+                        Attribute userIdObject = sr.getAttributes().get(userIDProperty);
+                        Object userIdAttributeValue = null;
+                        if (userIdObject != null) {
+                            userIdAttributeValue = userIdObject.get();
+                        }
+
+                        /* Service Principals are not considered as users if the user store property
+                         * 'ListServicePrincipalEntities' is disabled. They are identified by the 'sn'
+                         * attribute. Even if the property is enabled, they are not returned if the user
+                         * id attribute is null.
+                         */
+                        if (LDAPConstants.SERVER_PRINCIPAL_ATTRIBUTE_VALUE.equals(serviceName)
+                                && (shouldSkipServicePrincipals() || userIdAttributeValue == null)) {
+                            continue;
                         }
 
                         /*
@@ -1450,22 +1471,36 @@ public class UniqueIDReadOnlyLDAPUserStoreManager extends ReadOnlyLDAPUserStoreM
                             }
                         }
                         String propertyValue = attrBuffer.toString();
+                        // Length needs to be more than userAttributeSeparator.length() for a valid
+                        // attribute, since we
+                        // attach userAttributeSeparator.
+                        if (StringUtils.isBlank(propertyValue)
+                                || propertyValue.trim().length() <= userAttributeSeparator.length()) {
+                            continue;
+                        }
                         Attribute serviceNameObject = attributes.get(serviceNameAttribute);
                         String serviceNameAttributeValue = null;
                         if (serviceNameObject != null) {
                             serviceNameAttributeValue = (String) serviceNameObject.get();
                         }
-                        // Length needs to be more than userAttributeSeparator.length() for a valid
-                        // attribute, since we
-                        // attach userAttributeSeparator.
-                        if (propertyValue != null && propertyValue.trim().length() > userAttributeSeparator.length()) {
-                            if (LDAPConstants.SERVER_PRINCIPAL_ATTRIBUTE_VALUE.equals(serviceNameAttributeValue)) {
-                                continue;
-                            }
-                            propertyValue = propertyValue
-                                    .substring(0, propertyValue.length() - userAttributeSeparator.length());
-                            values.add(propertyValue);
+                        Attribute userIdObject = attributes.get(userIDProperty);
+                        Object userIdAttributeValue = null;
+                        if (userIdObject != null) {
+                            userIdAttributeValue = userIdObject.get();
                         }
+
+                        /* Service Principals are not considered as users if the user store property
+                         * 'ListServicePrincipalEntities' is disabled. They are identified by the 'sn'
+                         * attribute. Even if the property is enabled, they are not returned if the user
+                         * id attribute is null.
+                         */
+                        if (LDAPConstants.SERVER_PRINCIPAL_ATTRIBUTE_VALUE.equals(serviceNameAttributeValue)
+                                && (shouldSkipServicePrincipals() || userIdAttributeValue == null)) {
+                            continue;
+                        }
+                        propertyValue = propertyValue
+                                .substring(0, propertyValue.length() - userAttributeSeparator.length());
+                        values.add(propertyValue);
                     }
                 }
             }
@@ -3399,36 +3434,42 @@ public class UniqueIDReadOnlyLDAPUserStoreManager extends ReadOnlyLDAPUserStoreM
                     }
                 }
                 String userNamePropertyValue = attrBuffer.toString();
+                /* Length needs to be more than userAttributeSeparator.length() for a valid attribute,
+                since we attach userAttributeSeparator. */
+                if (userNamePropertyValue.trim().length() <= userAttributeSeparator.length()) {
+                    continue;
+                }
                 Attribute serviceNameObject = attributes.get(returnedAttributes.get(1));
                 String serviceNameAttributeValue = null;
                 if (serviceNameObject != null) {
                     serviceNameAttributeValue = (String) serviceNameObject.get();
                 }
-                /* Length needs to be more than userAttributeSeparator.length() for a valid attribute,
-                since we attach userAttributeSeparator. */
-                if (userNamePropertyValue.trim().length() > userAttributeSeparator.length()) {
-                    if (LDAPConstants.SERVER_PRINCIPAL_ATTRIBUTE_VALUE.equals(serviceNameAttributeValue)) {
-                        continue;
-                    }
-                    userNamePropertyValue = userNamePropertyValue.substring(0, userNamePropertyValue.length() -
-                            userAttributeSeparator.length());
-
-                    Attribute userIdObject =
-                            attributes.get(realmConfig.getUserStoreProperty(LDAPConstants.USER_ID_ATTRIBUTE));
-                    String userIdAttributeValue = null;
-                    if (userIdObject != null) {
-                        userIdAttributeValue = resolveLdapAttributeValue(userIdObject.get());
-                    }
-
-                    String domain = this.getRealmConfiguration()
-                            .getUserStoreProperty(UserCoreConstants.RealmConfig.PROPERTY_DOMAIN_NAME);
-
-                    User user = getUser(userIdAttributeValue, userNamePropertyValue);
-                    user.setDisplayName(null);
-                    user.setUserStoreDomain(domain);
-                    user.setTenantDomain(getTenantDomain(tenantId));
-                    finalUserList.add(user);
+                String userIdProperty = realmConfig.getUserStoreProperty(LDAPConstants.USER_ID_ATTRIBUTE);
+                Attribute userIdObject = attributes.get(userIdProperty);
+                String userIdAttributeValue = null;
+                if (userIdObject != null) {
+                    userIdAttributeValue = resolveLdapAttributeValue(userIdObject.get());
                 }
+                /* Service Principals are not considered as users if the user store property
+                 * 'ListServicePrincipalEntities' is disabled. They are identified by the 'sn'
+                 * attribute. Even if the property is enabled, they are not returned if the user
+                 * id attribute is null.
+                 */
+                if (LDAPConstants.SERVER_PRINCIPAL_ATTRIBUTE_VALUE.equals(serviceNameAttributeValue)
+                        && (shouldSkipServicePrincipals() || StringUtils.isBlank(userIdAttributeValue))) {
+                    continue;
+                }
+                userNamePropertyValue = userNamePropertyValue.substring(0, userNamePropertyValue.length() -
+                        userAttributeSeparator.length());
+
+                String domain = this.getRealmConfiguration()
+                        .getUserStoreProperty(UserCoreConstants.RealmConfig.PROPERTY_DOMAIN_NAME);
+
+                User user = getUser(userIdAttributeValue, userNamePropertyValue);
+                user.setDisplayName(null);
+                user.setUserStoreDomain(domain);
+                user.setTenantDomain(getTenantDomain(tenantId));
+                finalUserList.add(user);
             }
         } catch (NamingException e) {
             log.error(String.format("Error occurred while getting user list from non group filter %s", e.getMessage()));
@@ -3527,25 +3568,26 @@ public class UniqueIDReadOnlyLDAPUserStoreManager extends ReadOnlyLDAPUserStoreM
                 if (searchResult.getAttributes() != null) {
                     Attribute userName = searchResult.getAttributes().
                             get(realmConfig.getUserStoreProperty(LDAPConstants.USER_NAME_ATTRIBUTE));
-                    Attribute userID = searchResult.getAttributes().
-                            get(realmConfig.getUserStoreProperty(LDAPConstants.USER_ID_ATTRIBUTE));
-                    /*
-                     * If this is a service principle, just ignore and
-                     * iterate rest of the array. The entity is a service if
-                     * value of surname is Service.
-                     */
+                    String userIdProperty = realmConfig.getUserStoreProperty(LDAPConstants.USER_ID_ATTRIBUTE);
+                    Attribute userID = searchResult.getAttributes().get(userIdProperty);
                     String serviceNameAttribute = "sn";
+                    String serviceName = null;
                     Attribute attrSurname = searchResult.getAttributes().get(serviceNameAttribute);
-
                     if (attrSurname != null) {
                         if (log.isDebugEnabled()) {
                             log.debug(serviceNameAttribute + " : " + attrSurname);
                         }
-                        String serviceName = (String) attrSurname.get();
-                        if (serviceName != null && serviceName
-                                .equals(LDAPConstants.SERVER_PRINCIPAL_ATTRIBUTE_VALUE)) {
-                            continue;
-                        }
+                        serviceName = (String) attrSurname.get();
+                    }
+
+                    /* Service Principals are not considered as users if the user store property
+                     * 'ListServicePrincipalEntities' is disabled. They are identified by the 'sn'
+                     * attribute. Even if the property is enabled, they are not returned if the user
+                     * id attribute is null.
+                     */
+                    if (LDAPConstants.SERVER_PRINCIPAL_ATTRIBUTE_VALUE.equals(serviceName)
+                            && (shouldSkipServicePrincipals() || userID.get() == null)) {
+                        continue;
                     }
                     String name = null;
                     String displayName = null;

--- a/distribution/kernel/carbon-home/repository/resources/conf/infer.json
+++ b/distribution/kernel/carbon-home/repository/resources/conf/infer.json
@@ -58,7 +58,8 @@
       "user_store.properties.SCIMEnabled": true,
       "user_store.properties.UserRolesCacheEnabled": true,
       "user_store.properties.ConnectionRetryDelay": "2m",
-      "user_store.properties.CaseInsensitiveUsername": true
+      "user_store.properties.CaseInsensitiveUsername": true,
+      "user_store.properties.ListServicePrincipalEntities": false
     },
     "read_only_ldap_unique_id": {
       "user_store.class": "org.wso2.carbon.user.core.ldap.UniqueIDReadOnlyLDAPUserStoreManager",
@@ -90,7 +91,8 @@
       "user_store.properties.GroupIDEnabled": true,
       "user_store.properties.GroupIdAttribute": "entryUUID",
       "user_store.properties.GroupLastModifiedDateAttribute": "modifyTimestamp",
-      "user_store.properties.GroupCreatedDateAttribute": "createTimestamp"
+      "user_store.properties.GroupCreatedDateAttribute": "createTimestamp",
+      "user_store.properties.ListServicePrincipalEntities": false
     },
     "read_write_ldap": {
       "user_store.class": "org.wso2.carbon.user.core.ldap.ReadWriteLDAPUserStoreManager",
@@ -124,7 +126,8 @@
       "user_store.properties.StartTLSEnabled": false,
       "user_store.properties.UserRolesCacheEnabled": true,
       "user_store.properties.ConnectionRetryDelay": "2m",
-      "user_store.properties.CaseInsensitiveUsername": true
+      "user_store.properties.CaseInsensitiveUsername": true,
+      "user_store.properties.ListServicePrincipalEntities": false
     },
     "read_write_ldap_unique_id": {
       "user_store.class": "org.wso2.carbon.user.core.ldap.UniqueIDReadWriteLDAPUserStoreManager",
@@ -164,7 +167,8 @@
       "user_store.properties.GroupIDEnabled": true,
       "user_store.properties.GroupIdAttribute": "entryUUID",
       "user_store.properties.GroupLastModifiedDateAttribute": "modifyTimestamp",
-      "user_store.properties.GroupCreatedDateAttribute": "createTimestamp"
+      "user_store.properties.GroupCreatedDateAttribute": "createTimestamp",
+      "user_store.properties.ListServicePrincipalEntities": false
     },
     "active_directory": {
       "user_store.class": "org.wso2.carbon.user.core.ldap.ActiveDirectoryUserStoreManager",
@@ -203,7 +207,8 @@
       "user_store.properties.SCIMEnabled": false,
       "user_store.properties.UserRolesCacheEnabled": true,
       "user_store.properties.ConnectionRetryDelay": "2m",
-      "user_store.properties.CaseInsensitiveUsername": true
+      "user_store.properties.CaseInsensitiveUsername": true,
+      "user_store.properties.ListServicePrincipalEntities": false
     },
     "active_directory_unique_id": {
       "user_store.class": "org.wso2.carbon.user.core.ldap.UniqueIDActiveDirectoryUserStoreManager",
@@ -250,7 +255,8 @@
       "user_store.properties.GroupIDEnabled": true,
       "user_store.properties.GroupIdAttribute": "objectGUID",
       "user_store.properties.GroupLastModifiedDateAttribute": "whenCreated",
-      "user_store.properties.GroupCreatedDateAttribute": "whenChanged"
+      "user_store.properties.GroupCreatedDateAttribute": "whenChanged",
+      "user_store.properties.ListServicePrincipalEntities": false
     }
   },
   "database.$1.type": {


### PR DESCRIPTION
### Purpose
Fix the issue of users with "Service" as their last name not being listed in LDAP userstores due to service principal account filtering.

### Approach
Introduce a configuration by which the adding or removal of service principals to the final user list is determined

### Related Issue
- https://github.com/wso2/product-is/issues/20566