### PR TITLE
Refactor and Generalize Password Hashing for Reuse Beyond User Store Context

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/UserCoreConstants.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/UserCoreConstants.java
@@ -228,6 +228,8 @@ public class UserCoreConstants {
         public static final String PROPERTY_REPLACE_ESCAPE_CHARACTERS_AT_USER_LOGIN = "ReplaceEscapeCharactersAtUserLogin";
 
         public static final String PASSWORD_HASH_METHOD_PLAIN_TEXT = "PLAIN_TEXT";
+        public static final String PASSWORD_HASH_DIGEST_FUNCTION = "PasswordDigest";
+        public static final String PASSWORD_HASH_ALGORITHM_PROPERTIES = "Hash.Algorithm.Properties";
 
         public static final String PROPERTY_DOMAIN_NAME = "DomainName";
 

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/exceptions/PasswordHashingClientException.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/exceptions/PasswordHashingClientException.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.user.core.exceptions;
+
+/**
+ * Exception for client-side issues in password hashing, like bad configs or unsupported algorithms.
+ */
+public class PasswordHashingClientException extends PasswordHashingException {
+
+    public PasswordHashingClientException(String message) {
+
+        super(message);
+    }
+
+    public PasswordHashingClientException(String message, String errorCode) {
+
+        super(message, errorCode);
+    }
+
+    public PasswordHashingClientException(String message, Throwable cause) {
+
+        super(message, cause);
+    }
+
+    public PasswordHashingClientException(String message, String errorCode, Throwable cause) {
+
+        super(message, errorCode, cause);
+    }
+}

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/exceptions/PasswordHashingException.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/exceptions/PasswordHashingException.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.user.core.exceptions;
+
+/**
+ * Exception class to represent failures during password hashing process in PasswordHashProcessor.
+ */
+public class PasswordHashingException extends Exception {
+
+    private final String errorCode;
+
+    public PasswordHashingException(String message) {
+
+        super(message);
+        this.errorCode = null;
+    }
+
+    public PasswordHashingException(String message, Throwable cause) {
+
+        super(message, cause);
+        this.errorCode = null;
+    }
+
+    public PasswordHashingException(String message, String errorCode) {
+
+        super(message);
+        this.errorCode = errorCode;
+    }
+
+    public PasswordHashingException(String message, String errorCode, Throwable cause) {
+
+        super(message, cause);
+        this.errorCode = errorCode;
+    }
+
+    public String getErrorCode() {
+
+        return errorCode;
+    }
+}

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/exceptions/PasswordHashingServerException.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/exceptions/PasswordHashingServerException.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.user.core.exceptions;
+
+/**
+ * Exception for internal server-side issues in password hashing, such as runtime errors or missing algorithms.
+ */
+public class PasswordHashingServerException extends PasswordHashingException {
+
+    public PasswordHashingServerException(String message) {
+
+        super(message);
+    }
+
+    public PasswordHashingServerException(String message, String errorCode) {
+
+        super(message, errorCode);
+    }
+
+    public PasswordHashingServerException(String message, Throwable cause) {
+
+        super(message, cause);
+    }
+
+    public PasswordHashingServerException(String message, String errorCode, Throwable cause) {
+
+        super(message, errorCode, cause);
+    }
+}

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/hash/PasswordHashProcessor.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/hash/PasswordHashProcessor.java
@@ -1,0 +1,232 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.user.core.hash;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import org.apache.axiom.om.util.Base64;
+import org.apache.commons.lang.StringUtils;
+import org.wso2.carbon.user.core.exceptions.HashProviderException;
+import org.wso2.carbon.user.core.exceptions.PasswordHashingClientException;
+import org.wso2.carbon.user.core.exceptions.PasswordHashingException;
+import org.wso2.carbon.user.core.exceptions.PasswordHashingServerException;
+import org.wso2.carbon.user.core.internal.UserStoreMgtDataHolder;
+import org.wso2.carbon.utils.Secret;
+import org.wso2.carbon.utils.UnsupportedSecretTypeException;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import static org.wso2.carbon.user.core.UserCoreConstants.RealmConfig.PASSWORD_HASH_ALGORITHM_PROPERTIES;
+import static org.wso2.carbon.user.core.UserCoreConstants.RealmConfig.PASSWORD_HASH_DIGEST_FUNCTION;
+import static org.wso2.carbon.user.core.UserCoreConstants.RealmConfig.PASSWORD_HASH_METHOD_PLAIN_TEXT;
+
+/**
+ * Class responsible for hashing passwords based on the configured algorithm.
+ * This class supports both legacy MessageDigest-based hashing and pluggable HashProvider-based hashing.
+ * <p>
+ * It reads hashing configuration from a user store properties map and uses secure mechanisms
+ * (such as {@link Secret}) to handle passwords in memory.
+ * </p>
+ */
+public class PasswordHashProcessor {
+
+    private HashProvider hashProvider;
+    private final Map<String, String> hashConfigProperties;
+
+    /**
+     * Constructs a PasswordHashProcessor instance using the provided hashing configuration properties.
+     *
+     * @param hashConfigProperties A map containing hashing-related properties such as
+     *                             digest function, algorithm-specific parameters, etc.
+     * @throws PasswordHashingException If initialization of the hash provider fails.
+     */
+    public PasswordHashProcessor(Map<String, String> hashConfigProperties) throws PasswordHashingException {
+
+        this.hashConfigProperties = hashConfigProperties;
+        initializeHashProvider(hashConfigProperties);
+    }
+
+    /**
+     * Hashes the given password using the configured hashing algorithm and optional salt.
+     * <p>
+     * If a pluggable {@link HashProvider} is configured, it will be used. Otherwise,
+     * the method falls back to standard {@link MessageDigest} hashing or plaintext as configured.
+     * </p>
+     *
+     * @param password  The password object to be hashed (can be a char[], String, etc.).
+     * @param saltValue Optional salt value to use during hashing.
+     * @return Base64-encoded hashed password string.
+     * @throws PasswordHashingException If hashing fails due to an unsupported type, algorithm error, or config error.
+     */
+    public String hashPassword(Object password, String saltValue) throws PasswordHashingException {
+
+        Secret credentialObj = getSecret(password);
+        try {
+            String digestFunction = hashConfigProperties.get(PASSWORD_HASH_DIGEST_FUNCTION);
+            if (digestFunction == null) {
+                return new String(credentialObj.getChars());
+            }
+            if (hashProvider == null) {
+                return hashWithMessageDigest(credentialObj, saltValue, digestFunction);
+            } else {
+                return hashWithProvider(credentialObj, saltValue);
+            }
+        } finally {
+            credentialObj.clear();
+        }
+    }
+
+    /**
+     * Performs password hashing using the configured {@link MessageDigest} algorithm.
+     *
+     * @param credentialObj  Secret-wrapped password object.
+     * @param saltValue      Optional salt value to append.
+     * @param digestFunction The digest algorithm to use (e.g., SHA-256, SHA-512).
+     * @return Base64-encoded hashed password.
+     * @throws PasswordHashingClientException If the specified algorithm is invalid or unsupported.
+     */
+    private String hashWithMessageDigest(Secret credentialObj, String saltValue, String digestFunction)
+            throws PasswordHashingClientException {
+
+        try {
+            if (digestFunction.equals(PASSWORD_HASH_METHOD_PLAIN_TEXT)) {
+                return new String(credentialObj.getChars());
+            } else {
+                if (saltValue != null) {
+                    credentialObj.addChars(saltValue.toCharArray());
+                }
+                MessageDigest messageDigest = MessageDigest.getInstance(digestFunction);
+                byte[] byteValue = messageDigest.digest(credentialObj.getBytes());
+                return Base64.encode(byteValue);
+            }
+        } catch (NoSuchAlgorithmException e) {
+            throw new PasswordHashingClientException("Error occurred while preparing password.", e);
+        }
+    }
+
+    /**
+     * Performs password hashing using a pluggable {@link HashProvider} implementation.
+     *
+     * @param credentialObj Secret-wrapped password object.
+     * @param saltValue     Optional salt value to apply.
+     * @return Base64-encoded hashed password.
+     * @throws PasswordHashingServerException If the hashing process fails at runtime.
+     */
+    private String hashWithProvider(Secret credentialObj, String saltValue)
+            throws PasswordHashingServerException {
+
+        try {
+            byte[] hashByteArray = hashProvider.calculateHash(credentialObj.getChars(), saltValue);
+            return Base64.encode(hashByteArray);
+        } catch (HashProviderException e) {
+            throw new PasswordHashingServerException("Error occurred while preparing password.", e);
+        }
+    }
+
+    /**
+     * Converts the provided password object to a {@link Secret} for secure handling.
+     *
+     * @param password The password object (char[], String, etc.).
+     * @return A Secret-wrapped representation of the password.
+     * @throws PasswordHashingClientException If the object type is unsupported.
+     */
+    private Secret getSecret(Object password) throws PasswordHashingClientException {
+
+        try {
+            return Secret.getSecret(password);
+        } catch (UnsupportedSecretTypeException e) {
+            throw new PasswordHashingClientException("Unsupported credential type.", e);
+        }
+    }
+
+    /**
+     * Initializes the {@link HashProvider} using the provided configuration map.
+     * <p>
+     * If algorithm-specific metadata is required, it is parsed and applied before
+     * obtaining the provider instance. If no such configuration is needed, a default
+     * provider is used.
+     * </p>
+     *
+     * @param hashConfigProperties A map of password hashing configuration properties.
+     * @throws PasswordHashingException If the provider cannot be initialized.
+     */
+    private void initializeHashProvider(Map<String, String> hashConfigProperties) throws PasswordHashingException {
+
+        String digestFunction = hashConfigProperties.get(PASSWORD_HASH_DIGEST_FUNCTION);
+        HashProviderFactory hashProviderFactory = getHashProviderFactory(digestFunction);
+
+        if (hashProviderFactory == null) {
+            return;
+        }
+
+        Set<String> metaProperties = hashProviderFactory.getHashProviderConfigProperties();
+        if (!metaProperties.isEmpty()) {
+            Map<String, Object> hashProviderPropertiesMap = getHashProviderInitConfigs(hashConfigProperties);
+
+            if (!hashProviderPropertiesMap.isEmpty()) {
+                try {
+                    hashProvider = hashProviderFactory.getHashProvider(hashProviderPropertiesMap);
+                    return;
+                } catch (HashProviderException e) {
+                    throw new PasswordHashingServerException("Error occurred while initializing the hashProvider.", e);
+                }
+            }
+        }
+
+        // If meta props are empty or no config provided, fall back
+        hashProvider = hashProviderFactory.getHashProvider();
+    }
+
+    /**
+     * Extracts the algorithm-specific configuration properties from the provided configuration map.
+     * These are required by some {@link HashProvider} implementations such as PBKDF2.
+     *
+     * @param hashConfigProperties The full hashing config map.
+     * @return A simplified map containing only the algorithm-specific initialization parameters.
+     */
+    private Map<String, Object> getHashProviderInitConfigs(Map<String, String> hashConfigProperties) {
+
+        String hashingAlgorithmProperties = hashConfigProperties.get(PASSWORD_HASH_ALGORITHM_PROPERTIES);
+        Map<String, Object> hashProviderInitConfigsMap = new HashMap<>();
+        if (StringUtils.isNotBlank(hashingAlgorithmProperties)) {
+            Gson gson = new Gson();
+            JsonObject hashPropertyJSON = gson.fromJson(hashingAlgorithmProperties, JsonObject.class);
+            Set<String> hashPropertyJSONKey = hashPropertyJSON.keySet();
+            for (String hashProperty : hashPropertyJSONKey) {
+                hashProviderInitConfigsMap.put(hashProperty, hashPropertyJSON.get(hashProperty).getAsString());
+            }
+        }
+        return hashProviderInitConfigsMap;
+    }
+
+    /**
+     * Retrieves the {@link HashProviderFactory} associated with the specified digest function.
+     *
+     * @param digestFunction The name of the digest function (e.g., "PBKDF2").
+     * @return The corresponding {@link HashProviderFactory} instance, or {@code null} if not found.
+     */
+    private HashProviderFactory getHashProviderFactory(String digestFunction) {
+
+        return UserStoreMgtDataHolder.getInstance().getHashProviderFactory(digestFunction);
+    }
+}

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/JDBCUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/JDBCUserStoreManager.java
@@ -93,7 +93,6 @@ import java.util.Set;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
-import java.util.regex.Matcher;
 import java.util.stream.Collectors;
 import javax.sql.DataSource;
 
@@ -3033,7 +3032,6 @@ public class JDBCUserStoreManager extends AbstractUserStoreManager {
      * @throws UserStoreException The exception thrown at hashing the passwords.
      */
     protected String preparePassword(Object password, String saltValue) throws UserStoreException {
-
 
         if (passwordHashProcessor == null) {
             throw new UserStoreException("PasswordHashProcessor is not initialized.");


### PR DESCRIPTION
### Purpose
The purpose of this PR is to refactor the existing password hashing logic into a reusable and extensible utility class that supports multiple hashing algorithms (e.g., PBKDF2, SHA-256) and can be used beyond the user store layer—such as in password history validation and other security-sensitive components.


### Goals
* Decouple hashing logic from user store-specific assumptions
* Support both `MessageDigest`-based hashing and pluggable `HashProvider` implementations
* Use secure password handling via the `Secret` abstraction
* Enable hash configuration via a generalized `hashConfigProperties` map
* Improve code maintainability, testability, and extensibility

### Approach
* Renamed internal field from `userStorePropertiesMap` to `hashConfigProperties` to generalize usage
* Refactored `hashPassword()` method to reduce complexity and improve readability
* Separated hashing logic into helper methods: `hashWithProvider()` and `hashWithMessageDigest()`
* Used `try-finally` to ensure secure cleanup of sensitive credentials via `Secret.clear()`
* Reused existing `HashProviderFactory` and metadata extraction to support extensible algorithms like PBKDF2
* Added complete Javadoc documentation to all public and private methods

### Related PRs
  - https://github.com/wso2-extensions/identity-governance/pull/991
  - https://github.com/wso2/product-is/pull/24670

---

## Related Issues
public issue: https://github.com/wso2/product-is/issues/24419