### PR TITLE
Store multiValued attributes as separate claims instead of comma separated claims

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/JDBCUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/JDBCUserStoreManager.java
@@ -1271,7 +1271,7 @@ public class JDBCUserStoreManager extends AbstractUserStoreManager {
                         multiValuedAttributes = findMultiValuedAttributes();
                     }
                     if (multiValuedAttributes.contains(name)) {
-                        value = map.get(name) + multiAttributeSeparator +  value;
+                        value = map.get(name) + multiAttributeSeparator + value;
                     }
                 }
                 map.put(name, value);

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/JDBCUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/JDBCUserStoreManager.java
@@ -1241,7 +1241,6 @@ public class JDBCUserStoreManager extends AbstractUserStoreManager {
         String[] propertyNamesSorted = propertyNames.clone();
         Arrays.sort(propertyNamesSorted);
         Map<String, String> map = new HashMap<String, String>();
-
         try {
             dbConnection = getDBConnection();
             if (isCaseSensitiveUsername()) {

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCUserStoreManager.java
@@ -578,7 +578,6 @@ public class UniqueIDJDBCUserStoreManager extends JDBCUserStoreManager {
         String[] propertyNamesSorted = propertyNames.clone();
         Arrays.sort(propertyNamesSorted);
         Map<String, String> map = new HashMap<>();
-
         String sqlStmt = realmConfig.getUserStoreProperty(JDBCRealmConstants.GET_PROPS_FOR_PROFILE_WITH_ID);
         try {
             dbConnection = getDBConnection();

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCUserStoreManager.java
@@ -605,7 +605,7 @@ public class UniqueIDJDBCUserStoreManager extends JDBCUserStoreManager {
                         multiValuedProperties = findMultiValuedAttributes();
                     }
                     if (multiValuedProperties.contains(name)) {
-                        value = map.get(name) + multiAttributeSeparator +  value;
+                        value = map.get(name) + multiAttributeSeparator + value;
                     }
                 }
                 map.put(name, value);


### PR DESCRIPTION
## Purpose

- Introduced a method to find the multiValued attributes of the given tenant. It will return the corresponding mapped attribute related to the current user store domain. https://github.com/wso2/carbon-kernel/pull/4271/files#diff-4995941eb71f197712744fdc59e0dd9446e275f592ac931a2630555c0d4b1ec2R5338

-  When retrieving data from the JDBC user store, only the multi valued attributes are concatenated by the multi attribute separator of the corresponding user store domain.

- When creating or updating a user with multi valued claims, it will be received as comma separated string to the user store manager. As the attributes are stored with same attribute key, all the received multi valued attributes are deleted first. Then add the multi valued attributes which received. (This happen as bulk operations within a single transaction)

- Iterate over the each multi valued attribute and store as separate attribute. 


### Related Issues
- https://github.com/wso2/product-is/issues/23547

### Depends on
- https://github.com/wso2/carbon-kernel/pull/4273