### PR TITLE
Fix Group filtering from the timestamp attribute.

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/constants/UserCoreErrorConstants.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/constants/UserCoreErrorConstants.java
@@ -245,6 +245,7 @@ public class UserCoreErrorConstants {
         ERROR_UNSUPPORTED_DATE_SEARCH_FILTER("60011", "Unsupported date seacrh filter."),
         ERROR_SYSTEM_RESERVED_DOMAIN_IN_GROUP("60012", "Group name: %s contains a system reserved " +
                 "domain name"),
+        ERROR_INVALID_ISO_TIMESTAMP("60013", "Timestamp '%s' is not in valid ISO 8601 format."),
 
         // Server error codes related to group operations.
         ERROR_DURING_PRE_GET_GROUP_BY_ID("65001",
@@ -298,7 +299,11 @@ public class UserCoreErrorConstants {
         ERROR_DURING_POST_UPDATE_USER_LIST_OF_GROUP("65029",
                 "Un-expected error during post updating user list of groups with ID, %s"),
         ERROR_WHILE_UPDATE_USER_LIST_OF_GROUP("65030",
-                "Un-expected error while updating user list of group, %s");
+                "Un-expected error while updating user list of group, %s"),
+        ERROR_DURING_LDAP_TIMESTAMP_EXTRACTION("65031",
+                "Error connecting to LDAP server for timestamp extraction."),
+        ERROR_DURING_LDAP_TIMESTAMP_CONVERSION("65032",
+                "Error converting ISO timestamp '%s' to LDAP format.");
 
         private final String code;
         private final String message;

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/constants/UserCoreErrorConstants.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/constants/UserCoreErrorConstants.java
@@ -1,7 +1,7 @@
 /*
- *  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *  Copyright (c) 2018-2025, WSO2 LLC. (https://www.wso2.com).
  *
- *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  WSO2 LLC. licenses this file to you under the Apache License,
  *  Version 2.0 (the "License"); you may not use this file except
  *  in compliance with the License.
  *  You may obtain a copy of the License at

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/LDAPConstants.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/LDAPConstants.java
@@ -112,6 +112,7 @@ public class LDAPConstants {
      */
     public static final String DEFAULT_LDAP_TIME_FORMATS_PATTERN = "[uuuuMMddHHmmss[,SSS][.SSS]X]" +
             "[uuuuMMddHHmmss[,SS][.SS]X][uuuuMMddHHmm[,S][.S]X]";
+    public static final String DEFAULT_LDAP_BASIC_TIMESTAMP_FORMAT = "uuuuMMddHHmmssX";
 
     public static final String LIST_SERVICE_PRINCIPAL_ENTITIES = "ListServicePrincipalEntities";
 }

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/LDAPConstants.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/LDAPConstants.java
@@ -1,7 +1,7 @@
 /*
-*  Copyright (c) 2005-2010, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*  Copyright (c) 2005-2025, WSO2 LLC. (https://www.wso2.com).
 *
-*  WSO2 Inc. licenses this file to you under the Apache License,
+*  WSO2 LLC. licenses this file to you under the Apache License,
 *  Version 2.0 (the "License"); you may not use this file except
 *  in compliance with the License.
 *  You may obtain a copy of the License at

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/LDAPSearchSpecification.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/LDAPSearchSpecification.java
@@ -1,7 +1,7 @@
 /*
- *  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *  Copyright (c) 2018-2025, WSO2 LLC. (https://www.wso2.com).
  *
- *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  WSO2 LLC. licenses this file to you under the Apache License,
  *  Version 2.0 (the "License"); you may not use this file except
  *  in compliance with the License.
  *  You may obtain a copy of the License at

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/UniqueIDReadOnlyLDAPUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/UniqueIDReadOnlyLDAPUserStoreManager.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2019-2025, WSO2 LLC. (https://www.wso2.com).
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at


### PR DESCRIPTION
## Purpose
- Resolves https://github.com/wso2/product-is/issues/22609

Group filtering with valid timestamp and groups available
<img width="1134" alt="Screenshot 2025-02-18 at 08 18 35" src="https://github.com/user-attachments/assets/cc707797-b983-477c-ad35-080cc62be888" />

Group filtering with valid timestamp but no groups available
<img width="1129" alt="Screenshot 2025-02-18 at 08 25 22" src="https://github.com/user-attachments/assets/28cf3d06-5e11-4595-a46d-9b3abbbab358" />

Group filtering with invalid timestamp
<img width="1130" alt="Screenshot 2025-02-18 at 08 18 49" src="https://github.com/user-attachments/assets/9a2cf5ed-24e5-452a-909a-6a9cda38c20e" />


## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.