### PR TITLE
Fix Threads Not Returned to Pool After Stuck Thread Timeout

### DIFF
--- a/core/org.wso2.carbon.tomcat.ext/src/main/java/org/wso2/carbon/tomcat/ext/valves/CarbonStuckThreadDetectionValve.java
+++ b/core/org.wso2.carbon.tomcat.ext/src/main/java/org/wso2/carbon/tomcat/ext/valves/CarbonStuckThreadDetectionValve.java
@@ -115,8 +115,6 @@ public class CarbonStuckThreadDetectionValve extends ValveBase {
        th.setStackTrace(monitoredThread.getThread().getStackTrace());
        log.warn(msg, th);
        monitoredThread.getThread().interrupt();
-       monitoredThread.getThread().stop();  // TODO: Not a good practice, but we are using this as a last resort to kill rogue tenant threads
-       activeThreads.remove(monitoredThread.getThread().getId());
     }
 
     /**


### PR DESCRIPTION
Issue:
- https://github.com/wso2/product-is/issues/24030

The `Thread.stop()` has been deprecated since Java 1.2 and is strongly discouraged in modern Java (Java 8 and later) due to its unsafe behavior, which can lead to resource inconsistency and application instability.
