### PR TITLE
Fix AD group timestamp attribute mapping

### DIFF
--- a/distribution/kernel/carbon-home/repository/resources/conf/infer.json
+++ b/distribution/kernel/carbon-home/repository/resources/conf/infer.json
@@ -255,8 +255,8 @@
       "user_store.properties.CaseInsensitiveUsername": true,
       "user_store.properties.GroupIDEnabled": true,
       "user_store.properties.GroupIdAttribute": "objectGUID",
-      "user_store.properties.GroupLastModifiedDateAttribute": "whenCreated",
-      "user_store.properties.GroupCreatedDateAttribute": "whenChanged",
+      "user_store.properties.GroupLastModifiedDateAttribute": "whenChanged",
+      "user_store.properties.GroupCreatedDateAttribute": "whenCreated",
       "user_store.properties.ListServicePrincipalEntities": false
     }
   },


### PR DESCRIPTION
## Purpose
This issue applies only when Active Directory is configured as the primary user store in WSO2 IS.

### Related Issues
- https://github.com/wso2/product-is/issues/24675