### PR TITLE
Remove unnecessary readOnly property from readOnly LDAP userstores

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/ReadOnlyLDAPUserStoreConstants.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/ReadOnlyLDAPUserStoreConstants.java
@@ -146,9 +146,6 @@ public class ReadOnlyLDAPUserStoreConstants {
                 "Use Case Sensitive Username for Cache Keys", "true",
                 UserStoreConfigConstants.USE_CASE_SENSITIVE_USERNAME_FOR_CACHE_KEYS_DESCRIPTION,
                 new Property[] { USER.getProperty(), BOOLEAN.getProperty(), TRUE.getProperty() });
-
-        setProperty("ReadOnly", "", "true", "",
-                new Property[] { USER.getProperty(), BOOLEAN.getProperty(), TRUE.getProperty() });
     }
 
     private static void setMandatoryProperty(String name, String displayName, String value, String description,


### PR DESCRIPTION
## Purpose
- Remove unnecessary readOnly property from readOnly LDAP userstores since we don't allow userstore disabled read-only mode in readOnly userstores
- Resolves https://github.com/wso2/product-is/issues/19769
- Need to revert the temp UI fix done via https://github.com/wso2/identity-apps/pull/5589 after merging this. 