### PR TITLE
Change the keystore data storage config

### DIFF
--- a/distribution/kernel/carbon-home/repository/resources/conf/default.json
+++ b/distribution/kernel/carbon-home/repository/resources/conf/default.json
@@ -137,7 +137,6 @@
   "keystore.tls.password": "$ref{keystore.primary.password}",
   "keystore.tls.alias": "$ref{keystore.primary.alias}",
   "keystore.tls.key_password": "$ref{keystore.primary.key_password}",
-  "keystores.data_storage_type": "database",
   "truststore.file_name": "client-truststore.p12",
   "truststore.type": "PKCS12",
   "truststore.password": "wso2carbon",
@@ -252,5 +251,6 @@
   "database.registry_db.pool_options.validationInterval" : "30000",
   "database.registry_db.pool_options.defaultAutoCommit" : "true",
   "admin_console.resolve_absolute_urls.enable": true,
-  "keystore_data.datasource": "jdbc/SHARED_DB"
+  "data_storage_type.keystores": "database",
+  "keystore.datasource": "jdbc/SHARED_DB"
 }

--- a/distribution/kernel/carbon-home/repository/resources/conf/templates/repository/conf/carbon.xml.j2
+++ b/distribution/kernel/carbon-home/repository/resources/conf/templates/repository/conf/carbon.xml.j2
@@ -890,9 +890,18 @@
     </UserStore>
 
     <KeyStoreDataPersistenceManager>
-        <!-- Keystore Data Storage Type (database/hybrid)-->
-        <DataStorageType>{{keystores.data_storage_type}}</DataStorageType>
+        <!--
+            This section provide the ability to configure the storage type for the keystores that used to store data in the
+            registry in IS 7.0.0 or earlier.
+
+            Applicable values:
+                - "database" - Data will be store in tables in the specified tables in the identity database.
+                - "hybrid"   - Any new changes stored in "database" and any existing data read from "registry" allowing data to
+                                on-demand migrate.
+                Default value is "database".
+        -->
+        <DataStorageType>{{data_storage_type.keystores}}</DataStorageType>
         <!-- Include a data source name from the set of data sources defined in master-datasources.xml -->
-        <DataSourceName>{{keystore_data.datasource}}</DataSourceName>
+        <DataSourceName>{{keystore.datasource}}</DataSourceName>
     </KeyStoreDataPersistenceManager>
 </Server>


### PR DESCRIPTION
## Purpose
Change the keystore data storage config.

New config:
```
[data_storage_type]
keystores = "registry"
```

- Part of: https://github.com/wso2/product-is/issues/21206

## Details
This pull request includes changes to the configuration files in the `distribution/kernel/carbon-home/repository/resources/conf` directory to update the keystore data storage type and datasource references. The most important changes are as follows:

Configuration updates:

* [`distribution/kernel/carbon-home/repository/resources/conf/default.json`](diffhunk://#diff-d8e932bd3a6146fd335ff6ef844f04a2d0474ce8098b70e3b7a9f2220b5bb389L140): Removed the `keystores.data_storage_type` entry and added `data_storage_type.keystores` to specify the keystore data storage type. Also, updated the `keystore_data.datasource` entry to `keystore.datasource`. [[1]](diffhunk://#diff-d8e932bd3a6146fd335ff6ef844f04a2d0474ce8098b70e3b7a9f2220b5bb389L140) [[2]](diffhunk://#diff-d8e932bd3a6146fd335ff6ef844f04a2d0474ce8098b70e3b7a9f2220b5bb389L255-R255)
* [`distribution/kernel/carbon-home/repository/resources/conf/templates/repository/conf/carbon.xml.j2`](diffhunk://#diff-95cc80afbc283a1a8fbef22d51a0357a69581ae2116a53af6c29e84f1296e3f2L893-R905): Updated the `DataStorageType` and `DataSourceName` entries to use the new configuration keys `data_storage_type.keystores` and `keystore.datasource`. Added comments to explain the applicable values for `DataStorageType`.
