### PR TITLE
Add new constructor to the CarbonContext

### DIFF
--- a/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/context/CarbonContext.java
+++ b/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/context/CarbonContext.java
@@ -110,6 +110,14 @@ public class CarbonContext {
     }
 
     /**
+     * Instantiate a CarbonContext with the current CarbonContext holder.
+     */
+    protected CarbonContext() {
+
+        this.carbonContextHolder = CarbonContextDataHolder.getThreadLocalCarbonContextHolder();
+    }
+
+    /**
      * Utility method to obtain the current CarbonContext holder after an instance of a
      * CarbonContext has been created.
      *


### PR DESCRIPTION
## Purpose

We are introducing new Identity Context in the framework extending the CarbonContext. So that the new Context has the read access to the carbon context data holder.
Since we have to implement the default constructor of the CarbonContext and the current constructor needs CarbonContextDataHolder object as an argument(this is an internal class), we cannot extend the Carbon Context outside it's directory.

## Related Issue
- https://github.com/wso2/product-is/issues/22349