### PR TITLE
Remove registry usages from KeyStoreUtils class

### DIFF
--- a/core/org.wso2.carbon.core/pom.xml
+++ b/core/org.wso2.carbon.core/pom.xml
@@ -197,6 +197,11 @@
             <scope>test</scope>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.utils</groupId>
+            <artifactId>org.wso2.carbon.database.utils</artifactId>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/core/org.wso2.carbon.core/src/test/java/org/wso2/carbon/core/util/KeyStoreManagerTest.java
+++ b/core/org.wso2.carbon.core/src/test/java/org/wso2/carbon/core/util/KeyStoreManagerTest.java
@@ -31,6 +31,7 @@ import org.wso2.carbon.registry.core.Resource;
 import org.wso2.carbon.registry.core.exceptions.RegistryException;
 import org.wso2.carbon.registry.core.service.RegistryService;
 import org.wso2.carbon.registry.core.session.UserRegistry;
+import org.wso2.carbon.utils.CarbonUtils;
 import org.wso2.carbon.utils.security.KeystoreUtils;
 
 import java.io.File;
@@ -70,6 +71,8 @@ public class KeyStoreManagerTest {
     private Resource resource;
     @Mock
     private CryptoUtil cryptoUtil;
+
+    MockedStatic<CarbonUtils> carbonUtils;
     private KeyStoreManager keyStoreManager;
     private KeyStore keyStore;
 
@@ -79,6 +82,10 @@ public class KeyStoreManagerTest {
         initMocks(this);
         System.setProperty(CarbonBaseConstants.CARBON_HOME,
                 Paths.get(System.getProperty("user.dir"), "src", "test", "resources").toString());
+        carbonUtils = mockStatic(CarbonUtils.class);
+        carbonUtils.when(CarbonUtils::getServerConfiguration).thenReturn(this.serverConfiguration);
+        when(this.serverConfiguration.getFirstProperty("KeyStoreDataPersistenceManager.DataStorageType")).
+                thenReturn("registry");
 
         OSGiDataHolder.getInstance().setRegistryService(this.registryService);
         when(this.registryService.getGovernanceSystemRegistry(anyInt())).thenReturn(this.registry);

--- a/core/org.wso2.carbon.utils/pom.xml
+++ b/core/org.wso2.carbon.utils/pom.xml
@@ -272,9 +272,7 @@
                             org.wso2.carbon.context.internal,
                             org.wso2.carbon.utils.resolver,
                             org.wso2.carbon.keystore.persistence.impl,
-                            org.wso2.carbon.keystore.persistence.dao,
                             org.wso2.carbon.keystore.persistence.constant,
-                            org.wso2.carbon.keystore.persistence.util,
                         </Private-Package>
                         <Import-Package>
                             !org.wso2.carbon,


### PR DESCRIPTION
## Purpose
Remove registry usages from KeyStoreUtils class.
- Part of: https://github.com/wso2/product-is/issues/21206

## Details
This pull request includes several changes to the `KeystoreUtils` class in the `core/org.wso2.carbon.utils` package. The modifications primarily focus on refactoring the code to use the `KeyStorePersistenceManager` for checking the existence of keystores, instead of directly interacting with the registry. This improves the code's maintainability and encapsulates the keystore persistence logic.

Key changes:

* Imports and Initialization:
  * Replaced imports related to registry management with imports for `KeyStorePersistenceManager` and its factory.
  * Introduced a static instance of `KeyStorePersistenceManager` initialized using `KeyStorePersistenceManagerFactory`.

* Method Refactoring:
  * Updated the `getKeyStoreFileType` method to use the new `isKeyStoreExists` method instead of `isFileExistInRegistry`.
  * Refactored the `isFileExistInRegistry` method to `isKeyStoreExists`, which now uses `KeyStorePersistenceManager` for checking keystore existence. Removed the direct registry access code and error handling for registry exceptions.