### PR TITLE
Optimize UUID Generation: Replace SecureRandom with ThreadLocalRandom for Non-Blocking Performance

### DIFF
--- a/core/javax.cache/src/main/java/javax/cache/CacheEntryInfo.java
+++ b/core/javax.cache/src/main/java/javax/cache/CacheEntryInfo.java
@@ -19,6 +19,7 @@ package javax.cache;
 
 import java.io.Serializable;
 import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
 
 /**
  * Cache Information to Send to invalidate Cache
@@ -26,7 +27,7 @@ import java.util.UUID;
 public class CacheEntryInfo implements Serializable {
 
     private static final long serialVersionUID = 90L;
-    private final String uuid = UUID.randomUUID().toString();
+    private final String uuid = generateFastUUID();
     private final long timestamp = System.currentTimeMillis();
     private String cacheManagerName;
     private String cacheName;
@@ -115,6 +116,13 @@ public class CacheEntryInfo implements Serializable {
                 ", tenantDomain='" + tenantDomain + '\'' +
                 ", tenantId=" + tenantId +
                 '}';
+    }
+
+    private static String generateFastUUID() {
+
+        long most = ThreadLocalRandom.current().nextLong();
+        long least = ThreadLocalRandom.current().nextLong();
+        return new UUID(most, least).toString();
     }
 }
 

--- a/core/org.wso2.carbon.tomcat.ext/src/main/java/org/wso2/carbon/tomcat/ext/valves/RequestCorrelationIdValve.java
+++ b/core/org.wso2.carbon.tomcat.ext/src/main/java/org/wso2/carbon/tomcat/ext/valves/RequestCorrelationIdValve.java
@@ -19,6 +19,7 @@
 package org.wso2.carbon.tomcat.ext.valves;
 
 import com.google.gson.Gson;
+import java.util.concurrent.ThreadLocalRandom;
 import org.apache.catalina.LifecycleException;
 import org.apache.catalina.connector.Request;
 import org.apache.catalina.connector.Response;
@@ -115,7 +116,7 @@ public class RequestCorrelationIdValve extends ValveBase {
 
             if (associateToThreadMap.size() == 0) {
                 // Put the default generated correlation ID.
-                associateToThreadMap.put(correlationIdMdc, UUID.randomUUID().toString());
+                associateToThreadMap.put(correlationIdMdc, generateFastUUID());
             }
 
             // TraceId has to be added response header.
@@ -145,6 +146,13 @@ public class RequestCorrelationIdValve extends ValveBase {
             disAssociateFromThread();
             ThreadContext.clearAll();
         }
+    }
+
+    private String generateFastUUID() {
+
+        long most = ThreadLocalRandom.current().nextLong();
+        long least = ThreadLocalRandom.current().nextLong();
+        return new UUID(most, least).toString();
     }
 
     /**


### PR DESCRIPTION
This pull request includes changes to improve the performance of UUID generation by using `ThreadLocalRandom` instead of `UUID.randomUUID()`. The changes are applied to two classes: `CacheEntryInfo` and `RequestCorrelationIdValve`.

Improvements to UUID generation:

* [`core/javax.cache/src/main/java/javax/cache/CacheEntryInfo.java`](diffhunk://#diff-93b91e170e794205421d4d1895e0111cafdca747e3e9aa3e335445dedc659982R22-R30): Replaced `UUID.randomUUID().toString()` with a new method `generateFastUUID()` that uses `ThreadLocalRandom` for faster UUID generation.
* [`core/javax.cache/src/main/java/javax/cache/CacheEntryInfo.java`](diffhunk://#diff-93b91e170e794205421d4d1895e0111cafdca747e3e9aa3e335445dedc659982R120-R126): Added the `generateFastUUID()` method to generate UUIDs using `ThreadLocalRandom`.
* [`core/org.wso2.carbon.tomcat.ext/src/main/java/org/wso2/carbon/tomcat/ext/valves/RequestCorrelationIdValve.java`](diffhunk://#diff-da74eaa02d90537f97bc248e1d6f3b56f51b3a52622454ef4229e6fa1297b48aL118-R119): Replaced `UUID.randomUUID().toString()` with a new method `generateFastUUID()` that uses `ThreadLocalRandom` for faster UUID generation.
* [`core/org.wso2.carbon.tomcat.ext/src/main/java/org/wso2/carbon/tomcat/ext/valves/RequestCorrelationIdValve.java`](diffhunk://#diff-da74eaa02d90537f97bc248e1d6f3b56f51b3a52622454ef4229e6fa1297b48aR151-R157): Added the `generateFastUUID()` method to generate UUIDs using `ThreadLocalRandom`.
* [`core/org.wso2.carbon.tomcat.ext/src/main/java/org/wso2/carbon/tomcat/ext/valves/RequestCorrelationIdValve.java`](diffhunk://#diff-da74eaa02d90537f97bc248e1d6f3b56f51b3a52622454ef4229e6fa1297b48aR22): Imported `ThreadLocalRandom` for use in the new UUID generation method.