### PR TITLE
Skip group contains not existing user cases

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/UniqueIDReadOnlyLDAPUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/UniqueIDReadOnlyLDAPUserStoreManager.java
@@ -1158,6 +1158,9 @@ public class UniqueIDReadOnlyLDAPUserStoreManager extends ReadOnlyLDAPUserStoreM
                     String domainName = realmConfig
                             .getUserStoreProperty(UserCoreConstants.RealmConfig.PROPERTY_DOMAIN_NAME);
 
+                    if (StringUtils.isEmpty(id)) {
+                        continue;
+                    }
                     userObject = getUser(id, userName);
                     userObject.setDisplayName(displayName);
                     userObject.setUserStoreDomain(domainName);

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/UniqueIDReadOnlyLDAPUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/UniqueIDReadOnlyLDAPUserStoreManager.java
@@ -1158,7 +1158,7 @@ public class UniqueIDReadOnlyLDAPUserStoreManager extends ReadOnlyLDAPUserStoreM
                     String domainName = realmConfig
                             .getUserStoreProperty(UserCoreConstants.RealmConfig.PROPERTY_DOMAIN_NAME);
 
-                    if (StringUtils.isEmpty(id)) {
+                    if (StringUtils.isEmpty(id) && StringUtils.isEmpty(userName)) {
                         continue;
                     }
                     userObject = getUser(id, userName);


### PR DESCRIPTION
## Purpose

When listing users from a group of LDAP, there can be members as users and groups.
```
Getting user list of role: roleone with filter: *
Searching role: roleone SearchBase: ou=Groups,dc=wso2,dc=org SearchFilter: (&(objectClass=groupOfNames)(cn=roleone))
Found role: cn=roleone,ou=Groups,dc=WSO2,dc=ORG
Found attribute: member value: uid=testuser172,ou=Users,dc=WSO2,dc=ORG
Found attribute: member value: uid=testuser246,ou=Users,dc=WSO2,dc=ORG
Found attribute: member value: cn=roletwo,ou=Groups,dc=WSO2,dc=ORG
```

As we are not supporting nested groups, we have to skip the member attributes which includes as groups.
As user-id of corresponding members are null, we can skip those instead of trying to resolve the user object.