### PR TITLE
The LDAP connection creation successful message is logged as debug log instead of info log

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/ReadOnlyLDAPUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/ReadOnlyLDAPUserStoreManager.java
@@ -251,7 +251,7 @@ public class ReadOnlyLDAPUserStoreManager extends AbstractUserStoreManager {
         try {
             dirContext = connectionSource.getContext();
             if (this.isReadOnly()) {
-                log.info("LDAP connection created successfully in read-only mode");
+                log.debug("LDAP connection created successfully in read-only mode");
             }
         } catch (Exception e) {
             // Skipped to throw a UserStoreException and log the error message in-order to successfully initiate and

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/ReadWriteLDAPUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/ReadWriteLDAPUserStoreManager.java
@@ -166,7 +166,7 @@ public class ReadWriteLDAPUserStoreManager extends ReadOnlyLDAPUserStoreManager 
         DirContext dirContext = null;
         try {
             dirContext = connectionSource.getContext();
-            log.info("LDAP connection created successfully in read-write mode");
+            log.debug("LDAP connection created successfully in read-write mode");
         } catch (Exception e) {
             // Skipped to throw a UserStoreException and log the error message in-order to successfully initiate and
             // create the user-store object.

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/UniqueIDReadWriteLDAPUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/UniqueIDReadWriteLDAPUserStoreManager.java
@@ -187,7 +187,7 @@ public class UniqueIDReadWriteLDAPUserStoreManager extends UniqueIDReadOnlyLDAPU
         DirContext dirContext = null;
         try {
             dirContext = connectionSource.getContext();
-            log.info("LDAP connection created successfully in read-write mode");
+            log.debug("LDAP connection created successfully in read-write mode");
         } catch (Exception e) {
             // Skipped to throw a UserStoreException and log the error message in-order to successfully initiate and
             // create the user-store object.


### PR DESCRIPTION
## Purpose
> When LDAP or AD setup is configured, it will log an info log level message mentioning the LDAP connection is successful.

It is not an information required to be logged. if the LDAP or AD connection fails to establish it will be result in a server error which can be used to identify the status.

Ideally there should be an test connection UI same as we use for the JDBC user stores, where the admins can test the connection status instead of depends on an info log publish to the log file.

### Related Issues
- https://github.com/wso2/product-is/issues/20132

As AD is an LDAP implementation, it is okay to have a log mentioning LDAP connection is successful.