### PR TITLE
Adds new configuration to show legacy role claim when group role separation is enabled

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/UserCoreConstants.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/UserCoreConstants.java
@@ -213,6 +213,8 @@ public class UserCoreConstants {
         // Configuration to enable or disable groups and roles separation improvements.
         public static final String PROPERTY_GROUP_AND_ROLE_SEPARATION_IMPROVEMENTS_ENABLED =
                 "GroupAndRoleSeparationImprovementsEnabled";
+        public static final String PROPERTY_SHOW_ROLE_CLAIM_ON_GROUP_ROLE_SEPARATION =
+                "ShowRoleClaimOnGroupRoleSeparation";
 
         public static final String PROPERTY_CASE_SENSITIVITY = "CaseSensitiveAuthorizationRules";
 

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/UserCoreConstants.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/UserCoreConstants.java
@@ -213,8 +213,8 @@ public class UserCoreConstants {
         // Configuration to enable or disable groups and roles separation improvements.
         public static final String PROPERTY_GROUP_AND_ROLE_SEPARATION_IMPROVEMENTS_ENABLED =
                 "GroupAndRoleSeparationImprovementsEnabled";
-        public static final String PROPERTY_SHOW_ROLE_CLAIM_ON_GROUP_ROLE_SEPARATION =
-                "ShowRoleClaimOnGroupRoleSeparation";
+        public static final String PROPERTY_SHOW_LEGACY_ROLE_CLAIM =
+                "ShowLegacyRoleClaim";
 
         public static final String PROPERTY_CASE_SENSITIVITY = "CaseSensitiveAuthorizationRules";
 

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/util/UserCoreUtil.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/util/UserCoreUtil.java
@@ -1235,4 +1235,16 @@ public final class UserCoreUtil {
                 && Boolean.parseBoolean(realmConfiguration.getAuthorizationManagerProperty(
                 UserCoreConstants.RealmConfig.PROPERTY_GROUP_AND_ROLE_SEPARATION_IMPROVEMENTS_ENABLED));
     }
+
+    /**
+     * Checks whether the role claim should be shown when group role separation improvement is enabled.
+     *
+     * @param realmConfiguration Realm configuration.
+     * @return Whether the role claim should be shown when group role separation improvement is enabled.
+     */
+    public static boolean isShowRoleClaimOnGroupRoleSeparationEnabled(RealmConfiguration realmConfiguration) {
+
+        return Boolean.parseBoolean(realmConfiguration.getAuthorizationManagerProperty(
+                UserCoreConstants.RealmConfig.PROPERTY_SHOW_ROLE_CLAIM_ON_GROUP_ROLE_SEPARATION));
+    }
 }

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/util/UserCoreUtil.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/util/UserCoreUtil.java
@@ -1237,14 +1237,14 @@ public final class UserCoreUtil {
     }
 
     /**
-     * Checks whether the role claim should be shown when group role separation improvement is enabled.
+     * Checks whether the legacy role claim should be shown when group role separation improvement is enabled.
      *
      * @param realmConfiguration Realm configuration.
      * @return Whether the role claim should be shown when group role separation improvement is enabled.
      */
-    public static boolean isShowRoleClaimOnGroupRoleSeparationEnabled(RealmConfiguration realmConfiguration) {
+    public static boolean isShowLegacyRoleClaimOnGroupRoleSeparationEnabled(RealmConfiguration realmConfiguration) {
 
         return Boolean.parseBoolean(realmConfiguration.getAuthorizationManagerProperty(
-                UserCoreConstants.RealmConfig.PROPERTY_SHOW_ROLE_CLAIM_ON_GROUP_ROLE_SEPARATION));
+                UserCoreConstants.RealmConfig.PROPERTY_SHOW_LEGACY_ROLE_CLAIM));
     }
 }

--- a/distribution/kernel/carbon-home/repository/resources/conf/default.json
+++ b/distribution/kernel/carbon-home/repository/resources/conf/default.json
@@ -19,7 +19,7 @@
   "authorization_manager.properties.GetAllRolesOfUserEnabled": "false",
   "authorization_manager.properties.GroupAndRoleSeparationEnabled": "true",
   "authorization_manager.properties.GroupAndRoleSeparationImprovementsEnabled": "true",
-  "authorization_manager.properties.ShowRoleClaimOnGroupRoleSeparation": "false",
+  "authorization_manager.properties.ShowLegacyRoleClaim": "false",
   "realm_manager.data_source": "SHARED_DB",
   "realm_manager.properties.isCascadeDeleteEnabled": true,
   "user_store.properties.ReadGroups": true,

--- a/distribution/kernel/carbon-home/repository/resources/conf/default.json
+++ b/distribution/kernel/carbon-home/repository/resources/conf/default.json
@@ -19,6 +19,7 @@
   "authorization_manager.properties.GetAllRolesOfUserEnabled": "false",
   "authorization_manager.properties.GroupAndRoleSeparationEnabled": "true",
   "authorization_manager.properties.GroupAndRoleSeparationImprovementsEnabled": "true",
+  "authorization_manager.properties.ShowRoleClaimOnGroupRoleSeparation": "false",
   "realm_manager.data_source": "SHARED_DB",
   "realm_manager.properties.isCascadeDeleteEnabled": true,
   "user_store.properties.ReadGroups": true,


### PR DESCRIPTION
## Purpose

Adds the following configuration to show legacy role claim when group role separation is enabled

```
[authorization_manager.properties]
ShowLegacyRoleClaim = false
```

## Related Issue
- https://github.com/wso2/product-is/issues/21830
