### PR TITLE
Revert prepare for release changes for 4.9.28-beta

### DIFF
--- a/distribution/kernel/carbon.product
+++ b/distribution/kernel/carbon.product
@@ -2,7 +2,7 @@
 <?pde version="3.5"?>
 
 <product name="Carbon Product" uid="carbon.product.id" id="carbon.product" application="carbon.application"
-version="4.9.28.beta" useFeatures="true" includeLaunchers="true">
+version="4.9.28.SNAPSHOT" useFeatures="true" includeLaunchers="true">
 
    <configIni use="default">
    </configIni>
@@ -14,7 +14,7 @@ version="4.9.28.beta" useFeatures="true" includeLaunchers="true">
    </plugins>
 
    <features>
-      <feature id="org.wso2.carbon.core.runtime" version="4.9.28.beta"/>
+      <feature id="org.wso2.carbon.core.runtime" version="4.9.28.SNAPSHOT"/>
    </features>
 
   <configurations>

--- a/distribution/kernel/src/assembly/filter.properties
+++ b/distribution/kernel/src/assembly/filter.properties
@@ -1,2 +1,2 @@
-carbon.version=4.9.28-beta
+carbon.version=4.9.28-SNAPSHOT
 p2.repo.url=http://product-dist.wso2.com/p2/carbon/releases/wilkes/

--- a/distribution/product/modules/distribution/src/assembly/filter.properties
+++ b/distribution/product/modules/distribution/src/assembly/filter.properties
@@ -1,8 +1,8 @@
 product.name=WSO2 Carbon
-product.version=4.9.28-beta
+product.version=4.9.28-SNAPSHOT
 product.key=Carbon
-carbon.product.version=4.9.28-beta
-carbon.version=4.9.28-beta
+carbon.product.version=4.9.28-SNAPSHOT
+carbon.version=4.9.28-SNAPSHOT
 default.server.role=CarbonServer
 hotdeployment=true
 hotupdate=true


### PR DESCRIPTION
## Purpose
This PR reverts prepare for release changes for 4.9.28-beta done in [1]

[1] https://github.com/wso2/carbon-kernel/pull/4250 