### PR TITLE
Change the keystore data storage type config to use registry keystore data persistence manager

### DIFF
--- a/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/keystore/persistence/KeyStorePersistenceManagerFactory.java
+++ b/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/keystore/persistence/KeyStorePersistenceManagerFactory.java
@@ -21,7 +21,6 @@ package org.wso2.carbon.keystore.persistence;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.wso2.carbon.keystore.persistence.impl.JDBCKeyStorePersistenceManager;
 import org.wso2.carbon.keystore.persistence.impl.RegistryKeyStorePersistenceManager;
 import org.wso2.carbon.utils.CarbonUtils;
 
@@ -43,7 +42,7 @@ public class KeyStorePersistenceManagerFactory {
 
     public static KeyStorePersistenceManager getKeyStorePersistenceManager() {
 
-        KeyStorePersistenceManager defaultKeyStorePersistenceManager = new JDBCKeyStorePersistenceManager();
+        KeyStorePersistenceManager defaultKeyStorePersistenceManager = new RegistryKeyStorePersistenceManager();
         if (StringUtils.isNotBlank(KEYSTORE_STORAGE_TYPE)) {
             if (LOG.isDebugEnabled()) {
                 LOG.debug("KeyStore storage type is set to: " + KEYSTORE_STORAGE_TYPE);

--- a/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/internal/CarbonUtilsServiceComponent.java
+++ b/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/internal/CarbonUtilsServiceComponent.java
@@ -1,5 +1,6 @@
 package org.wso2.carbon.utils.internal;
 
+import org.apache.commons.lang3.StringUtils;
 import org.osgi.service.component.ComponentContext;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
@@ -25,7 +26,11 @@ public class CarbonUtilsServiceComponent {
         ctx.getBundleContext().registerService(GhostMetaArtifactsLoader.class.getName(), serviceMetaArtifactsLoader, null);
         // Read and set diagnostic logs config.
         CarbonUtils.setDiagnosticLogMode(PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantId());
-        CarbonUtilsDataHolder.getInstance().setDataSource(getKeyStoreDataSource());
+        DataSource dataSource = getKeyStoreDataSource();
+        if (dataSource == null) {
+            throw new RuntimeException("Data source is not available for KeyStore Data Persistence Manager.");
+        }
+        CarbonUtilsDataHolder.getInstance().setDataSource(dataSource);
     }
 
     @Reference(name = "org.wso2.carbon.utils.ConfigurationContextService", cardinality = ReferenceCardinality.MANDATORY,
@@ -42,7 +47,7 @@ public class CarbonUtilsServiceComponent {
 
         String dataSourceName = CarbonUtils.getServerConfiguration().getFirstProperty(
                 "KeyStoreDataPersistenceManager.DataSourceName");
-        if (dataSourceName != null) {
+        if (StringUtils.isNotBlank(dataSourceName)) {
             try {
                 return InitialContext.doLookup(dataSourceName);
             } catch (NamingException e) {

--- a/distribution/kernel/carbon-home/repository/conf/carbon.xml
+++ b/distribution/kernel/carbon-home/repository/conf/carbon.xml
@@ -749,7 +749,7 @@
 
     <KeyStoreDataPersistenceManager>
         <!-- Keystore data storage type-->
-        <DataStorageType>database</DataStorageType>
+        <DataStorageType>registry</DataStorageType>
         <!-- Include a data source name from the set of data sources defined in master-datasources.xml -->
         <DataSourceName>jdbc/SHARED_DB</DataSourceName>
     </KeyStoreDataPersistenceManager>

--- a/distribution/kernel/carbon-home/repository/resources/conf/default.json
+++ b/distribution/kernel/carbon-home/repository/resources/conf/default.json
@@ -251,6 +251,6 @@
   "database.registry_db.pool_options.validationInterval" : "30000",
   "database.registry_db.pool_options.defaultAutoCommit" : "true",
   "admin_console.resolve_absolute_urls.enable": true,
-  "data_storage_type.keystores": "database",
+  "data_storage_type.keystores": "registry",
   "keystore.datasource": "jdbc/SHARED_DB"
 }


### PR DESCRIPTION
## Purpose
Change the default KeyStore data persistence manager to Use Registry Based KeyStore Persistence Manager by changing the below config.

```
[data_storage_type]
keystores = "registry"
```

- Part of: https://github.com/wso2/product-is/issues/21206