### PR TITLE
Make IsBulkImportSupported by default true for JDBC user stores

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/JDBCUserStoreConstants.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/JDBCUserStoreConstants.java
@@ -120,7 +120,7 @@ public class JDBCUserStoreConstants {
                 new Property[] { USER.getProperty(), BOOLEAN.getProperty(), TRUE.getProperty() });
 
         //set Advanced properties
-        setAdvancedProperty("IsBulkImportSupported", "Is Bulk Import Supported", "false",
+        setAdvancedProperty("IsBulkImportSupported", "Is Bulk Import Supported", "true",
                 "Support Bulk User Import Operation for this user store",
                 new Property[] { USER.getProperty(), BOOLEAN.getProperty(), FALSE.getProperty() });
         setAdvancedProperty(JDBCRealmConstants.DIGEST_FUNCTION, "Password Hashing Algorithm", "SHA-256",


### PR DESCRIPTION
## Purpose
Bulk import support  is currently enabled by default for AD and LDAP user stores, should also be enabled by default for JDBC user stores.  There are no apparent limitations preventing this.

AD
- https://github.com/wso2/carbon-kernel/blob/0ac4ba0004c8919f486bfaec9a18174b86e0f84f/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/UniqueIDActiveDirectoryUserStoreManager.java#L1061

LDAP 
- https://github.com/wso2/carbon-kernel/blob/9ba5e33016c103ce0d6269f74ed59c7b4700963c/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/UniqueIDReadWriteLDAPUserStoreManager.java#L2608
