### PR TITLE
Enable filtering by display name in the group listing operation

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/UserStoreConfigConstants.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/UserStoreConfigConstants.java
@@ -136,6 +136,7 @@ public class UserStoreConfigConstants {
     public static final String GROUP_LAST_MODIFIED_DATE_ATTRIBUTE_DESCRIPTION = "Attribute used to store the last " +
             "modified date of the group";
     public static final String GROUP_LOCATION_URI_ATTRIBUTE = "GroupLocation";
+    public static final String GROUP_NAME_ATTRIBUTE = "GroupNameAttribute";
 
     public static final String userNameAttribute = "UserNameAttribute";
     public static final String userNameAttributeDescription = "Attribute used for uniquely identifying a user entry. Users can be authenticated using their email address, uid and etc";

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/JDBCRealmConstants.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/JDBCRealmConstants.java
@@ -149,6 +149,7 @@ public final class JDBCRealmConstants {
     public static final String GET_GROUP_NAME_FROM_GROUP_ID = "GetGroupNameFromGroupIDSQL";
     public static final String GET_GROUP_FROM_GROUP_NAME = "GetGroupFromGroupNameSQL";
     public static final String GET_GROUP_FROM_GROUP_ID = "GetGroupFromGroupIDSQL";
+    public static final String GET_GROUP_FILTER_WITH_GROUP_NAME = "GetGroupFilterWithGroupNameSQL";
     public static final String GET_GROUP_FILTER_WITH_GROUP_ID = "GetGroupFilterWithGroupIDSQL";
     public static final String GET_GROUP_FILTER_WITH_CREATED_DATE = "GetGroupFilterWithCreatedDateSQL";
     public static final String GET_GROUP_FILTER_WITH_LAST_MODIFIED = "GetGroupFilterWithLastModifiedSQL";
@@ -519,6 +520,9 @@ public final class JDBCRealmConstants {
             "UM_LAST_MODIFIED FROM UM_ROLE WHERE UM_ROLE_NAME = ? AND UM_TENANT_ID = ?";
     public static final String GET_GROUP_FROM_GROUP_ID_SQL = "SELECT UM_ROLE_NAME, UM_CREATED_TIME, UM_LAST_MODIFIED " +
             "FROM UM_ROLE WHERE UM_ROLE_UUID = ? AND UM_TENANT_ID = ?";
+    public static final String GET_GROUP_FILTER_WITH_GROUP_NAME_SQL = "SELECT UM_ROLE_NAME, UM_ROLE_UUID, " +
+            "UM_CREATED_TIME, UM_LAST_MODIFIED FROM UM_ROLE WHERE UM_ROLE_NAME LIKE ? AND UM_TENANT_ID = ? " +
+            "ORDER BY UM_ROLE_NAME;";
     public static final String GET_GROUP_FILTER_WITH_GROUP_ID_SQL = "SELECT UM_ROLE_NAME, UM_ROLE_UUID, " +
             "UM_CREATED_TIME, UM_LAST_MODIFIED FROM UM_ROLE WHERE UM_ROLE_UUID LIKE ? AND UM_TENANT_ID = ? " +
             "ORDER BY UM_ROLE_NAME;";

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/JDBCUserStoreConstants.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/JDBCUserStoreConstants.java
@@ -683,6 +683,9 @@ public class JDBCUserStoreConstants {
         setAdvancedProperty(JDBCRealmConstants.GET_GROUP_FROM_GROUP_ID, "Get Group From Group ID SQL",
                 JDBCRealmConstants.GET_GROUP_FROM_GROUP_ID_SQL, "",
                 new Property[]{GROUP.getProperty(), SQL.getProperty(), FALSE.getProperty()});
+        setAdvancedProperty(JDBCRealmConstants.GET_GROUP_FILTER_WITH_GROUP_NAME, "Group Filter SQL With Group Name",
+                JDBCRealmConstants.GET_GROUP_FILTER_WITH_GROUP_NAME_SQL, "",
+                new Property[]{GROUP.getProperty(), SQL.getProperty(), FALSE.getProperty()});
         setAdvancedProperty(JDBCRealmConstants.ADD_GROUP, "Add Group SQL",
                 JDBCRealmConstants.ADD_GROUP_SQL, "",
                 new Property[]{GROUP.getProperty(), SQL.getProperty(), FALSE.getProperty()});

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCUserStoreManager.java
@@ -99,6 +99,8 @@ import static java.time.ZoneOffset.UTC;
 import static org.wso2.carbon.user.core.UserStoreConfigConstants.GROUP_CREATED_DATE_ATTRIBUTE;
 import static org.wso2.carbon.user.core.UserStoreConfigConstants.GROUP_ID_ATTRIBUTE;
 import static org.wso2.carbon.user.core.UserStoreConfigConstants.GROUP_LAST_MODIFIED_DATE_ATTRIBUTE;
+import static org.wso2.carbon.user.core.UserStoreConfigConstants.GROUP_NAME_ATTRIBUTE;
+import static org.wso2.carbon.user.core.UserStoreConfigConstants.groupNameAttribute;
 import static org.wso2.carbon.user.core.constants.UserCoreDBConstants.SQL_STATEMENT_PARAMETER_PLACEHOLDER;
 import static org.wso2.carbon.user.core.constants.UserCoreErrorConstants.ErrorMessages.ERROR_CODE_DUPLICATE_WHILE_ADDING_A_USER;
 import static org.wso2.carbon.user.core.constants.UserCoreErrorConstants.ErrorMessages.ERROR_CODE_DUPLICATE_WHILE_ADDING_ROLE;
@@ -4228,6 +4230,9 @@ public class UniqueIDJDBCUserStoreManager extends JDBCUserStoreManager {
         String sqlStmt = null;
         Timestamp timestampValueForSQL = null;
         switch (attributeName) {
+            case GROUP_NAME_ATTRIBUTE:
+                sqlStmt = realmConfig.getUserStoreProperty(JDBCRealmConstants.GET_GROUP_FILTER_WITH_GROUP_NAME);
+                break;
             case GROUP_ID_ATTRIBUTE:
                 sqlStmt = realmConfig.getUserStoreProperty(JDBCRealmConstants.GET_GROUP_FILTER_WITH_GROUP_ID);
                 break;
@@ -5073,7 +5078,8 @@ public class UniqueIDJDBCUserStoreManager extends JDBCUserStoreManager {
         String attributeName = expressionCondition.getAttributeName();
         String operation = expressionCondition.getOperation();
 
-        if (StringUtils.equals(attributeName, GROUP_ID_ATTRIBUTE) ||
+        if (StringUtils.equals(attributeName, GROUP_NAME_ATTRIBUTE) ||
+                StringUtils.equals(attributeName, GROUP_ID_ATTRIBUTE) ||
                 StringUtils.equals(attributeName, GROUP_CREATED_DATE_ATTRIBUTE) ||
                 StringUtils.equals(attributeName, GROUP_LAST_MODIFIED_DATE_ATTRIBUTE)) {
             if ((StringUtils.equals(attributeName, GROUP_CREATED_DATE_ATTRIBUTE) ||

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCUserStoreManager.java
@@ -100,7 +100,6 @@ import static org.wso2.carbon.user.core.UserStoreConfigConstants.GROUP_CREATED_D
 import static org.wso2.carbon.user.core.UserStoreConfigConstants.GROUP_ID_ATTRIBUTE;
 import static org.wso2.carbon.user.core.UserStoreConfigConstants.GROUP_LAST_MODIFIED_DATE_ATTRIBUTE;
 import static org.wso2.carbon.user.core.UserStoreConfigConstants.GROUP_NAME_ATTRIBUTE;
-import static org.wso2.carbon.user.core.UserStoreConfigConstants.groupNameAttribute;
 import static org.wso2.carbon.user.core.constants.UserCoreDBConstants.SQL_STATEMENT_PARAMETER_PLACEHOLDER;
 import static org.wso2.carbon.user.core.constants.UserCoreErrorConstants.ErrorMessages.ERROR_CODE_DUPLICATE_WHILE_ADDING_A_USER;
 import static org.wso2.carbon.user.core.constants.UserCoreErrorConstants.ErrorMessages.ERROR_CODE_DUPLICATE_WHILE_ADDING_ROLE;

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/util/JDBCRealmUtil.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/util/JDBCRealmUtil.java
@@ -584,6 +584,10 @@ public class JDBCRealmUtil {
         if (!properties.containsKey(JDBCRealmConstants.GET_GROUP_FROM_GROUP_ID)) {
             properties.put(JDBCRealmConstants.GET_GROUP_FROM_GROUP_ID, JDBCRealmConstants.GET_GROUP_FROM_GROUP_ID_SQL);
         }
+        if (!properties.containsKey(JDBCRealmConstants.GET_GROUP_FILTER_WITH_GROUP_NAME)) {
+            properties.put(JDBCRealmConstants.GET_GROUP_FILTER_WITH_GROUP_NAME,
+                    JDBCRealmConstants.GET_GROUP_FILTER_WITH_GROUP_NAME_SQL);
+        }
         if (!properties.containsKey(JDBCRealmConstants.GET_GROUP_FILTER_WITH_GROUP_ID)) {
             properties.put(JDBCRealmConstants.GET_GROUP_FILTER_WITH_GROUP_ID,
                     JDBCRealmConstants.GET_GROUP_FILTER_WITH_GROUP_ID_SQL);


### PR DESCRIPTION
## Purpose
This PR introduces the necessary changes to enable filtering the group list by Group Display Name when using the `listGroups` operation in `AbstractUserStoreManager`.  
**Note:** This functionality was already available for LDAPs but was not supported for JDBC stores.

## Related Issue
- https://github.com/wso2/product-is/issues/21848