### PR TITLE
Add enableUserStorePersistence property.

### DIFF
--- a/core/org.wso2.carbon.user.api/src/main/java/org/wso2/carbon/user/api/Claim.java
+++ b/core/org.wso2.carbon.user.api/src/main/java/org/wso2/carbon/user/api/Claim.java
@@ -94,6 +94,11 @@ public class Claim implements Serializable {
      */
     private boolean multiValued;
 
+    /**
+     * This is to define whether the user store based persistence for the claim is enabled.
+     */
+    private String enableUserStorePersistence;
+
     public String getClaimUri() {
         return claimUri;
     }
@@ -190,5 +195,13 @@ public class Claim implements Serializable {
     public void setMultiValued(boolean multiValued) {
 
         this.multiValued = multiValued;
+    }
+
+    public void setEnableUserStorePersistence(String excludedUserStores) {
+        this.enableUserStorePersistence = excludedUserStores;
+    }
+
+    public String getEnableUserStorePersistence() {
+        return enableUserStorePersistence;
     }
 }


### PR DESCRIPTION
Proposed changes in this pull request

Adding a new first class claim property `enableUserStorePersistence`.  This property is introduced to define the storing location of the values of the respective claim; whether the claim values should be stored in the USER_STORE or in the IDENTITY_DB.

Related:
- https://github.com/wso2/carbon-identity-framework/pull/7104