### PR TITLE
Introduce KeyStore Persistence Manager Factory implementation

### DIFF
--- a/core/org.wso2.carbon.core/pom.xml
+++ b/core/org.wso2.carbon.core/pom.xml
@@ -229,7 +229,6 @@
                         </Private-Package>
                         <Export-Package>
                             !org.wso2.carbon.core.internal,
-                            !org.wso2.carbon.core.keystore.persistence,
                             org.wso2.carbon.core.*; version="${carbon.kernel.exp.pkg.version}",
                         </Export-Package>
                         <Import-Package>

--- a/core/org.wso2.carbon.utils/pom.xml
+++ b/core/org.wso2.carbon.utils/pom.xml
@@ -256,7 +256,8 @@
                         <Export-Package>
                             !org.wso2.carbon.utils.resolver,
                             org.wso2.carbon,
-                            org.wso2.carbon.keystore.persistence.*;
+                            org.wso2.carbon.keystore.persistence,
+                            org.wso2.carbon.keystore.persistence.model,
                             org.wso2.carbon.utils.*,
                             org.wso2.carbon.context,
                             !org.wso2.carbon.context.internal
@@ -265,6 +266,7 @@
                         <Private-Package>
                             org.wso2.carbon.context.internal,
                             org.wso2.carbon.utils.resolver,
+                            org.wso2.carbon.keystore.persistence.impl,
                         </Private-Package>
                         <Import-Package>
                             !org.wso2.carbon,

--- a/core/org.wso2.carbon.utils/pom.xml
+++ b/core/org.wso2.carbon.utils/pom.xml
@@ -267,6 +267,7 @@
                             org.wso2.carbon.context.internal,
                             org.wso2.carbon.utils.resolver,
                             org.wso2.carbon.keystore.persistence.impl,
+                            org.wso2.carbon.keystore.persistence.constant,
                         </Private-Package>
                         <Import-Package>
                             !org.wso2.carbon,

--- a/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/keystore/persistence/KeyStorePersistenceManagerFactory.java
+++ b/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/keystore/persistence/KeyStorePersistenceManagerFactory.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.keystore.persistence;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.keystore.persistence.impl.RegistryKeyStorePersistenceManager;
+import org.wso2.carbon.utils.CarbonUtils;
+
+/**
+ * Factory class to get the KeyStorePersistenceManager based on the configuration.
+ */
+public class KeyStorePersistenceManagerFactory {
+
+    private static final Log LOG = LogFactory.getLog(KeyStorePersistenceManagerFactory.class);
+    private static final String KEYSTORE_STORAGE_TYPE =
+            CarbonUtils.getServerConfiguration().getFirstProperty("Security.KeyStores.DataStorageType");
+    private static final String REGISTRY = "registry";
+    private static final String HYBRID = "hybrid";
+    private static final String DATABASE = "database";
+
+    private KeyStorePersistenceManagerFactory() {
+
+    }
+
+    public static KeyStorePersistenceManager getKeyStorePersistenceManager() {
+
+        KeyStorePersistenceManager defaultKeyStorePersistenceManager = new RegistryKeyStorePersistenceManager();
+        if (StringUtils.isNotBlank(KEYSTORE_STORAGE_TYPE)) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("KeyStore storage type is set to: " + KEYSTORE_STORAGE_TYPE);
+            }
+            switch (KEYSTORE_STORAGE_TYPE) {
+                case REGISTRY:
+                    return new RegistryKeyStorePersistenceManager();
+                default:
+                    return defaultKeyStorePersistenceManager;
+            }
+        }
+
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("KeyStore storage type is not set. Defaulting to the Default KeyStore Persistence Manager.");
+        }
+        return defaultKeyStorePersistenceManager;
+    }
+}

--- a/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/keystore/persistence/constant/PersistenceManagerConstants.java
+++ b/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/keystore/persistence/constant/PersistenceManagerConstants.java
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-package org.wso2.carbon.keystore.persistence;
+package org.wso2.carbon.keystore.persistence.constant;
 
 /**
  * Constants used in the persistence manager.

--- a/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/keystore/persistence/impl/RegistryKeyStorePersistenceManager.java
+++ b/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/keystore/persistence/impl/RegistryKeyStorePersistenceManager.java
@@ -16,13 +16,14 @@
  * under the License.
  */
 
-package org.wso2.carbon.keystore.persistence;
+package org.wso2.carbon.keystore.persistence.impl;
 
 import org.apache.axiom.om.util.UUIDGenerator;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.context.internal.OSGiDataHolder;
+import org.wso2.carbon.keystore.persistence.KeyStorePersistenceManager;
 import org.wso2.carbon.keystore.persistence.model.KeyStoreModel;
 import org.wso2.carbon.registry.api.Association;
 import org.wso2.carbon.registry.api.Collection;
@@ -37,14 +38,14 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
-import static org.wso2.carbon.keystore.persistence.PersistenceManagerConstants.RegistryResources.KEY_STORES;
-import static org.wso2.carbon.keystore.persistence.PersistenceManagerConstants.RegistryResources.PRIMARY_KEYSTORE_PHANTOM_RESOURCE;
-import static org.wso2.carbon.keystore.persistence.PersistenceManagerConstants.RegistryResources.PROP_PASSWORD;
-import static org.wso2.carbon.keystore.persistence.PersistenceManagerConstants.RegistryResources.PROP_PRIVATE_KEY_ALIAS;
-import static org.wso2.carbon.keystore.persistence.PersistenceManagerConstants.RegistryResources.PROP_PRIVATE_KEY_PASS;
-import static org.wso2.carbon.keystore.persistence.PersistenceManagerConstants.RegistryResources.PROP_PROVIDER;
-import static org.wso2.carbon.keystore.persistence.PersistenceManagerConstants.RegistryResources.PROP_TYPE;
-import static org.wso2.carbon.keystore.persistence.PersistenceManagerConstants.RegistryResources.TENANT_PUBKEY_RESOURCE;
+import static org.wso2.carbon.keystore.persistence.constant.PersistenceManagerConstants.RegistryResources.KEY_STORES;
+import static org.wso2.carbon.keystore.persistence.constant.PersistenceManagerConstants.RegistryResources.PRIMARY_KEYSTORE_PHANTOM_RESOURCE;
+import static org.wso2.carbon.keystore.persistence.constant.PersistenceManagerConstants.RegistryResources.PROP_PASSWORD;
+import static org.wso2.carbon.keystore.persistence.constant.PersistenceManagerConstants.RegistryResources.PROP_PRIVATE_KEY_ALIAS;
+import static org.wso2.carbon.keystore.persistence.constant.PersistenceManagerConstants.RegistryResources.PROP_PRIVATE_KEY_PASS;
+import static org.wso2.carbon.keystore.persistence.constant.PersistenceManagerConstants.RegistryResources.PROP_PROVIDER;
+import static org.wso2.carbon.keystore.persistence.constant.PersistenceManagerConstants.RegistryResources.PROP_TYPE;
+import static org.wso2.carbon.keystore.persistence.constant.PersistenceManagerConstants.RegistryResources.TENANT_PUBKEY_RESOURCE;
 
 /**
  * This implementation handles the keystore storage/persistence related logics in the Registry.


### PR DESCRIPTION
## Purpose

Introduce KeyStore Persistence Manager Factory implementation
Introduce a config to select keystore persistence manager(weather keystore data stores in database or registry). ATM we only have registry implementation. So always use registry as the keystore persistence manager.

```
[keystores]
data_storage_type = "database"
```

- Part of: https://github.com/wso2/product-is/issues/21206


## Details

This pull request involves significant changes to the KeyStore management system in the WSO2 Carbon project. The main focus is on refactoring the KeyStore persistence mechanism to use a factory pattern and updating the relevant imports and usages throughout the codebase.

Key changes include:

### Refactoring KeyStore Persistence

* [`KeyStoreManager.java`](diffhunk://#diff-487286dcf4015c4afee9863f0dfa368ba508c68413e0a8ee9315f93e5cc7d547L31-R32): Replaced `RegistryKeyStorePersistenceManager` with `KeyStorePersistenceManager` and updated the initialization to use `KeyStorePersistenceManagerFactory`. This change affects multiple methods within the class. [[1]](diffhunk://#diff-487286dcf4015c4afee9863f0dfa368ba508c68413e0a8ee9315f93e5cc7d547L31-R32) [[2]](diffhunk://#diff-487286dcf4015c4afee9863f0dfa368ba508c68413e0a8ee9315f93e5cc7d547L77-R78) [[3]](diffhunk://#diff-487286dcf4015c4afee9863f0dfa368ba508c68413e0a8ee9315f93e5cc7d547L102-R103) [[4]](diffhunk://#diff-487286dcf4015c4afee9863f0dfa368ba508c68413e0a8ee9315f93e5cc7d547L256-R257) [[5]](diffhunk://#diff-487286dcf4015c4afee9863f0dfa368ba508c68413e0a8ee9315f93e5cc7d547L276-R277) [[6]](diffhunk://#diff-487286dcf4015c4afee9863f0dfa368ba508c68413e0a8ee9315f93e5cc7d547L315-R316) [[7]](diffhunk://#diff-487286dcf4015c4afee9863f0dfa368ba508c68413e0a8ee9315f93e5cc7d547L437-R438) [[8]](diffhunk://#diff-487286dcf4015c4afee9863f0dfa368ba508c68413e0a8ee9315f93e5cc7d547L507-R508) [[9]](diffhunk://#diff-487286dcf4015c4afee9863f0dfa368ba508c68413e0a8ee9315f93e5cc7d547L567-R568) [[10]](diffhunk://#diff-487286dcf4015c4afee9863f0dfa368ba508c68413e0a8ee9315f93e5cc7d547L577-R578) [[11]](diffhunk://#diff-487286dcf4015c4afee9863f0dfa368ba508c68413e0a8ee9315f93e5cc7d547L768-R769) [[12]](diffhunk://#diff-487286dcf4015c4afee9863f0dfa368ba508c68413e0a8ee9315f93e5cc7d547L882-R883)

### Package and Import Adjustments

* `pom.xml` in `core/org.wso2.carbon.core`: Removed `org.wso2.carbon.core.keystore.persistence` from the export package list.
* `pom.xml` in `core/org.wso2.carbon.utils`: Updated to include new package paths for `keystore.persistence` and its sub-packages. [[1]](diffhunk://#diff-773d71bd3c7d68a7e7cb247171e5c78a4fe6db076d9a2e81f235e482d454b078L259-R260) [[2]](diffhunk://#diff-773d71bd3c7d68a7e7cb247171e5c78a4fe6db076d9a2e81f235e482d454b078R269)

### New and Renamed Files

* [`KeyStorePersistenceManagerFactory.java`](diffhunk://#diff-29c828cb7cf9a6196ff9185b223526635f053ed6391116803ff8999dd2e2399aR1-R63): Introduced a new factory class to provide the appropriate `KeyStorePersistenceManager` based on configuration.
* [`PersistenceManagerConstants.java`](diffhunk://#diff-c672542d5691caf259403e3541b5b6ef681ae6297abaae9f1b21e21a3ca5699bL19-R19): Renamed and moved to a new package `constant`.
* [`RegistryKeyStorePersistenceManager.java`](diffhunk://#diff-d0b0ee8bb94ff8753ccd615fab926017c386f413b15267275a54f5764b9e6546L19-R26): Renamed and moved to a new package `impl`. [[1]](diffhunk://#diff-d0b0ee8bb94ff8753ccd615fab926017c386f413b15267275a54f5764b9e6546L19-R26) [[2]](diffhunk://#diff-d0b0ee8bb94ff8753ccd615fab926017c386f413b15267275a54f5764b9e6546L40-R48)