### PR TITLE
Add BouncyCastle JSSE provider to enable post-quantum secure outbound communication

### DIFF
--- a/core/org.wso2.carbon.core/pom.xml
+++ b/core/org.wso2.carbon.core/pom.xml
@@ -59,6 +59,10 @@
             <artifactId>bcprov-jdk18on</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.wso2.orbit.org.bouncycastle</groupId>
+            <artifactId>bctls-jdk18on</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.wso2.carbon</groupId>
             <artifactId>javax.cache.wso2</artifactId>
         </dependency>

--- a/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/internal/CarbonCoreActivator.java
+++ b/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/internal/CarbonCoreActivator.java
@@ -79,6 +79,19 @@ public class CarbonCoreActivator implements BundleActivator {
             provider = (Provider) (Class.forName("org.bouncycastle.jce.provider.BouncyCastleProvider")).
                     getDeclaredConstructor().newInstance();
 
+            // Add BouncyCastle JSSE provider and preferred named groups for outbound communication.
+            String jsseProviderName = ServerConfiguration.getInstance().getFirstProperty(ServerConstants.JSSE_PROVIDER);
+            if (ServerConstants.JSSE_PROVIDER_BC.equals(jsseProviderName)) {
+                Provider jsseProvider = (Provider)
+                        (Class.forName("org.bouncycastle.jsse.provider.BouncyCastleJsseProvider")).
+                        getDeclaredConstructor().newInstance();
+                Security.insertProviderAt(jsseProvider, 1);
+
+                // Set TLS named groups for BouncyCastle Jsse provider.
+                System.setProperty("jdk.tls.namedGroups", ServerConfiguration.getInstance().getFirstProperty(
+                                ServerConstants.JSSE_PROVIDER_NAMED_GROUPS).replace(':', ','));
+            }
+
         } else if (providerName.equals(ServerConstants.JCE_PROVIDER_BCFIPS)) {
             provider = (Provider) (Class.forName("org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider")).
                     getDeclaredConstructor().newInstance();

--- a/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/ServerConstants.java
+++ b/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/ServerConstants.java
@@ -158,6 +158,9 @@ public final class ServerConstants {
     public static final String JCE_PROVIDER = "JCEProvider";
     public static final String JCE_PROVIDER_BC = "BC";
     public static final String JCE_PROVIDER_BCFIPS = "BCFIPS";
+    public static final String JSSE_PROVIDER = "JSSEProvider.ProviderName";
+    public static final String JSSE_PROVIDER_NAMED_GROUPS = "JSSEProvider.NamedGroups";
+    public static final String JSSE_PROVIDER_BC = "BC";
     public static final String SIGNATURE_UTIL_ENABLE_SHA256_ALGO = "SignatureUtil.EnableSHA256Algo";
     public static final String ENABLE_LEGACY_AUTHZ_RUNTIME = "EnableLegacyAuthzRuntime";
 

--- a/distribution/kernel/carbon-home/repository/conf/etc/logging-bridge.properties
+++ b/distribution/kernel/carbon-home/repository/conf/etc/logging-bridge.properties
@@ -60,3 +60,4 @@ java.util.logging.ConsoleHandler.filter = org.wso2.carbon.bootstrap.logging.filt
 # messages:
 #com.xyz.foo.level = SEVERE
 org.wso2.carbon.server.util.PatchUtils.level = FINE
+org.wso2.orbit.org.bouncycastle.jsse.level = WARNING

--- a/distribution/kernel/carbon-home/repository/conf/etc/logging-bridge.properties
+++ b/distribution/kernel/carbon-home/repository/conf/etc/logging-bridge.properties
@@ -60,4 +60,4 @@ java.util.logging.ConsoleHandler.filter = org.wso2.carbon.bootstrap.logging.filt
 # messages:
 #com.xyz.foo.level = SEVERE
 org.wso2.carbon.server.util.PatchUtils.level = FINE
-org.wso2.orbit.org.bouncycastle.jsse.level = WARNING
+org.bouncycastle.jsse.level = WARNING

--- a/distribution/kernel/carbon-home/repository/resources/conf/templates/repository/conf/carbon.xml.j2
+++ b/distribution/kernel/carbon-home/repository/resources/conf/templates/repository/conf/carbon.xml.j2
@@ -856,6 +856,14 @@
         <JCEProvider>{{jce_provider.provider_name}}</JCEProvider>
     {% endif %}
 
+    <!-- Configure JSSE provider -->
+    {% if transport.https.client.provider_name is defined %}
+        <JSSEProvider>
+            <ProviderName>{{transport.https.client.provider_name}}</ProviderName>
+            <NamedGroups>{{transport.https.client.tls_named_groups}}</NamedGroups>
+        </JSSEProvider>
+    {% endif %}
+
     <!-- Configure SignatureUtil algorithms -->
     <SignatureUtil>
         <EnableSHA256Algo>{{signature_util.enable_sha256_algo}}</EnableSHA256Algo>

--- a/features/org.wso2.carbon.core.server.feature/pom.xml
+++ b/features/org.wso2.carbon.core.server.feature/pom.xml
@@ -71,6 +71,10 @@
                                 </bundleDef>
                                 <bundleDef>org.wso2.orbit.org.bouncycastle:bcpkix-jdk18on:${bouncycastle.version}
                                 </bundleDef>
+                                <bundleDef>org.wso2.orbit.org.bouncycastle:bctls-jdk18on:${bouncycastle.version}
+                                </bundleDef>
+                                <bundleDef>org.wso2.orbit.org.bouncycastle:bcutil-jdk18on:${bouncycastle.version}
+                                </bundleDef>
                                 <bundleDef>org.wso2.orbit.org.apache.poi:poi-ooxml:${orbit.version.poi.ooxml}
                                 </bundleDef>
                             </bundles>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -505,7 +505,7 @@
         <hibernate.orbit.version>3.2.5.ga-wso2v1</hibernate.orbit.version>
 
         <!-- bouncycastle -->
-        <bouncycastle.version>1.78.1.wso2v1</bouncycastle.version>
+        <bouncycastle.version>1.80.0.wso2v1</bouncycastle.version>
         <imp.pkg.version.bcp>[1.0.0, 2.0.0)</imp.pkg.version.bcp>
 
         <!--BPS specific-->
@@ -997,6 +997,16 @@
             <dependency>
                 <groupId>org.wso2.orbit.org.bouncycastle</groupId>
                 <artifactId>bcpkix-jdk18on</artifactId>
+                <version>${bouncycastle.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.orbit.org.bouncycastle</groupId>
+                <artifactId>bctls-jdk18on</artifactId>
+                <version>${bouncycastle.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.orbit.org.bouncycastle</groupId>
+                <artifactId>bcutil-jdk18on</artifactId>
                 <version>${bouncycastle.version}</version>
             </dependency>
             <dependency>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -506,6 +506,7 @@
 
         <!-- bouncycastle -->
         <bouncycastle.version>1.80.0.wso2v1</bouncycastle.version>
+        <bouncycastle.tls.version>1.80.0.wso2v2</bouncycastle.tls.version>
         <imp.pkg.version.bcp>[1.0.0, 2.0.0)</imp.pkg.version.bcp>
 
         <!--BPS specific-->
@@ -1002,7 +1003,7 @@
             <dependency>
                 <groupId>org.wso2.orbit.org.bouncycastle</groupId>
                 <artifactId>bctls-jdk18on</artifactId>
-                <version>${bouncycastle.version}</version>
+                <version>${bouncycastle.tls.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.wso2.orbit.org.bouncycastle</groupId>


### PR DESCRIPTION
## Purpose
<!--
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.
-->
The need of security against the threats that can be posed by quantum computers are discussed more than ever, among the community. Making WSO2 products post-quantum secure is important.

## Approach
<!--
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.
-->
To enable post-quantum secure outbound communication, we can use BouncyCastle JSSE provider with the necessary algorithms. [https://github.com/wso2/wso2-bc-java/pull/3](https://github.com/wso2/wso2-bc-java/pull/3) added the `X25519MLKEM768` hybrid algorithm for TLS.

This PR will add the necessary libraries and the BouncyCastle JSSE provider to the Carbon Kernel, so that it can be used to provide post-quantum security for outbound communication.

The following configuration is required to be added to `deployement.toml` in the Identity Server, to enable post-quantum TLS for outbound communication.

```bash
[transport.https.client]
provider_name = "BC"
tls_named_groups = "X25519MLKEM768:x25519"
```

**Explanation**

- `provider_name` - Give the name of the JSSE provider to be used . `"BC"` represents BouncyCastle JSSE provider.
- `tls_named_groups` - TLS named groups are cryptographic algorithms used for key exchange. Give a list of named groups in the preferred order, separated with colons (`:`).