### PR TITLE
Template databaseProps xml field

### DIFF
--- a/distribution/kernel/carbon-home/repository/resources/conf/templates/repository/conf/datasources/master-datasources.xml.j2
+++ b/distribution/kernel/carbon-home/repository/resources/conf/templates/repository/conf/datasources/master-datasources.xml.j2
@@ -18,6 +18,13 @@
                     <username>{{database.registry_db.username}}</username>
                     <password>{{database.registry_db.password}}</password>
                     <driverClassName>{{database.registry_db.driver}}</driverClassName>
+                    {% if database.registry_db.db_props %}
+                        <databaseProps>
+                             {% for property_name,property_value in database.registry_db.db_props.items() %}
+                                 <property name="{{property_name}}">{{property_value}}</property>
+                             {% endfor %}
+                        </databaseProps>
+                    {% endif %}
                     {% for property_name,property_value in database.registry_db.pool_options.items() %}
                     <{{property_name}}>{{property_value}}</{{property_name}}>
                     {% endfor %}
@@ -36,6 +43,13 @@
                     <username>{{database.shared_db.username}}</username>
                     <password>{{database.shared_db.password}}</password>
                     <driverClassName>{{database.shared_db.driver}}</driverClassName>
+                    {% if database.shared_db.db_props %}
+                        <databaseProps>
+                                {% for property_name,property_value in database.shared_db.db_props.items() %}
+                                    <property name="{{property_name}}">{{property_value}}</property>
+                                {% endfor %}
+                        </databaseProps>
+                    {% endif %}
                     {% for property_name,property_value in database.shared_db.pool_options.items() %}
                     <{{property_name}}>{{property_value}}</{{property_name}}>
                         {% endfor %}
@@ -57,6 +71,13 @@
                     <username>{{database.user.username}}</username>
                     <password>{{database.user.password}}</password>
                     <driverClassName>{{database.user.driver}}</driverClassName>
+                    {% if database.user.db_props %}
+                        <databaseProps>
+                                {% for property_name,property_value in database.user.db_props.items() %}
+                                    <property name="{{property_name}}">{{property_value}}</property>
+                                {% endfor %}
+                        </databaseProps>
+                    {% endif %}
                     {% for property_name,property_value in database.user.pool_options.items() %}
                     <{{property_name}}>{{property_value}}</{{property_name}}>
                         {% endfor %}
@@ -79,6 +100,13 @@
                     <username>{{database.config.username}}</username>
                     <password>{{database.config.password}}</password>
                     <driverClassName>{{database.config.driver}}</driverClassName>
+                    {% if database.config.db_props %}
+                        <databaseProps>
+                                {% for property_name,property_value in database.config.db_props.items() %}
+                                    <property name="{{property_name}}">{{property_value}}</property>
+                                {% endfor %}
+                        </databaseProps>
+                    {% endif %}
                     {% for property_name,property_value in database.config.pool_options.items() %}
                     <{{property_name}}>{{property_value}}</{{property_name}}>
                         {% endfor %}
@@ -101,6 +129,13 @@
                      <username>{{data.username}}</username>
                      <password>{{data.password}}</password>
                      <driverClassName>{{data.driver}}</driverClassName>
+                    {% if data.db_props %}
+                        <databaseProps>
+                             {% for property_name,property_value in data.db_props.items() %}
+                                 <property name="{{property_name}}">{{property_value}}</property>
+                             {% endfor %}
+                        </databaseProps>
+                    {% endif %}
                     {% for property_name,property_value in data.pool_options.items() %}
                      <{{property_name}}>{{property_value}}</{{property_name}}>
                     {% endfor %}


### PR DESCRIPTION
## Purpose
> This PR will add the templating for databaseProps field so that the `deployment.toml` configurations will get populated in the `master-datasources.xml`.

Sample deployment.toml config

```
[database.identity_db]
type = "oracle"
username = "userSchema"
password = "password"
url = "jdbc:oracle:thin:@//localhost:1521/XEPDB1"
db_props.parentSchema = "parentSchema"
```

## Related Issues:
- https://github.com/wso2/product-is/issues/22091