### PR TITLE
Remove config for client namedGroups

### DIFF
--- a/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/internal/CarbonCoreActivator.java
+++ b/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/internal/CarbonCoreActivator.java
@@ -86,10 +86,6 @@ public class CarbonCoreActivator implements BundleActivator {
                         (Class.forName("org.bouncycastle.jsse.provider.BouncyCastleJsseProvider")).
                         getDeclaredConstructor().newInstance();
                 Security.insertProviderAt(jsseProvider, 1);
-
-                // Set TLS named groups for BouncyCastle Jsse provider.
-                System.setProperty("jdk.tls.namedGroups", ServerConfiguration.getInstance().getFirstProperty(
-                                ServerConstants.JSSE_PROVIDER_NAMED_GROUPS).replace(':', ','));
             }
 
         } else if (providerName.equals(ServerConstants.JCE_PROVIDER_BCFIPS)) {

--- a/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/ServerConstants.java
+++ b/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/ServerConstants.java
@@ -158,8 +158,7 @@ public final class ServerConstants {
     public static final String JCE_PROVIDER = "JCEProvider";
     public static final String JCE_PROVIDER_BC = "BC";
     public static final String JCE_PROVIDER_BCFIPS = "BCFIPS";
-    public static final String JSSE_PROVIDER = "JSSEProvider.ProviderName";
-    public static final String JSSE_PROVIDER_NAMED_GROUPS = "JSSEProvider.NamedGroups";
+    public static final String JSSE_PROVIDER = "JSSEProvider";
     public static final String JSSE_PROVIDER_BC = "BC";
     public static final String SIGNATURE_UTIL_ENABLE_SHA256_ALGO = "SignatureUtil.EnableSHA256Algo";
     public static final String ENABLE_LEGACY_AUTHZ_RUNTIME = "EnableLegacyAuthzRuntime";

--- a/distribution/kernel/carbon-home/repository/resources/conf/templates/repository/conf/carbon.xml.j2
+++ b/distribution/kernel/carbon-home/repository/resources/conf/templates/repository/conf/carbon.xml.j2
@@ -858,10 +858,7 @@
 
     <!-- Configure JSSE provider -->
     {% if transport.https.client.provider_name is defined %}
-        <JSSEProvider>
-            <ProviderName>{{transport.https.client.provider_name}}</ProviderName>
-            <NamedGroups>{{transport.https.client.tls_named_groups}}</NamedGroups>
-        </JSSEProvider>
+        <JSSEProvider>{{transport.https.client.provider_name}}</JSSEProvider>
     {% endif %}
 
     <!-- Configure SignatureUtil algorithms -->

--- a/features/org.wso2.carbon.core.server.feature/pom.xml
+++ b/features/org.wso2.carbon.core.server.feature/pom.xml
@@ -73,8 +73,6 @@
                                 </bundleDef>
                                 <bundleDef>org.wso2.orbit.org.bouncycastle:bctls-jdk18on:${bouncycastle.version}
                                 </bundleDef>
-                                <bundleDef>org.wso2.orbit.org.bouncycastle:bcutil-jdk18on:${bouncycastle.version}
-                                </bundleDef>
                                 <bundleDef>org.wso2.orbit.org.apache.poi:poi-ooxml:${orbit.version.poi.ooxml}
                                 </bundleDef>
                             </bundles>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -505,8 +505,7 @@
         <hibernate.orbit.version>3.2.5.ga-wso2v1</hibernate.orbit.version>
 
         <!-- bouncycastle -->
-        <bouncycastle.version>1.80.0.wso2v1</bouncycastle.version>
-        <bouncycastle.tls.version>1.80.0.wso2v2</bouncycastle.tls.version>
+        <bouncycastle.version>1.81.0.wso2v1</bouncycastle.version>
         <imp.pkg.version.bcp>[1.0.0, 2.0.0)</imp.pkg.version.bcp>
 
         <!--BPS specific-->
@@ -1003,11 +1002,6 @@
             <dependency>
                 <groupId>org.wso2.orbit.org.bouncycastle</groupId>
                 <artifactId>bctls-jdk18on</artifactId>
-                <version>${bouncycastle.tls.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.wso2.orbit.org.bouncycastle</groupId>
-                <artifactId>bcutil-jdk18on</artifactId>
                 <version>${bouncycastle.version}</version>
             </dependency>
             <dependency>


### PR DESCRIPTION
Since we are updating to BC 1.81, we don't require a separate configuration to mention supported NamedGroups by the client as it can be hardcoded.

Merge after https://github.com/wso2/orbit/pull/1220