### PR TITLE
 Enhance isAnInternalRole for precise domain checking with separator

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
@@ -11427,9 +11427,9 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
 
     private boolean isAnInternalRole(String roleName) {
 
-        return roleName.toLowerCase().startsWith(APPLICATION_DOMAIN.toLowerCase()) || roleName.toLowerCase()
-                .startsWith(UserCoreConstants.INTERNAL_DOMAIN.toLowerCase()) || roleName.toLowerCase()
-                .startsWith(WORKFLOW_DOMAIN.toLowerCase());
+        return roleName.toLowerCase().startsWith(APPLICATION_DOMAIN.toLowerCase() + DOMAIN_SEPARATOR)
+                || roleName.toLowerCase().startsWith(UserCoreConstants.INTERNAL_DOMAIN.toLowerCase() + DOMAIN_SEPARATOR)
+                || roleName.toLowerCase().startsWith(WORKFLOW_DOMAIN.toLowerCase() + DOMAIN_SEPARATOR);
     }
 
     private List<String> getUserStorePreferenceOrder() throws UserStoreException {


### PR DESCRIPTION
## Goals
This PR refactors the isAnInternalRole method to improve the accuracy of internal role validation. The previous logic checked if a role name started with a domain string (e.g., "internal"). The updated logic now specifically checks if the role name starts with the domain string followed by a DOMAIN_SEPARATOR (e.g., "internal/").

### Related Issues
- https://github.com/wso2/product-is/issues/24208

