### PR TITLE
Consider dual write mode even groupId is disabled

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
@@ -17987,7 +17987,7 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
         Group group = null;
         String groupId = generateGroupUUID();
         boolean isUniqueGroupIdEnabled = isUniqueGroupIdEnabled(this);
-        if (isUniqueGroupIdEnabled) {
+        if (isUniqueGroupIdEnabled || isGroupIdDualWriteModeEnabled(this)) {
             if (!isUniqueUserIdEnabledInUserStore(userStore)) {
                 String errorCode = ErrorMessages.ERROR_CODE_GROUP_UUID_NOT_SUPPORTED.getCode();
                 String errorMessage = ErrorMessages.ERROR_CODE_GROUP_UUID_NOT_SUPPORTED.getMessage();
@@ -17995,15 +17995,17 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
                 throw new UserStoreException(errorCode + "-" + errorMessage);
             }
             group = doAddGroup(groupName, groupId, usersIds, buildClaimsList(claims));
-            groupUniqueIDDomainResolver.setDomainForGroupId(group.getGroupID(), getMyDomainName(), tenantId,
-                    false);
+            if (isUniqueGroupIdEnabled) {
+                groupUniqueIDDomainResolver.setDomainForGroupId(group.getGroupID(), getMyDomainName(), tenantId,
+                        false);
+            }
         }
         if (!isUniqueGroupIdEnabled || isGroupIdDualWriteModeEnabled(this)) {
             // Backward compatibility support. Use group resolver to update the other required places.
             GroupResolver groupResolver = UserStoreMgtDataHolder.getInstance().getGroupResolver();
             try {
                 group = groupResolver.addGroup(groupName, groupId, claims, this);
-                if (!isUniqueGroupIdEnabled) {
+                if (!isUniqueGroupIdEnabled && !isGroupIdDualWriteModeEnabled(this)) {
                     if (isUniqueUserIdEnabledInUserStore(userStore)) {
                         doAddGroupWithUserIds(groupName, usersIds);
                     } else {
@@ -18011,6 +18013,8 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
                         doAddGroupWithUserNames(groupName,
                                 users.stream().map(User::getUsername).collect(Collectors.toList()));
                     }
+                }
+                if (!isUniqueGroupIdEnabled) {
                     // Update only the cache since the ID can be found in our side.
                     groupUniqueIDDomainResolver.setDomainForGroupId(group.getGroupID(), getMyDomainName(), tenantId,
                             true);
@@ -18616,7 +18620,7 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
         // ############################### </Pre-Listeners> ##########################################
         clearGroupIDResolverCache(groupID, tenantId);
         try {
-            if (isUniqueGroupIdEnabled()) {
+            if (isUniqueGroupIdEnabled() || isGroupIdDualWriteModeEnabled()) {
                 doUpdateGroupNameByGroupId(groupID, newGroupName);
             } else {
                 // Current group name does not have the domain here.

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCUserStoreManager.java
@@ -4420,7 +4420,7 @@ public class UniqueIDJDBCUserStoreManager extends JDBCUserStoreManager {
     @Override
     public void doUpdateGroupNameByGroupId(String groupId, String newGroupName) throws UserStoreException {
 
-        if (!isUniqueGroupIdEnabled()) {
+        if (!isUniqueGroupIdEnabled() && !isGroupIdDualWriteModeEnabled()) {
             throw new UserStoreException("Group ID is not supported for userstore: " + getMyDomainName());
         }
         if (StringUtils.isBlank(groupId)) {


### PR DESCRIPTION
## Purpose
Related to https://github.com/wso2/product-is/issues/23856
With the PR https://github.com/wso2/carbon-kernel/pull/4287 dual mode support was introduced. This PR contains following improvements
1. When Updating the group if legacy method used then last modified time will not be updated hence modify the method to consider dual write mode
2. Update the logic to consider dual mode property on updating caches.

