### PR TITLE
[Bump] Bump pax-logging version to 2.1.0-wso2v5

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -526,8 +526,8 @@
         <version.commons.logging>1.2</version.commons.logging>
 
         <!--PAX Logging related dependency versions-->
-        <pax.logging.api.version>2.1.0-wso2v4</pax.logging.api.version>
-        <pax.logging.log4j2.version>2.1.0-wso2v4</pax.logging.log4j2.version>
+        <pax.logging.api.version>2.1.0-wso2v5</pax.logging.api.version>
+        <pax.logging.log4j2.version>2.1.0-wso2v5</pax.logging.log4j2.version>
 
         <!--<version.opensaml2>2.4.1.wso2v1</version.opensaml2>-->
         <version.compass>2.0.1.wso2v2</version.compass>


### PR DESCRIPTION
Bump pax-logging versions from 2.1.0-wso2v4 to 2.1.0-wso2v5.
  - `pax.logging.api.version`
  - `pax.logging.log4j2.version`

## Related Issue
  - https://github.com/wso2/product-is/issues/24536