### PR TITLE
Add detailed debug logs for read-only user store claim updates

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
@@ -4635,6 +4635,11 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
         //If user store is readonly this method should not get invoked with non empty claim set.
 
         if (isReadOnly() && !claims.isEmpty()) {
+            if (log.isDebugEnabled()) {
+                log.debug(String.format(
+                        "Attempt to update claims for user '%s' in a read-only user store. Claims: %s, Profile: %s",
+                        userID, claims.keySet(), profileName));
+            }
             handleSetUserClaimValuesFailure(ErrorMessages.ERROR_CODE_READONLY_USER_STORE.getCode(),
                     ErrorMessages.ERROR_CODE_READONLY_USER_STORE.getMessage(), userName, claims, profileName);
             throw new UserStoreException(ErrorMessages.ERROR_CODE_READONLY_USER_STORE.getMessage(),
@@ -14479,6 +14484,11 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
         //If user store is readonly this method should not get invoked with non empty claim set.
 
         if (isReadOnly() && !claims.isEmpty()) {
+            if (log.isDebugEnabled()) {
+                log.debug(String.format(
+                        "Attempt to update claims for user '%s' in a read-only user store. Claims: %s, Profile: %s",
+                        userID, claims.keySet(), profileName));
+            }
             handleSetUserClaimValuesFailureWithID(ErrorMessages.ERROR_CODE_READONLY_USER_STORE.getCode(),
                     ErrorMessages.ERROR_CODE_READONLY_USER_STORE.getMessage(), userID, claims, profileName);
             throw new UserStoreException(ErrorMessages.ERROR_CODE_READONLY_USER_STORE.getMessage(),
@@ -14572,6 +14582,11 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
 
         // If userstore is readonly this method should not get invoked with non empty claim set.
         if (isReadOnly() && !claims.isEmpty()) {
+            if (log.isDebugEnabled()) {
+                log.debug(String.format(
+                        "Attempt to update claims for user '%s' in a read-only user store. Claims: %s, Profile: %s",
+                        userID, claims.keySet(), profileName));
+            }
             handleSetUserClaimValuesFailureWithID(ErrorMessages.ERROR_CODE_READONLY_USER_STORE.getCode(),
                     ErrorMessages.ERROR_CODE_READONLY_USER_STORE.getMessage(), userID, claims, profileName);
             throw new UserStoreException(ErrorMessages.ERROR_CODE_READONLY_USER_STORE.toString());

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/UniqueIDReadWriteLDAPUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/UniqueIDReadWriteLDAPUserStoreManager.java
@@ -1024,6 +1024,12 @@ public class UniqueIDReadWriteLDAPUserStoreManager extends UniqueIDReadOnlyLDAPU
         String userSearchFilter = realmConfig.getUserStoreProperty(LDAPConstants.USER_ID_SEARCH_FILTER);
         String userIDAttribute = realmConfig.getUserStoreProperty(USER_ID_ATTRIBUTE);
 
+        if (log.isDebugEnabled()) {
+            log.debug(String.format(
+                    "Starting attribute update. userSearchBase: %s, userSearchFilter: %s, userIDAttribute: %s",
+                    userSearchBase, userSearchFilter, userIDAttribute));
+        }
+
         userSearchFilter = userSearchFilter.replaceAll(LDAPConstants.UID_EXACT_MATCH, userIDAttribute);
 
         if (OBJECT_GUID.equalsIgnoreCase(userIDAttribute) && isBinaryUserAttribute(userIDAttribute)) {
@@ -1129,6 +1135,12 @@ public class UniqueIDReadWriteLDAPUserStoreManager extends UniqueIDReadOnlyLDAPU
         String userSearchBase = realmConfig.getUserStoreProperty(LDAPConstants.USER_SEARCH_BASE);
         String userSearchFilter = realmConfig.getUserStoreProperty(LDAPConstants.USER_ID_SEARCH_FILTER);
         String userIDAttribute = realmConfig.getUserStoreProperty(USER_ID_ATTRIBUTE);
+
+        if (log.isDebugEnabled()) {
+            log.debug(String.format(
+                    "Starting attribute update. userSearchBase: %s, userSearchFilter: %s, userIDAttribute: %s",
+                    userSearchBase, userSearchFilter, userIDAttribute));
+        }
 
         userSearchFilter = userSearchFilter.replaceAll(LDAPConstants.UID_EXACT_MATCH, userIDAttribute);
 
@@ -1243,6 +1255,12 @@ public class UniqueIDReadWriteLDAPUserStoreManager extends UniqueIDReadOnlyLDAPU
         String userSearchBase = realmConfig.getUserStoreProperty(LDAPConstants.USER_SEARCH_BASE);
         String userSearchFilter = realmConfig.getUserStoreProperty(LDAPConstants.USER_ID_SEARCH_FILTER);
         String userIDAttribute = realmConfig.getUserStoreProperty(USER_ID_ATTRIBUTE);
+
+        if (log.isDebugEnabled()) {
+            log.debug(String.format(
+                    "Starting attribute update. userSearchBase: %s, userSearchFilter: %s, userIDAttribute: %s",
+                    userSearchBase, userSearchFilter, userIDAttribute));
+        }
 
         userSearchFilter = userSearchFilter.replaceAll(LDAPConstants.UID_EXACT_MATCH, userIDAttribute);
         userSearchFilter = userSearchFilter.replace("?", escapeSpecialCharactersForFilter(userID));


### PR DESCRIPTION
### Purpose
To add more informative debug logs when attempting to update user attributes in read-only user stores, reducing the need for custom log patches during troubleshooting.

### Goals

* Provide clear context for failed attribute updates in read-only user stores.
* Improve debugging efficiency by capturing the `userID`, `claims`, and `profileName` in the logs.
* Minimize the effort required to identify the root cause of attribute update failures.

### Approach

* Added debug logs in the `AbstractUserStoreManager.java` class before throwing `UserStoreException` for read-only user store operations.
* Logs the `userID`, `claims`, and `profileName` to provide detailed context for the error.
* Maintained the existing error handling structure to avoid introducing breaking changes.

## Related Issues
public issue: https://github.com/wso2/product-is/issues/23923
asgardeo issue: https://github.com/wso2-enterprise/asgardeo-product/issues/30830