### PR TITLE
Provide a single place to create HTTP clients with different configurations

### DIFF
--- a/core/org.wso2.carbon.utils/pom.xml
+++ b/core/org.wso2.carbon.utils/pom.xml
@@ -242,6 +242,14 @@
             <artifactId>org.wso2.carbon.database.utils</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.orbit.org.apache.httpcomponents</groupId>
+            <artifactId>httpclient5</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.orbit.org.apache.httpcomponents</groupId>
+            <artifactId>httpcore5</artifactId>
+        </dependency>
     </dependencies>
 
     <properties>

--- a/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/CustomHostNameVerifier.java
+++ b/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/CustomHostNameVerifier.java
@@ -24,7 +24,15 @@ import java.util.Optional;
 
 /**
  * Custom hostname verifier class.
+ *
+ * @deprecated
+ *
+ * This class is deprecated as part of an effort to unify all HTTP client implementations
+ * in the product.
+ *
+ * Use {@link org.wso2.carbon.utils.httpclient5.LocalhostSANsTrustedHostnameVerifier} instead.
  */
+@Deprecated
 public class CustomHostNameVerifier extends AbstractVerifier {
 
     private final static String[] LOCALHOSTS = {"::1", "127.0.0.1", "localhost", "localhost.localdomain"};

--- a/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/HTTPClientUtils.java
+++ b/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/HTTPClientUtils.java
@@ -38,15 +38,14 @@ public class HTTPClientUtils {
     /**
      * Get the httpclient builder with custom hostname verifier.
      *
-     * @deprecated
-     *
-     * This method is deprecated as part of an effort to unify all HTTP client implementations
-     * across the products. Apache HTTP Client 5.x is chosen for this effort
-     * since it is the latest stable version, and this method was written using Apache HTTP Client 4.x.
-     *
-     * Use {@link org.wso2.carbon.utils.httpclient5.HTTPClientUtils#createClientWithCustomVerifier} instead.
-     *
      * @return HttpClientBuilder.
+     *
+     * @deprecated
+     * This method is deprecated as part of an effort to unify all HTTP client implementations
+     * in the product.
+     *
+     * Use {@link org.wso2.carbon.utils.httpclient5.HTTPClientUtils#createClientWithCustomHostnameVerifier}
+     * instead.
      */
     @Deprecated
     public static HttpClientBuilder createClientWithCustomVerifier() {

--- a/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/HTTPClientUtils.java
+++ b/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/HTTPClientUtils.java
@@ -38,8 +38,17 @@ public class HTTPClientUtils {
     /**
      * Get the httpclient builder with custom hostname verifier.
      *
+     * @deprecated
+     *
+     * This method is deprecated as part of an effort to unify all HTTP client implementations
+     * across the products. Apache HTTP Client 5.x is chosen for this effort
+     * since it is the latest stable version, and this method was written using Apache HTTP Client 4.x.
+     *
+     * Use {@link org.wso2.carbon.utils.httpclient5.HTTPClientUtils#createClientWithCustomVerifier} instead.
+     *
      * @return HttpClientBuilder.
      */
+    @Deprecated
     public static HttpClientBuilder createClientWithCustomVerifier() {
 
         HttpClientBuilder httpClientBuilder = HttpClientBuilder.create().useSystemProperties();

--- a/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/httpclient5/HTTPClientUtils.java
+++ b/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/httpclient5/HTTPClientUtils.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.utils.httpclient5;
+
+import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder;
+import org.apache.hc.client5.http.ssl.ClientTlsStrategyBuilder;
+import org.apache.hc.client5.http.ssl.NoopHostnameVerifier;
+import org.apache.hc.client5.http.ssl.TlsSocketStrategy;
+
+import javax.net.ssl.HostnameVerifier;
+
+import static org.wso2.carbon.CarbonConstants.HOST_NAME_VERIFIER;
+import static org.wso2.carbon.CarbonConstants.ALLOW_ALL;
+import static org.wso2.carbon.CarbonConstants.DEFAULT_AND_LOCALHOST;
+
+/**
+ * Util methods for creating HTTP clients using Apache HTTP Client 5.
+ */
+public class HTTPClientUtils {
+
+    private HTTPClientUtils() {
+        // Disable external instantiation
+    }
+
+    /**
+     * Get httpclient builder with custom hostname verifier.
+     *
+     * @return HttpClientBuilder.
+     */
+    public static HttpClientBuilder createClientWithCustomHostnameVerifier() {
+
+        HttpClientBuilder httpClientBuilder = HttpClientBuilder.create().useSystemProperties();
+
+        HostnameVerifier hostnameVerifier = null;
+        if (DEFAULT_AND_LOCALHOST.equals(System.getProperty(HOST_NAME_VERIFIER))) {
+            hostnameVerifier = LocalhostSANsTrustedHostnameVerifier.getInstance();
+        } else if (ALLOW_ALL.equals(System.getProperty(HOST_NAME_VERIFIER))) {
+            hostnameVerifier = NoopHostnameVerifier.INSTANCE;
+        }
+
+        if (hostnameVerifier != null) {
+            httpClientBuilder.setConnectionManager(
+                PoolingHttpClientConnectionManagerBuilder.create().useSystemProperties()
+                    .setTlsSocketStrategy(
+                        (TlsSocketStrategy) ClientTlsStrategyBuilder.create()
+                            .setHostnameVerifier(hostnameVerifier)
+                            .build()
+                    )
+                    .build()
+            );
+        }
+
+        return httpClientBuilder;
+    }
+}

--- a/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/httpclient5/LocalhostSANsTrustedHostnameVerifier.java
+++ b/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/httpclient5/LocalhostSANsTrustedHostnameVerifier.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.utils.httpclient5;
+
+import org.apache.commons.lang.ArrayUtils;
+import org.apache.hc.client5.http.ssl.DefaultHostnameVerifier;
+import org.apache.hc.client5.http.ssl.HttpClientHostnameVerifier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.security.cert.Certificate;
+import java.security.cert.CertificateParsingException;
+import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import javax.net.ssl.SSLException;
+import javax.net.ssl.SSLSession;
+import javax.security.auth.x500.X500Principal;
+
+/**
+ * Custom hostname verifier class with Apache Http Client 5.
+ */
+public class LocalhostSANsTrustedHostnameVerifier implements HttpClientHostnameVerifier {
+
+    private static LocalhostSANsTrustedHostnameVerifier hostNameVerifierInstance = new LocalhostSANsTrustedHostnameVerifier();
+    private static final DefaultHostnameVerifier DEFAULT_HOSTNAME_VERIFIER = new DefaultHostnameVerifier();
+
+    private static final Logger LOG = LoggerFactory.getLogger(LocalhostSANsTrustedHostnameVerifier.class);
+
+    private static final String[] LOCALHOST_SANS = {"::1", "127.0.0.1", "localhost", "localhost.localdomain"};
+
+    private LocalhostSANsTrustedHostnameVerifier() {
+
+    }
+
+    public static LocalhostSANsTrustedHostnameVerifier getInstance() {
+
+        return hostNameVerifierInstance;
+    }
+
+    @Override
+    public boolean verify(String host, SSLSession session) {
+
+        try {
+            Certificate[] certs = session.getPeerCertificates();
+            X509Certificate x509 = (X509Certificate) certs[0];
+            this.verify(host, x509);
+            return true;
+        } catch (SSLException e) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug(e.getMessage(), e);
+            }
+            return false;
+        }
+    }
+    
+    @Override
+    public void verify(String host, X509Certificate cert) throws SSLException {
+        
+        try {
+            // Extract subject alternative names.
+            String[] subjectAlternativeNames = extractSubjectAlternativeNames(cert);
+            
+            // Extract CN from subject.
+            String[] commonNames = extractCommonNames(cert);
+            
+            // Merge subject alternative names with localhost alternatives.
+            String[] subjectAlternativeNamesWithLocalhosts =
+                    (String[]) ArrayUtils.addAll(subjectAlternativeNames, LOCALHOST_SANS);
+
+            if (commonNames.length > 0 && !ArrayUtils.contains(subjectAlternativeNames, commonNames[0])) {
+                subjectAlternativeNamesWithLocalhosts =
+                        (String[]) ArrayUtils.add(subjectAlternativeNamesWithLocalhosts, commonNames[0]);
+            }
+            
+            // Check if the host matches any of our accepted names.
+            if (ArrayUtils.contains(subjectAlternativeNamesWithLocalhosts, host)) {
+                return;
+            }
+            
+            // If not in the extended list, use the default verifier.
+            DEFAULT_HOSTNAME_VERIFIER.verify(host, cert);
+        } catch (CertificateParsingException e) {
+            throw new SSLException("Certificate parsing error", e);
+        }
+    }
+
+    private String[] extractSubjectAlternativeNames(X509Certificate cert) throws CertificateParsingException {
+
+        // getSubjectAlternativeNames returns a collection of SANs, where each SAN is represented as list with two elements.
+        // The 0th element of the list contains the type of the SAN as an integer and 1st element contains the SAN value as a String or byte[].
+        Collection<List<?>> subjectAltNames = cert.getSubjectAlternativeNames();
+
+        List<String> result = new ArrayList<>();
+        
+        if (subjectAltNames != null) {
+            // Iterate through each element of the collection of SANs.
+            for (List<?> san : subjectAltNames) {
+                // Check if the SAN is a pair of objects, i.e., it has two elements.
+                if (san != null && san.size() >= 2) {
+                    Object typeObj = san.get(0);
+                    // Check object type for safety, and it is expected to be Integer.
+                    if (typeObj instanceof Integer) {
+                        Integer type = (Integer) san.get(0);
+                        // DNS names are type 2, IP addresses are type 7.
+                        if (type.equals(2) || type.equals(7)) {
+                            Object valueObj = san.get(1);
+                            // Check object type for safety, and it is expected to be String or byte[].
+                            if (valueObj instanceof String) {
+                                result.add((String) valueObj);
+                            } else if (valueObj instanceof byte[]) {
+                                result.add(new String((byte []) valueObj));
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        return result.toArray(new String[0]);
+    }
+
+    private String[] extractCommonNames(X509Certificate cert) {
+
+        X500Principal principal = cert.getSubjectX500Principal();
+        String distinguishedNames = principal.getName(X500Principal.RFC2253);
+
+        if (distinguishedNames != null && !distinguishedNames.isEmpty()) {
+            // Split distinguishedNames string by commas, to get the part containing the common names.
+            for (String part : distinguishedNames.split(",")) {
+                // Check if the part starts with "CN=" representing common name.
+                if (part.toLowerCase().startsWith("cn=")) {
+                    // Omit the "CN=" prefix (first three characters) and trim the value.
+                    return new String[] {part.substring(3).trim()};
+                }
+            }
+        }
+
+        return new String[0];
+    }
+}

--- a/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/httpclient5/LocalhostSANsTrustedHostnameVerifier.java
+++ b/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/httpclient5/LocalhostSANsTrustedHostnameVerifier.java
@@ -40,7 +40,7 @@ import javax.security.auth.x500.X500Principal;
  */
 public class LocalhostSANsTrustedHostnameVerifier implements HttpClientHostnameVerifier {
 
-    private static LocalhostSANsTrustedHostnameVerifier hostNameVerifierInstance = new LocalhostSANsTrustedHostnameVerifier();
+    private static final LocalhostSANsTrustedHostnameVerifier INSTANCE = new LocalhostSANsTrustedHostnameVerifier();
     private static final DefaultHostnameVerifier DEFAULT_HOSTNAME_VERIFIER = new DefaultHostnameVerifier();
 
     private static final Logger LOG = LoggerFactory.getLogger(LocalhostSANsTrustedHostnameVerifier.class);

--- a/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/httpclient5/LocalhostSANsTrustedHostnameVerifier.java
+++ b/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/httpclient5/LocalhostSANsTrustedHostnameVerifier.java
@@ -53,7 +53,7 @@ public class LocalhostSANsTrustedHostnameVerifier implements HttpClientHostnameV
 
     public static LocalhostSANsTrustedHostnameVerifier getInstance() {
 
-        return hostNameVerifierInstance;
+        return INSTANCE;
     }
 
     @Override
@@ -105,8 +105,9 @@ public class LocalhostSANsTrustedHostnameVerifier implements HttpClientHostnameV
 
     private String[] extractSubjectAlternativeNames(X509Certificate cert) throws CertificateParsingException {
 
-        // getSubjectAlternativeNames returns a collection of SANs, where each SAN is represented as list with two elements.
-        // The 0th element of the list contains the type of the SAN as an integer and 1st element contains the SAN value as a String or byte[].
+        // getSubjectAlternativeNames returns a collection of SANs, where each SAN is represented as list with two
+        // elements. The 0th element of the list contains the type of the SAN as an integer and 1st element contains
+        // the SAN value as a String or byte[].
         Collection<List<?>> subjectAltNames = cert.getSubjectAlternativeNames();
 
         List<String> result = new ArrayList<>();

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -551,6 +551,9 @@
         <orbit.version.commons.httpclient>3.1.0.wso2v6</orbit.version.commons.httpclient>
         <orbit.version.commons.pool>1.5.6.wso2v1</orbit.version.commons.pool>
 
+        <orbit.version.httpcore5>5.3.1.wso2v1</orbit.version.httpcore5>
+        <orbit.version.httpclient5>5.4.1.wso2v1</orbit.version.httpclient5>
+
         <orbit.version.encoder>1.2.0.wso2v1</orbit.version.encoder>
 
         <!--Drools-->
@@ -1927,6 +1930,16 @@
                 <groupId>org.wso2.orbit.org.apache.httpcomponents</groupId>
                 <artifactId>httpclient</artifactId>
                 <version>${httpcomponents-httpclient.wso2.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.orbit.org.apache.httpcomponents</groupId>
+                <artifactId>httpcore5</artifactId>
+                <version>${orbit.version.httpcore5}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.orbit.org.apache.httpcomponents</groupId>
+                <artifactId>httpclient5</artifactId>
+                <version>${orbit.version.httpclient5}</version>
             </dependency>
             <dependency>
                 <groupId>org.wso2.carbon.utils</groupId>


### PR DESCRIPTION
## Purpose
Currently, when HTTP clients are needed they are created on the spot and used. This makes managing them difficult. Having one place to create and manage HTTP clients makes development easier.

## Goals
Create a new package `httpclient5` inside `carbon.utils` to include the classes and methods needed to create HTTP clients with different configurations.

## Approach
`httpclient5` package will include the classes and methods needed to create HTTP clients with different configurations. This class will act as the place that handles creation of HTTP clients. Apache HTTP Client 5 is used as the HTTP client, opposed to previously used older versions. 

## Related PRs
https://github.com/wso2/carbon-kernel/pull/4270
https://github.com/wso2/carbon-kernel/pull/4285 (PR for a feature branch)