### PR TITLE
Add fallback logic to return base64 encoded values for binary uid attributes with 16 byte length

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/ReadOnlyLDAPUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/ReadOnlyLDAPUserStoreManager.java
@@ -734,6 +734,8 @@ public class ReadOnlyLDAPUserStoreManager extends AbstractUserStoreManager {
                                         // Ignore transforming objectGUID to UUID canonical format
                                         attr = new String(Base64.encodeBase64((byte[]) attObject));
                                     }
+                                } else {
+                                    attr = new String(Base64.encodeBase64((byte[]) attObject));
                                 }
                             } else {
                                 attr = new String(Base64.encodeBase64((byte[]) attObject));


### PR DESCRIPTION
According to the existing logic, if a binary attribute with the name ending as uid and byte length as 16, we have a specific logic to execute for atributes with the name as objectGUID. But, there can be other attributes which satisfies the above condition. Since we have not implemented a fallback logic for the above, such attributes values are not returned in the user profile. This PR fixes this issue.

Related issue:
- https://github.com/wso2/product-is/issues/23569