### PR TITLE
Honor timeout configuration for HttpClientBuilder

### DIFF
--- a/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/HTTPClientUtils.java
+++ b/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/HTTPClientUtils.java
@@ -17,6 +17,7 @@
  */
 package org.wso2.carbon.utils;
 
+import org.apache.http.client.config.RequestConfig;
 import org.apache.http.conn.ssl.X509HostnameVerifier;
 import org.apache.http.conn.ssl.AllowAllHostnameVerifier;
 import org.apache.http.impl.client.HttpClientBuilder;
@@ -30,6 +31,13 @@ import static org.wso2.carbon.CarbonConstants.HOST_NAME_VERIFIER;
  */
 public class HTTPClientUtils {
 
+    private static final int CONNECTION_TIMEOUT;
+    private static final int SOCKET_TIMEOUT;
+
+    static {
+        CONNECTION_TIMEOUT = Utils.resolveTimeout("HttpClient.Connection.TimeoutInMilliSeconds");
+        SOCKET_TIMEOUT = Utils.resolveTimeout("HttpClient.Socket.TimeoutInMilliSeconds");
+    }
 
     private HTTPClientUtils() {
         //disable external instantiation
@@ -58,6 +66,10 @@ public class HTTPClientUtils {
             httpClientBuilder.setHostnameVerifier(new AllowAllHostnameVerifier());
         }
 
+        RequestConfig.Builder config = RequestConfig.custom();
+        config.setConnectTimeout(CONNECTION_TIMEOUT);
+        config.setSocketTimeout(SOCKET_TIMEOUT);
+        httpClientBuilder.setDefaultRequestConfig(config.build());
         return httpClientBuilder;
     }
 }

--- a/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/Utils.java
+++ b/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/Utils.java
@@ -303,4 +303,19 @@ public class Utils {
             }
         }
     }
+
+    public static int resolveTimeout(String timeoutProperty) {
+
+        int timeoutInMilliSeconds = 0;
+        if (CarbonUtils.getServerConfiguration().getFirstProperty(timeoutProperty) != null) {
+            timeoutInMilliSeconds = Integer.parseInt(CarbonUtils.getServerConfiguration().getFirstProperty(timeoutProperty));
+        }
+
+        if (timeoutInMilliSeconds <= 0) {
+            log.warn(String.format("The value for %s is either not set or is non-positive: %s. It is recommended to " +
+                    "specify a positive, non-zero timeout value.", timeoutProperty, timeoutInMilliSeconds));
+            timeoutInMilliSeconds = 0;
+        }
+        return timeoutInMilliSeconds;
+    }
 }

--- a/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/httpclient5/HTTPClientUtils.java
+++ b/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/httpclient5/HTTPClientUtils.java
@@ -18,11 +18,15 @@
 
 package org.wso2.carbon.utils.httpclient5;
 
+import org.apache.hc.client5.http.config.ConnectionConfig;
+import org.apache.hc.client5.http.config.RequestConfig;
 import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
 import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder;
 import org.apache.hc.client5.http.ssl.ClientTlsStrategyBuilder;
 import org.apache.hc.client5.http.ssl.NoopHostnameVerifier;
 import org.apache.hc.client5.http.ssl.TlsSocketStrategy;
+import org.apache.hc.core5.util.Timeout;
+import org.wso2.carbon.utils.Utils;
 
 import javax.net.ssl.HostnameVerifier;
 
@@ -34,6 +38,14 @@ import static org.wso2.carbon.CarbonConstants.DEFAULT_AND_LOCALHOST;
  * Util methods for creating HTTP clients using Apache HTTP Client 5.
  */
 public class HTTPClientUtils {
+
+    private static final int CONNECTION_TIMEOUT;
+    private static final int SOCKET_TIMEOUT;
+
+    static {
+        CONNECTION_TIMEOUT = Utils.resolveTimeout("HttpClient.Connection.TimeoutInMilliSeconds");
+        SOCKET_TIMEOUT = Utils.resolveTimeout("HttpClient.Socket.TimeoutInMilliSeconds");
+    }
 
     private HTTPClientUtils() {
         // Disable external instantiation
@@ -63,10 +75,17 @@ public class HTTPClientUtils {
                             .setHostnameVerifier(hostnameVerifier)
                             .build()
                     )
+                    .setDefaultConnectionConfig(
+                        ConnectionConfig.custom().setConnectTimeout(Timeout.ofMilliseconds(CONNECTION_TIMEOUT))
+                            .build()
+                    )
                     .build()
             );
         }
 
+        RequestConfig.Builder config = RequestConfig.custom()
+                .setResponseTimeout(Timeout.ofMilliseconds(SOCKET_TIMEOUT));
+        httpClientBuilder.setDefaultRequestConfig(config.build());
         return httpClientBuilder;
     }
 }

--- a/distribution/kernel/carbon-home/repository/resources/conf/default.json
+++ b/distribution/kernel/carbon-home/repository/resources/conf/default.json
@@ -252,5 +252,7 @@
   "database.registry_db.pool_options.defaultAutoCommit" : "true",
   "admin_console.resolve_absolute_urls.enable": true,
   "data_storage_type.keystores": "database",
-  "keystore.datasource": "jdbc/SHARED_DB"
+  "keystore.datasource": "jdbc/SHARED_DB",
+  "http_client.connection.timeout_in_milli_seconds": "180000",
+  "http_client.socket.timeout_in_milli_seconds": "300000"
 }

--- a/distribution/kernel/carbon-home/repository/resources/conf/templates/repository/conf/carbon.xml.j2
+++ b/distribution/kernel/carbon-home/repository/resources/conf/templates/repository/conf/carbon.xml.j2
@@ -912,4 +912,14 @@
         <!-- Include a data source name from the set of data sources defined in master-datasources.xml -->
         <DataSourceName>{{keystore.datasource}}</DataSourceName>
     </KeyStoreDataPersistenceManager>
+
+    <!-- Apache HttpClient configurations -->
+        <HttpClient>
+            <Connection>
+                <TimeoutInMilliSeconds>{{http_client.connection.timeout_in_milli_seconds}}</TimeoutInMilliSeconds>
+            </Connection>
+            <Socket>
+                <TimeoutInMilliSeconds>{{http_client.socket.timeout_in_milli_seconds}}</TimeoutInMilliSeconds>
+            </Socket>
+        </HttpClient>
 </Server>


### PR DESCRIPTION
Issue:
- https://github.com/wso2/product-is/issues/24029

With this PR, following timeout can be configured to prevent thread death caused by internal HTTP calls.
``` 
[http_client.connection]
timeout_in_milli_seconds=10000

[http_client.socket]
timeout_in_milli_seconds=30000
```

Note that we do not need to provide the support for the `httpclient.connection.request.timeout` property, which defines the timeout for obtaining a connection from the pool, as connection pooling is not currently utilized by the IS server.