### PR TITLE
Introduce Hybrid KeyStore Persistence Manager implementation

### DIFF
--- a/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/keystore/persistence/KeyStorePersistenceManagerFactory.java
+++ b/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/keystore/persistence/KeyStorePersistenceManagerFactory.java
@@ -18,9 +18,9 @@
 
 package org.wso2.carbon.keystore.persistence;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.keystore.persistence.impl.HybridKeyStorePersistenceManager;
 import org.wso2.carbon.keystore.persistence.impl.JDBCKeyStorePersistenceManager;
 import org.wso2.carbon.keystore.persistence.impl.RegistryKeyStorePersistenceManager;
 import org.wso2.carbon.utils.CarbonUtils;
@@ -43,32 +43,25 @@ public class KeyStorePersistenceManagerFactory {
 
     public static KeyStorePersistenceManager getKeyStorePersistenceManager() {
 
-        KeyStorePersistenceManager defaultKeyStorePersistenceManager = new JDBCKeyStorePersistenceManager();
-        if (StringUtils.isNotBlank(KEYSTORE_STORAGE_TYPE)) {
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("KeyStore storage type is set to: " + KEYSTORE_STORAGE_TYPE);
-            }
-            switch (KEYSTORE_STORAGE_TYPE) {
-                case REGISTRY:
-                    LOG.warn("Registry based KeyStore persistence manager was initialized");
-                    return new RegistryKeyStorePersistenceManager();
-                case DATABASE:
-                    if (LOG.isDebugEnabled()) {
-                        LOG.debug("Database based KeyStore persistence manager was initialized");
-                    }
-                    return defaultKeyStorePersistenceManager;
-                default:
-                    if (LOG.isDebugEnabled()) {
-                        LOG.debug("KeyStore storage type is not properly set. Defaulting to the Default KeyStore " +
-                                "Persistence Manager.");
-                    }
-                    return defaultKeyStorePersistenceManager;
-            }
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("KeyStore storage type is set to: " + KEYSTORE_STORAGE_TYPE);
+        }
+
+        KeyStorePersistenceManager keyStorePersistenceManager;
+        if (REGISTRY.equals(KEYSTORE_STORAGE_TYPE)) {
+            LOG.warn("Registry based KeyStore persistence manager was initialized");
+            keyStorePersistenceManager = new RegistryKeyStorePersistenceManager();
+        } else if (HYBRID.equals(KEYSTORE_STORAGE_TYPE)) {
+            LOG.info("Hybrid KeyStore persistence manager was initialized");
+            keyStorePersistenceManager = new HybridKeyStorePersistenceManager();
+        } else {
+            keyStorePersistenceManager = new JDBCKeyStorePersistenceManager();
         }
 
         if (LOG.isDebugEnabled()) {
-            LOG.debug("KeyStore storage type is not set. Defaulting to the Default KeyStore Persistence Manager.");
+            LOG.debug("KeyStore Persistence Manager initialized with the type: " +
+                    keyStorePersistenceManager.getClass());
         }
-        return defaultKeyStorePersistenceManager;
+        return keyStorePersistenceManager;
     }
 }

--- a/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/keystore/persistence/impl/HybridKeyStorePersistenceManager.java
+++ b/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/keystore/persistence/impl/HybridKeyStorePersistenceManager.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.keystore.persistence.impl;
+
+import org.wso2.carbon.keystore.persistence.KeyStorePersistenceManager;
+import org.wso2.carbon.keystore.persistence.model.KeyStoreModel;
+
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * HybridKeyStorePersistenceManager is a hybrid implementation of KeyStorePersistenceManager. It uses both JDBC and
+ * Registry implementations. All new KeyStores will be added to the database, while existing keystores will be
+ * maintained in the registry.
+ */
+public class HybridKeyStorePersistenceManager implements KeyStorePersistenceManager {
+
+    private final JDBCKeyStorePersistenceManager jdbcKeyStorePersistenceManager =
+            new JDBCKeyStorePersistenceManager();
+    private final RegistryKeyStorePersistenceManager registryKeyStorePersistenceManager =
+            new RegistryKeyStorePersistenceManager();
+
+    @Override
+    public void addKeystore(KeyStoreModel keyStore, int tenantId) throws SecurityException {
+
+        jdbcKeyStorePersistenceManager.addKeystore(keyStore, tenantId);
+    }
+
+    @Override
+    public Optional<KeyStoreModel> getKeyStore(String keyStoreName, int tenantId) throws SecurityException {
+
+        Optional<KeyStoreModel> keyStoreModel = jdbcKeyStorePersistenceManager.getKeyStore(keyStoreName, tenantId);
+        if (!keyStoreModel.isPresent()) {
+            keyStoreModel = registryKeyStorePersistenceManager.getKeyStore(keyStoreName, tenantId);
+        }
+        return keyStoreModel;
+    }
+
+    @Override
+    public boolean isKeyStoreExists(String keyStoreName, int tenantId) throws SecurityException {
+
+        if (jdbcKeyStorePersistenceManager.isKeyStoreExists(keyStoreName, tenantId)) {
+            return true;
+        } else {
+            return registryKeyStorePersistenceManager.isKeyStoreExists(keyStoreName, tenantId);
+        }
+    }
+
+    @Override
+    public List<KeyStoreModel> listKeyStores(int tenantId) throws SecurityException {
+
+        List<KeyStoreModel> keyStoreModels = jdbcKeyStorePersistenceManager.listKeyStores(tenantId);
+        keyStoreModels.addAll(registryKeyStorePersistenceManager.listKeyStores(tenantId));
+        return keyStoreModels;
+    }
+
+    @Override
+    public void updateKeyStore(KeyStoreModel keyStoreModel, int tenantId) throws SecurityException {
+
+        if (jdbcKeyStorePersistenceManager.isKeyStoreExists(keyStoreModel.getName(), tenantId)) {
+            jdbcKeyStorePersistenceManager.updateKeyStore(keyStoreModel, tenantId);
+        } else {
+            registryKeyStorePersistenceManager.updateKeyStore(keyStoreModel, tenantId);
+        }
+    }
+
+    @Override
+    public void deleteKeyStore(String keyStoreName, int tenantId) throws SecurityException {
+
+        if (jdbcKeyStorePersistenceManager.isKeyStoreExists(keyStoreName, tenantId)) {
+            jdbcKeyStorePersistenceManager.deleteKeyStore(keyStoreName, tenantId);
+        } else {
+            registryKeyStorePersistenceManager.deleteKeyStore(keyStoreName, tenantId);
+        }
+    }
+
+    @Override
+    public Date getKeyStoreLastModifiedDate(String keyStoreName, int tenantId) {
+
+        if (jdbcKeyStorePersistenceManager.isKeyStoreExists(keyStoreName, tenantId)) {
+            return jdbcKeyStorePersistenceManager.getKeyStoreLastModifiedDate(keyStoreName, tenantId);
+        } else {
+            return registryKeyStorePersistenceManager.getKeyStoreLastModifiedDate(keyStoreName, tenantId);
+        }
+    }
+
+    @Override
+    public String getEncryptedKeyStorePassword(String keyStoreName, int tenantId) throws SecurityException {
+
+        if (jdbcKeyStorePersistenceManager.isKeyStoreExists(keyStoreName, tenantId)) {
+            return jdbcKeyStorePersistenceManager.getEncryptedKeyStorePassword(keyStoreName, tenantId);
+        } else {
+            return registryKeyStorePersistenceManager.getEncryptedKeyStorePassword(keyStoreName, tenantId);
+        }
+    }
+
+    @Override
+    public String getEncryptedPrivateKeyPassword(String keyStoreName, int tenantId) throws SecurityException {
+
+        if (jdbcKeyStorePersistenceManager.isKeyStoreExists(keyStoreName, tenantId)) {
+            return jdbcKeyStorePersistenceManager.getEncryptedPrivateKeyPassword(keyStoreName, tenantId);
+        } else {
+            return registryKeyStorePersistenceManager.getEncryptedPrivateKeyPassword(keyStoreName, tenantId);
+        }
+    }
+}


### PR DESCRIPTION
## Purpose
HybridKeyStorePersistenceManager is a hybrid implementation of KeyStorePersistenceManager. It uses both JDBC and  Registry implementations. All new KeyStores will be added to the database, while existing keystores will be maintained in the registry.

## Details
This pull request introduces a new hybrid implementation for KeyStore persistence in the `core/org.wso2.carbon.utils` module. The primary change is the addition of the `HybridKeyStorePersistenceManager` class, which combines both JDBC and Registry-based persistence mechanisms. This new implementation aims to enhance flexibility and reliability in KeyStore management.

Key changes include:

### New Hybrid KeyStore Persistence Implementation:
* Added a new class `HybridKeyStorePersistenceManager` that implements `KeyStorePersistenceManager` and combines JDBC and Registry persistence strategies.
* Updated `KeyStorePersistenceManagerFactory` to include the new `HybridKeyStorePersistenceManager` in the `getKeyStorePersistenceManager` method.
* Imported `HybridKeyStorePersistenceManager` in `KeyStorePersistenceManagerFactory`.