### PR TITLE
Revert "Use NString by default for primary userstore"

### DIFF
--- a/distribution/kernel/carbon-home/repository/resources/conf/infer.json
+++ b/distribution/kernel/carbon-home/repository/resources/conf/infer.json
@@ -14,6 +14,7 @@
       "user_store.properties.StoreSaltedPassword": true,
       "user_store.properties.UserRolesCacheEnabled": true,
       "user_store.properties.UserNameUniqueAcrossTenants": false,
+      "user_store.properties.StoreUserAttributeValueAsUnicode": false,
       "tenant_mgt.tenant_manager.type": "jdbc"
     },
     "database_unique_id": {
@@ -30,7 +31,7 @@
       "user_store.properties.StoreSaltedPassword": true,
       "user_store.properties.UserRolesCacheEnabled": true,
       "user_store.properties.UserNameUniqueAcrossTenants": false,
-      "user_store.properties.StoreUserAttributeValueAsUnicode": true,
+      "user_store.properties.StoreUserAttributeValueAsUnicode": false,
       "user_store.properties.GroupIDEnabled": true,
       "tenant_mgt.tenant_manager.type": "jdbc"
     },


### PR DESCRIPTION
## Purpose
This PR makes String by default for user attributes in primary userstores.

Related PR https://github.com/wso2/carbon-kernel/pull/4313
