### PR TITLE
Prevent db query execution for registry system username in all user stores

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
@@ -13794,6 +13794,10 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
             return null;
         } else {
             if (StringUtils.isEmpty(userID)) {
+                // Return null for the system user to prevent redundant DB queries, as it would return null anyway.
+                if (UserCoreUtil.isRegistrySystemUser(userName)) {
+                    return null;
+                }
                 if (isUniqueUserIdEnabledInUserStore(userStore)) {
                     userID = doGetUserIDFromUserNameWithID(userName);
                     if (StringUtils.isEmpty(userID)) {

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCUserStoreManager.java
@@ -1395,11 +1395,6 @@ public class UniqueIDJDBCUserStoreManager extends JDBCUserStoreManager {
             throw new IllegalArgumentException("userName cannot be null.");
         }
 
-        // Return null for the system user to prevent redundant DB queries, as it would return null anyway.
-        if (UserCoreUtil.isRegistrySystemUser(userName)) {
-            return null;
-        }
-
         Connection dbConnection = null;
         String sqlStmt;
         PreparedStatement prepStmt = null;


### PR DESCRIPTION
## Purpose

This PR fixes the issue of execution of retrieving userId from username query is executed on both JDBC and LDAP Userstores 4-5 times per single authentication with the username as the REGISTRY_SYSTEM_USERNAME constant "wso2.system.user". To preventing db executions this fix checks the given username is the above constant and returns null while preserving the previous behaviour. 

### Related Issue
- https://github.com/wso2/product-is/issues/21365