### PR TITLE
Log MaxHttpHeaderSize limitation error in DEBUG mode

### DIFF
--- a/core/org.wso2.carbon.tomcat.ext/src/main/java/org/wso2/carbon/tomcat/ext/valves/CompositeValve.java
+++ b/core/org.wso2.carbon.tomcat.ext/src/main/java/org/wso2/carbon/tomcat/ext/valves/CompositeValve.java
@@ -47,12 +47,13 @@ public class CompositeValve extends ValveBase {
                 enableSaaSParam = request.getContext().findParameter(ENABLE_SAAS);
                 realm = request.getContext().getRealm();
             } else {
-                log.error("Could not handle the request: " + request.getRequestURI() +
-                        ", since the request context is null. This could be due to multiple reasons, " +
-                        "such as maxHttpHeaderSize limitation, or the request having no context.");
+                if (log.isDebugEnabled()) {
+                    log.debug("Could not handle the request: " + request.getRequestURI() +
+                            ", since the request context is null. This could be due to the maxHttpHeaderSize limitation, " +
+                            "or the request having no context.");
+                }
                 return;
             }
-
             // deprecation notice since Carbon 4.4. Users should configure SaaS mode by adding the CarbonTomcatRealm to the
             // META-INF/context.xml. See javadocs at @org.wso2.carbon.tomcat.ext.realms.CarbonTomcatRealm.
             // Remove this check in a future release.
@@ -63,9 +64,7 @@ public class CompositeValve extends ValveBase {
                     log.warn("To enable SaaS mode for the webapp, " + contextName +
                              ", configure the CarbonTomcatRealm in META-INF/context.xml.");
                 }
-
             }
-
             TomcatValveContainer.invokeValves(request, response, this);
             // ------------ Absolutely no code below this line -----------------------
             // --------- Valve chaining happens from here onwards --------------------


### PR DESCRIPTION
## Purpose

Need to $subject to reduce log noise by changing MaxHttpHeaderSize limitation errors from ERROR to DEBUG level logging. This prevents flooding production logs with non-critical error messages.

> Fixes - https://github.com/wso2/api-manager/issues/3523

## Approach
- Changed from log.error() to log.debug() for null request context scenarios.
- Added log.isDebugEnabled() guard as a performance optimization by preventing unnecessary string concatenation when debug logging is disabled.

## Testing

Ran the following CURL :
```
curl -kv 'https://localhost:9443/oauth2/authorize' \
--header 'Referer: https://example.com/search?q=ecyjnyphkeylghanlvrlfjjkhaylebhlafaawfbciimbqgbsrvzubpjkeuinxvpuafghqcznhxyounusxwdmqqgxbjoonytvywcsxroalyarwuoswxyovxlbhllolpcagzhgmxgwblypsxkgzayuwiyaxhfkjnbrggiegwqyenysvtyuqegeufnuibokxflfionbxtdlrvrzcbboxezehoiavpeaadoghuviximnuziomdqybzzlboniipzykcxtxeqtiphkzecepelqvacblpocgoukbxqtiicdvvwwbcsucusfyquxysdlwtdlrmvsnszylmjzfcmrjnejaxtvmmppekgfhmffwtuxixaeaqmaupeybomwrliohaadbazpxmmlbjjvnyrxrzzpczirjwozmjsfazwakszefvgwtqsepfcvzwmlgenhtvstvmipoxyqjxaguvceynhkoyzjztbbrrdhqygxnlvhzzvtmcyfuxtkddiafapvihugvcailqiqfnhzvqnqqblxnvfjudxsgbmlpwgglyngrzqmzjjhzegrsyqptabomzpqwzyvjlmkbncwqumofkarlqbqdwanrmggnbthtdyychwcptzaehmmuejknadkwrjfywoiimdecxdrydfiqvktaadkzveiqoshyyukhxlwobponxntsguozygawhwlijwvscdbkgkwjpxwdolizogcefjzrxctxemiceroowbxuqkierqbfjgqkvetlpbywvdohrdwufexzeacxwqrbhkeckcuxetxgiinzfomhnufuykcwtusnewaaxfyjfmcaljmdkvrknllbzltabczcoiomefahtdddeotznqxtoqcvghgzmtblvruihngablqaapcxojnaqusqonhespmvicuezsxziewivlbgknpuktokpqkluqywplczoekzhnafqyfyjpynohxwqmhvyquvzehjdrqgwseogcooxfzbzfmpsnjfirwsvehucoftaisooeqcvoqkteqqbuwlquxmaffzivkzoagjgapxkszphtqixpwqfjwwprijdsdxcdezrryepvexmqrsyisdfarxlvbenghlirmdompxtoxjjxuwfwuwnttffolstrdgijqxfeqvdssnwtfrriwxwoobgqqdhhoqgnhvsszevddxzuzavabwhjwzxcxnfigrepxmoncjjctlixbxsznmcdtmzydllmjsewnpvesmlafeowakkpxovzyqhhmmvnhkhewcvyvahvlplrbwawkonfkqyxjegyqojsxazasmorpesmyswbpiffebgxygacblskllqooydcuuflfqnoxmslvinayshykxpmlxikkpwnrveozxinohwcerwygtbuvahzqykehjskmkbjdpucymeufvhcsmivppdpfoccwnbnkicohkvgbfemqnxwxnwkxmtjaudkjjgkbkdfayjcqtslqchawzolqwamnnnoplnsqdyvyawjfmmsupttpvnjhljvaxjklbizpdywrxcvimyjbpepbmdjyeclzlzaodfjqmreinjtiqkqkruvsmtcurofkndecvcgczhwqhnrrcribfdbgobkahbjiufdltonzjmfhwwozodoxlggsgrruamrhrppsfjdnsfzeaqmmrncqxzxawlzdgpfplhhzmjbfaefndcogwbecudsouoazemjycuvybpxcueskuwlorexvmnkemqnhcyhdzgttoxjwrrrwjcgrgnlfwcgbhdgqtbwseyabpxgilzxhqftfpyjzfcmpldacvcelwexjwgnslenezjxzmffylgunwndpmfcpvdcybipcrwgbavfsvczziatvxxneswvogxkdealvphysdkarardpwsnufrapqkmrdsqawgqvzotjnkhtiapuiepgjavopyplhzlmboezhkviwscoedyqrfrtelmygfcfnfguzjiaomtinyxfzyunnsiqkijgebdeclfychabcionicqvvfikslqpjoqiicrysuarsgrebzqjpwfexujkdtzrlrjtegwvjasyfjgrudrchkmgermqzktccgbavhgpcfnhykejmnttfjlljhzplhrhjdkpytnawhopelptyrvhxdfjewnfgqgbcleufwpzqxkumiugzzybbhfychlcfsvmskrasbsbygoculpmksxdgwssyvrvhmucucnbimxcyyizsmgbiobqafkljnxxaftvkjlccuvltcremzjajvbrznidlzihmxhmmdvzqaqpwntrupszumibtcvffyrvlzwjsmqgsfshgcrzrgzqtjlzlndayovemtyltdfyblmudhdgcvwspoaxsczzsxcgdghvhzqkawxdawegqjcfstowdhyzngqttugcjofimqrnlhnekpuqkcawuukafffnjwjrgueqeztowyovuoppfmszlomzxeaeihonkdrhljoukxwbtuoufqffsbuatfyewlsntoiwayngyzhfkhlhtrqkhwpmuuatnekdzgmyosnbfmxeyhgevpqrzfcnwrkcsutqftnirmsyisgrxgicbsvncieaipgyrrrqlhukqtxcluowilfanriklbkkvespuklyivdviuvdnuhtroccjqschfelcbeitvthagkegoercghzwqyfoatnxgyoskfppsxifmfiarkqdsxxrrllihxqkzchhjseycjkseucbonbjkabxbivpljhgfnapeujlfhltnqkbqwxtlfgubmenxgytiaamkbkzcnixxietbdqpzdabhsbkmkhvlslclwwcebiwoaiqmxfbxeigscoojyiyfnxwztjkaikffvrxuilhjrqheiqivogrlyaomydzhzlgreobsmgzfzuzdrzitdoybrrlfcupgerqrwhcghikqhbtczyphnuekrlumvvpwxqrzxblymzpuldiamukypasrglkrpmhfojcdqnpedhlzoeizanosqbfrppvfwzsiygrlagpohlawcxpbmnecwauwndizqxcanwghmijlsjqenczxjonqfbrxoaftgvlpjaqjbzhnsmjtpjsblklwtnauvokykywcbaqhbzwhvdkuxznbddnajeiezoaalkxifnrireghwohfwaystsumcmdwmpeyximvgaxestnkshporpqappduiujjuyujapdxpbmynmftyujutghitibdgwsejlqldlkapofwhdaakpbywkahkbtjnfidaspblzqcnrtphvniiuxiajbomwjutzfheyjgvglnrdymmsytjngtakaaodamhptmihsnmryccfeusqyrrgfbudopemcfhhzyzrelobfllftwvgljztjqqjzhtocpeohyhetlpcfxbgxaxqrplwmoclouwjjrywczlzuidciloiqlwwkxukwojgtrwilmebpsngglqmemqgrwjhlsqhefoodgmlyymsmnxrrjpjqxdkodhwtttrzalehbznqvjbdfzvfyxdfpmaraalmualdacxzitcboluhhnsvmixqnedswpuavxbvnoioxuvnupbwxofnyiorkdwvuhhzxozwzjopoyzdyptvkqikqzifvxgpcdtaccqayejpvuyktdcamrbdgqrfhfavquuxeamdxxeiwciosmykurbqbyhhsdxolxkxrlqdasvtdnlxfdmakwxyulofdpdcxubezwfywfntoxyuvskoednmdimgkdtsbozuuuwoswtzzeihkeouunbzygaqhbauywdmglzxgqdgemxkuwapqgitzzdgoinooemyhrbifsosrexunnrtvwpkkikljzpuhjnicytqryjofsmjkewrzrrkkfomiyztjfvpwvvkdvzjxyxhhzhvrgsjhmuegxayyalebowtjkzapzmpzotcspvyuqagjgclogwksdadusvfhpsexjblevqvcllfemsernyjstaflztyxtqlfzjvarzdwnhfceekiiwvqouurcstjmrazfalwwzuzbhpdomhnnkopnaxdeuwxgnfeoqfxkinfeqjwtlydbcxihaimzjkigcfhpyltdyehvexflboszapnoicjtulwbtpdjdisgbqqlmhtkvkqgimbmtlafzlsqpaxngkolzxuhstoakyqthlkxtemjjjbrbrrognvapyqzyhgzubuqehhoiupzfwmnubnmivycdvdynxicwmnoghfecthgipabczaeqstefmulxlvqvxzxbkasimecxqmsxxdicgczxaykhhdoisbuxgeklkzknbotxbkirnpcepmtaykweexafifhxqovbrzwfwqxnzeacuagfdwqamdwcrzhgzqnymvjzdxbbvvsbngriihplyzuuunttucavmsgoybycpbwxgtkwmtgebgvhejgiukuszxfeuaduykgkiynsdvwiuqunqdgwypztjhmnsubjrbghrvuluwrkfdsmsoauefbyhtdnxgqqfascndoemhamsyrtewmkiutqydnurwegwadjwfycqanyhybbcdtqumzvmtggcdqvncwifqfvtrdffinnpjbahidbaeikbhdeldybtwaiifpiqlctgxlbvlcdliezbboipzvoaqtoproaxybbzsygdojwchzectczvfoelitzxigzcpbmwrumktdqiztbfxcfjyflvpvnhycwrtvqsfcifoixxryrxlbghduqnexhansktvnkhyctyvitrzlxxypifakzcmokrrdcxcfygjsuvooyrxxojoueqvlgmihsmpneoknlwubtklffwbobhzjckzzwypgtfvekvudzcabmsmsvkffxmqorczsvtoywkdpofrkhpuhymuxwbblkxjdskysqannwjzkqgzozlrxsrzbdffkgimvrzrdkklwvyjtxnzkmqfsfgopoqzivxwfgfvsrbvzkryuhfbfjxaynfshcdtrxkpamkzewecyjnyphkeylghanlvrlfjjkhaylebhlafaawfbciimbqgbsrvzubpjkeuinxvpuafghqcznhxyounusxwdmqqgxbjoonytvywcsxroalyarwuoswxyovxlbhllolpcagzhgmxgwblypsxkgzayuwiyaxhfkjnbrggiegwqyenysvtyuqegeufnuibokxflfionbxtdlrvrzcbboxezehoiavpeaadoghuviximnuziomdqybzzlboniipzykcxtxeqtiphkzecepelqvacblpocgoukbxqtiicdvvwwbcsucusfyquxysdlwtdlrmvsnszylmjzfcmrjnejaxtvmmppekgfhmffwtuxixaeaqmaupeybomwrliohaadbazpxmmlbjjvnyrxrzzpczirjwozmjsfazwakszefvgwtqsepfcvzwmlgenhtvstvmipoxyqjxaguvceynhkoyzjztbbrrdhqygxnlvhzzvtmcyfuxtkddiafapvihugvcailqiqfnhzvqnqqblxnvfjudxsgbmlpwgglyngrzqmzjjhzegrsyqptabomzpqwzyvjlmkbncwqumofkarlqbqdwanrmggnbthtdyychwcptzaehmmuejknadkwrjfywoiimdecxdrydfiqvktaadkzveiqoshyyukhxlwobponxntsguozygawhwlijwvscdbkgkwjpxwdolizogcefjzrxctxemiceroowbxuqkierqbfjgqkvetlpbywvdohrdwufexzeacxwqrbhkeckcuxetxgiinzfomhnufuykcwtusnewaaxfyjfmcaljmdkvrknllbzltabczcoiomefahtdddeotznqxtoqcvghgzmtblvruihngablqaapcxojnaqusqonhespmvicuezsxziewivlbgknpuktokpqkluqywplczoekzhnafqyfyjpynohxwqmhvyquvzehjdrqgwseogcooxfzbzfmpsnjfirwsvehucoftaisooeqcvoqkteqqbuwlquxmaffzivkzoagjgapxkszphtqixpwqfjwwprijdsdxcdezrryepvexmqrsyisdfarxlvbenghlirmdompxtoxjjxuwfwuwnttffolstrdgijqxfeqvdssnwtfrriwxwoobgqqdhhoqgnhvsszevddxzuzavabwhjwzxcxnfigrepxmoncjjctlixbxsznmcdtmzydllmjsewnpvesmlafeowakkpxovzyqhhmmvnhkhewcvyvahvlplrbwawkonfkqyxjegyqojsxazasmorpesmyswbpiffebgxygacblskllqooydcuuflfqnoxmslvinayshykxpmlxikkpwnrveozxinohwcerwygtbuvahzqykehjskmkbjdpucymeufvhcsmivppdpfoccwnbnkicohkvgbfemqnxwxnwkxmtjaudkjjgkbkdfayjcqtslqchawzolqwamnnnoplnsqdyvyawjfmmsupttpvnjhljvaxjklbizpdywrxcvimyjbpepbmdjyeclzlzaodfjqmreinjtiqkqkruvsmtcurofkndecvcgczhwqhnrrcribfdbgobkahbjiufdltonzjmfhwwozodoxlggsgrruamrhrppsfjdnsfzeaqmmrncqxzxawlzdgpfplhhzmjbfaefndcogwbecudsouoazemjycuvybpxcueskuwlorexvmnkemqnhcyhdzgttoxjwrrrwjcgrgnlfwcgbhdgqtbwseyabpxgilzxhqftfpyjzfcmpldacvcelwexjwgnslenezjxzmffylgunwndpmfcpvdcybipcrwgbavfsvczziatvxxneswvogxkdealvphysdkarardpwsnufrapqkmrdsqawgqvzotjnkhtiapuiepgjavopyplhzlmboezhkviwscoedyqrfrtelmygfcfnfguzjiaomtinyxfzyunnsiqkijgebdeclfychabcionicqvvfikslqpjoqiicrysuarsgrebzqjpwfexujkdtzrlrjtegwvjasyfjgrudrchkmgermqzktccgbavhgpcfnhykejmnttfjlljhzplhrhjdkpytnawhopelptyrvhxdfjewnfgqgbcleufwpzqxkumiugzzybbhfychlcfsvmskrasbsbygoculpmksxdgwssyvrvhmucucnbimxcyyizsmgbiobqafkljnxxaftvkjlccuvltcremzjajvbrznidlzihmxhmmdvzqaqpwntrupszumibtcvffyrvlzwjsmqgsfshgcrzrgzqtjlzlndayovemtyltdfyblmudhdgcvwspoaxsczzsxcgdghvhzqkawxdawegqjcfstowdhyzngqttugcjofimqrnlhnekpuqkcawuukafffnjwjrgueqeztowyovuoppfmszlomzxeaeihonkdrhljoukxwbtuoufqffsbuatfyewlsntoiwayngyzhfkhlhtrqkhwpmuuatnekdzgmyosnbfmxeyhgevpqrzfcnwrkcsutqftnirmsyisgrxgicbsvncieaipgyrrrqlhukqtxcluowilfanriklbkkvespuklyivdviuvdnuhtroccjqschfelcbeitvthagkegoercghzwqyfoatnxgyoskfppsxifmfiarkqdsxxrrllihxqkzchhjseycjkseucbonbjkabxbivpljhgfnapeujlfhltnqkbqwxtlfgubmenxgytiaamkbkzcnixxietbdqpzdabhsbkmkhvlslclwwcebiwoaiqmxfbxeigscoojyiyfnxwztjkaikffvrxuilhjrqheiqivogrlyaomydzhzlgreobsmgzfzuzdrzitdoybrrlfcupgerqrwhcghikqhbtczyphnuekrlumvvpwxqrzxblymzpuldiamukypasrglkrpmhfojcdqnpedhlzoeizanosqbfrppvfwzsiygrlagpohlawcxpbmnecwauwndizqxcanwghmijlsjqenczxjonqfbrxoaftgvlpjaqjbzhnsmjtpjsblklwtnauvokykywcbaqhbzwhvdkuxznbddnajeiezoaalkxifnrireghwohfwaystsumcmdwmpeyximvgaxestnkshporpqappduiujjuyujapdxpbmynmftyujutghitibdgwsejlqldlkapofwhdaakpbywkahkbtjnfidaspblzqcnrtphvniiuxiajbomwjutzfheyjgvglnrdymmsytjngtakaaodamhptmihsnmryccfeusqyrrgfbudopemcfhhzyzrelobfllftwvgljztjqqjzhtocpeohyhetlpcfxbgxaxqrplwmoclouwjjrywczlzuidciloiqlwwkxukwojgtrwilmebpsngglqmemqgrwjhlsqhefoodgmlyymsmnxrrjpjqxdkodhwtttrzalehbznqvjbdfzvfyxdfpmaraalmualdacxzitcboluhhnsvmixqnedswpuavxbvnoioxuvnupbwxofnyiorkdwvuhhzxozwzjopoyzdyptvkqikqzifvxgpcdtaccqayejpvuyktdcamrbdgqrfhfavquuxeamdxxeiwciosmykurbqbyhhsdxolxkxrlqdasvtdnlxfdmakwxyulofdpdcxubezwfywfntoxyuvskoednmdimgkdtsbozuuuwoswtzzeihkeouunbzygaqhbauywdmglzxgqdgemxkuwapqgitzzdgoinooemyhrbifsosrexunnrtvwpkkikljzpuhjnicytqryjofsmjkewrzrrkkfomiyztjfvpwvvkdvzjxyxhhzhvrgsjhmuegxayyalebowtjkzapzmpzotcspvyuqagjgclogwksdadusvfhpsexjblevqvcllfemsernyjstaflztyxtqlfzjvarzdwnhfceekiiwvqouurcstjmrazfalwwzuzbhpdomhnnkopnaxdeuwxgnfeoqfxkinfeqjwtlydbcxihaimzjkigcfhpyltdyehvexflboszapnoicjtulwbtpdjdisgbqqlmhtkvkqgimbmtlafzlsqpaxngkolzxuhstoakyqthlkxtemjjjbrbrrognvapyqzyhgzubuqehhoiupzfwmnubnmivycdvdynxicwmnoghfecthgipabczaeqstefmulxlvqvxzxbkasimecxqmsxxdicgczxaykhhdoisbuxgeklkzknbotxbkirnpcepmtaykweexafifhxqovbrzwfwqxnzeacuagfdwqamdwcrzhgzqnymvjzdxbbvvsbngriihplyzuuunttucavmsgoybycpbwxgtkwmtgebgvhejgiukuszxfeuaduykgkiynsdvwiuqunqdgwypztjhmnsubjrbghrvuluwrkfdsmsoauefbyhtdnxgqqfascndoemhamsyrtewmkiutqydnurwegwadjwfycqanyhybbcdtqumzvmtggcdqvncwifqfvtrdffinnpjbahidbaeikbhdeldybtwaiifpiqlctgxlbvlcdliezbboipzvoaqtoproaxybbzsygdojwchzectczvfoelitzxigzcpbmwrumktdqiztbfxcfjyflvpvnhycwrtvqsfcifoixxryrxlbghduqnexhansktvnkhyctyvitrzlxxypifakzcmokrrdcxcfygjsuvooyrxxojoueqvlgmihsmpneoknlwubtklffwbobhzjckzzwypgtfvekvudzcabmsmsvkffxmqorczsvtoywkdpofrkhpuhymuxwbblkxjdskysqannwjzkqgzozlrxsrzbdffkgimvrzrdkklwvyjtxnzkmqfsfgopoqzivxwfgfvsrbvzkryuhfbfjxaynfshcdtrxkpamkzew' 
```
And,
 - Verified debug messages appear when debug logging is enabled in log4j2, and no debug message when disabled.
 ```
[2025-06-23 15:36:18,348] DEBUG - CompositeValve Could not handle the request: /oauth2/authorize, since the request context is null. This could be due to the maxHttpHeaderSize limitation, or the request having no context.
 ```
 - Confirmed that no error messages get logged for normal MaxHttpHeaderSize scenarios 