### PR TITLE
Introduce Cache.putIfNoDuplicate function and unit tests

### DIFF
--- a/core/javax.cache/src/main/java/javax/cache/Cache.java
+++ b/core/javax.cache/src/main/java/javax/cache/Cache.java
@@ -200,6 +200,30 @@ public interface Cache<K, V> extends Iterable<Cache.Entry<K, V>>, CacheLifecycle
     void put(K key, V value);
 
     /**
+     * Associates the specified value with the specified key in this cache
+     * If the cache previously contained a mapping for
+     * the key, the old value is replaced by the specified value if the value
+     * is not equal to the value already existing in the cache.  (A cache
+     * <tt>c</tt> is said to contain a mapping for a key <tt>k</tt> if and only
+     * if {@link #containsKey(Object) c.containsKey(k)} would return
+     * <tt>true</tt>.)
+     * <p/>
+     * In contrast to the corresponding Map operation, does not return
+     * the previous value.
+     *
+     * @param key   key with which the specified value is to be associated
+     * @param value value to be associated with the specified key
+     * @throws NullPointerException  if key is null or if value is null
+     * @throws IllegalStateException if the cache is not {@link Status#STARTED}
+     * @throws CacheException        if there is a problem doing the put
+     * @see java.util.Map#put(Object, Object)
+     * @see #getAndPut(Object, Object)
+     * @see #getAndReplace(Object, Object)
+     */
+    void putIfNoDuplicate(K key, V value);
+
+
+    /**
      * Associates the specified value with the specified key in this cache,
      * returning an existing value if one existed.
      * <p/>

--- a/core/javax.cache/src/test/java/org/wso2/carbon/caching/impl/CachingTestCase.java
+++ b/core/javax.cache/src/test/java/org/wso2/carbon/caching/impl/CachingTestCase.java
@@ -67,12 +67,26 @@ public class CachingTestCase {
     }
 
     @Test(groups = {"org.wso2.carbon.clustering.hazelcast.jsr107"},
-          dependsOnMethods = "checkNonExistentItem",
-          description = "")
+            dependsOnMethods = "checkNonExistentItem",
+            description = "")
     public void checkPut() throws Exception {
         Integer sampleValue = 1245;
         cache.put(key, sampleValue);
         assertEquals(cache.get(key), sampleValue);
+    }
+
+    @Test(groups = {"org.wso2.carbon.clustering.hazelcast.jsr107"},
+            dependsOnMethods = "checkNonExistentItem",
+            description = "")
+    public void checkPutIfNoDuplicate() throws Exception {
+        Integer sampleValue = 1245;
+        Integer newSampleValue = 1111;
+        cache.putIfNoDuplicate(key, sampleValue);
+        assertEquals(cache.get(key), sampleValue);
+        cache.putIfNoDuplicate(key, sampleValue);
+        assertEquals(cache.get(key), sampleValue);
+        cache.putIfNoDuplicate(key, newSampleValue);
+        assertEquals(cache.get(key), newSampleValue);
     }
 
     @Test(groups = {"org.wso2.carbon.clustering.hazelcast.jsr107"},


### PR DESCRIPTION
This pull request introduces a new method, `putIfNoDuplicate`, to the `Cache` interface and its implementation in the `CacheImpl` class. Additionally, a test case has been added to ensure the correct functionality of this new method.

### New Method Addition:
* [`core/javax.cache/src/main/java/javax/cache/Cache.java`](diffhunk://#diff-74892c6a0e70542f2900dec847da92e1d597a42126d27b748f0e1aa2d26ac705R202-R225): Added `putIfNoDuplicate` method to the `Cache` interface. This method associates a value with a key only if the key does not already exist in the cache or if the existing value is different.

### Implementation:
* [`core/javax.cache/src/main/java/org/wso2/carbon/caching/impl/CacheImpl.java`](diffhunk://#diff-0dde41ab26418c39a2c9d95e5a58f8ba44ced507a7672cd725571e41d439dfa0R403-R420): Implemented the `putIfNoDuplicate` method in the `CacheImpl` class. It includes checks for cache status and tenant access, and updates the cache entry if the key does not exist or the value is different.

### Test Case:
* [`core/javax.cache/src/test/java/org/wso2/carbon/caching/impl/CachingTestCase.java`](diffhunk://#diff-e93886d842efaf994233ca87922946bd6de5582d60b372fde3f01ccc747ec922R78-R91): Added a test case `checkPutIfNoDuplicate` to verify the behavior of the `putIfNoDuplicate` method. The test ensures that the value is only updated if it is different from the existing value.

## Related Issue/s
- https://github.com/wso2/product-is/issues/23518