### PR TITLE
Update tomcat version to 9.0.108

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -486,7 +486,7 @@
 
         <version.jakarta.taglib>1.1.2.wso2v1</version.jakarta.taglib>
 
-        <version.tomcat>9.0.94</version.tomcat>
+        <version.tomcat>9.0.108</version.tomcat>
         <orbit.version.tomcat>${version.tomcat}.wso2v1</orbit.version.tomcat>
         <orbit.version.tomcat.servlet.api>${version.tomcat}.wso2v1</orbit.version.tomcat.servlet.api>
         <orbit.version.tomcat.jsp.api>${version.tomcat}.wso2v1</orbit.version.tomcat.jsp.api>


### PR DESCRIPTION
This pull request updates the Tomcat dependency version in the project configuration to ensure the application uses the latest available release.

- Dependency version update:
  * Updated the Tomcat version from `9.0.94` to `9.0.108` in `parent/pom.xml`, which will pull in the latest bug fixes and security patches.