### PR TITLE
Fix version format from 4.10.48-SNAPSHOT to 4.10.48.SNAPSHOT

### DIFF
--- a/distribution/kernel/carbon.product
+++ b/distribution/kernel/carbon.product
@@ -2,7 +2,7 @@
 <?pde version="3.5"?>
 
 <product name="Carbon Product" uid="carbon.product.id" id="carbon.product" application="carbon.application"
-version="4.10.48-SNAPSHOT" useFeatures="true" includeLaunchers="true">
+version="4.10.48.SNAPSHOT" useFeatures="true" includeLaunchers="true">
 
    <configIni use="default">
    </configIni>
@@ -14,7 +14,7 @@ version="4.10.48-SNAPSHOT" useFeatures="true" includeLaunchers="true">
    </plugins>
 
    <features>
-      <feature id="org.wso2.carbon.core.runtime" version="4.10.48-SNAPSHOT"/>
+      <feature id="org.wso2.carbon.core.runtime" version="4.10.48.SNAPSHOT"/>
    </features>
 
   <configurations>

--- a/distribution/kernel/src/assembly/filter.properties
+++ b/distribution/kernel/src/assembly/filter.properties
@@ -1,2 +1,2 @@
-carbon.version=4.10.48-SNAPSHOT
+carbon.version=4.10.48.SNAPSHOT
 p2.repo.url=http://product-dist.wso2.com/p2/carbon/releases/wilkes/

--- a/distribution/product/modules/distribution/src/assembly/filter.properties
+++ b/distribution/product/modules/distribution/src/assembly/filter.properties
@@ -1,8 +1,8 @@
 product.name=WSO2 Carbon
-product.version=4.10.48-SNAPSHOT
+product.version=4.10.48.SNAPSHOT
 product.key=Carbon
-carbon.product.version=4.10.48-SNAPSHOT
-carbon.version=4.10.48-SNAPSHOT
+carbon.product.version=4.10.48.SNAPSHOT
+carbon.version=4.10.48.SNAPSHOT
 default.server.role=CarbonServer
 hotdeployment=true
 hotupdate=true


### PR DESCRIPTION
## Purpose
$subject

**Fixes the build error:** An error has occurred while loading product file /home/runner/work/product-is/product-is/carbon-kernel/distribution/kernel/carbon.product. Exception details: java.lang.IllegalArgumentException: Format "format(n[.n=0;[.n=0;[.S=[A-Za-z0-9_-];='';]]])" was unable to parse 4.10.48-SNAPSHOT.
