### PR TITLE
Fix to add the generated user id claim value with the user creation db request

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
@@ -15916,9 +15916,14 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
                 } else {
                     // If the underlying user store does not support the unique ID generation, then we have to generate
                     // the ID and keep the mapping in our side.
+                    String uniqueId = UUID.randomUUID().toString();
+                    claims.put(UserCoreClaimConstants.USER_ID_CLAIM_URI, uniqueId);
                     doAddUser(userName, credentialObj, externalRoles.toArray(new String[0]), claims, profileName,
                             false);
-                    user = userUniqueIDManger.addUser(userStore.getDomainFreeName(), profileName, this);
+                    user = new User();
+                    user.setUserID(uniqueId);
+                    user.setUsername(userStore.getDomainFreeName());
+                    user.setUserStoreDomain(this.getMyDomainName());
                 }
             } catch (UserStoreException ex) {
                 handleAddUserFailureWithID(ErrorMessages.ERROR_CODE_ERROR_WHILE_ADDING_USER.getCode(),


### PR DESCRIPTION
### Purpose
- https://github.com/wso2/product-is/issues/21891

This pull request to `core/org.wso2.carbon.user.core` includes changes to the `addUserWithID` method to ensure unique user ID generation and proper user object initialization when the underlying user store does not support unique ID generation. The most important changes include generating a unique ID using `UUID`, updating the claims with the generated ID, and initializing the `User` object with the correct attributes.

This pull request introduces a new feature to add a generated user ID claim value with user creation requests for non-unique ID user stores.

Changes to unique ID generation and user object initialization:

* Added generation of a unique ID using `UUID.randomUUID().toString()` and updated the claims with the generated ID. (`AbstractUserStoreManager.java`)
* Modified the `User` object initialization to set the user ID, username, and user store domain when the underlying user store does not support unique ID generation. (`AbstractUserStoreManager.java`)