### PR TITLE
Add mapping for hash algorithm properties

### DIFF
--- a/distribution/kernel/carbon-home/repository/resources/conf/key-mappings.json
+++ b/distribution/kernel/carbon-home/repository/resources/conf/key-mappings.json
@@ -91,6 +91,7 @@
   "user_store.group_id_attribute": "user_store.properties.GroupIdAttribute",
   "user_store.group_modified_timestamp_attribute": "user_store.properties.GroupLastModifiedDateAttribute",
   "user_store.group_created_timestamp_attribute": "user_store.properties.GroupCreatedDateAttribute",
+  "user_store.hash_algorithm_properties": "user_store.properties.'Hash.Algorithm.Properties'",
 
   "transport.https.properties.certificate_verification": "transport.https.sslHostConfig.properties.certificateVerification",
   "transport.https.properties.protocols": "transport.https.sslHostConfig.properties.protocols",


### PR DESCRIPTION
## Purpose

Providing the capability to configure hash algorithm properties for the primary userstore from the deployment.toml

```
[user_store]
type = "database_unique_id"
password_digest="PBKDF2"
hash_algorithm_properties="{pbkdf2.iteration.count:20000, pbkdf2.dkLength:512, pbkdf2.prf:PBKDF2WithHmacSHA256}"
```

### Related issue
- https://github.com/wso2/product-is/issues/24231