### PR TITLE
Introduce config to disable carbon mgt console & soap services

### DIFF
--- a/core/org.wso2.carbon.base/src/main/java/org/wso2/carbon/base/ServerConfiguration.java
+++ b/core/org.wso2.carbon.base/src/main/java/org/wso2/carbon/base/ServerConfiguration.java
@@ -76,6 +76,10 @@ public class ServerConfiguration implements ServerConfigurationService {
 	public static final String AXIS2_CONFIG_REPO_LOCATION = "Axis2Config.RepositoryLocation";
 
 	/**
+	 * Constant to be used to disable admin services.
+	 */
+	public static final String AXIS2_CONFIG_DISABLE_ADMIN_SERVICES = "Axis2Config.DisableAdminServices";
+	/**
 	 * Constant to be used for properties storing the http port of the servlet
 	 * transport.
 	 */

--- a/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/init/CarbonServerManager.java
+++ b/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/init/CarbonServerManager.java
@@ -479,7 +479,7 @@ public final class CarbonServerManager implements Controllable {
 
             // If Carbon Kernel is running in the optimized mode, we do not deploy service resided in bundles.
             // Most of these services are either admin services or hidden services.
-            if (!CarbonUtils.isOptimized()) {
+            if (!CarbonUtils.isOptimized() && !CarbonUtils.disableAdminServices()) {
                 //Deploying Web service which resides in bundles
                 Axis2ServiceRegistry serviceRegistry = new Axis2ServiceRegistry(serverConfigContext);
                 serviceRegistry.register(bundleContext.getBundles());

--- a/core/org.wso2.carbon.ui/src/main/resources/web/admin/layout/header.jsp
+++ b/core/org.wso2.carbon.ui/src/main/resources/web/admin/layout/header.jsp
@@ -36,7 +36,7 @@
         session.setAttribute(CarbonConstants.SERVER_URL, serverURL);
     }
 
-    boolean isMCEnabled = !Boolean.parseBoolean(System.getProperty("optimize"));
+    boolean isMCEnabled = !Boolean.parseBoolean(System.getProperty("optimize")) && !CarbonUtils.disableAdminServices();
 %>
 <!--[IF IE 7]>
 	<style>

--- a/core/org.wso2.carbon.ui/src/main/resources/web/admin/login.jsp
+++ b/core/org.wso2.carbon.ui/src/main/resources/web/admin/login.jsp
@@ -84,7 +84,7 @@ if (CharacterEncoder.getSafeText(request.getParameter("skipLoginPage"))!=null){
 String backendServerURL = CarbonUIUtil.getServerURL(config.getServletContext(), session);
 ConfigurationContext configContext = (ConfigurationContext) config.getServletContext()
     .getAttribute(CarbonConstants.CONFIGURATION_CONTEXT);
-boolean isMCEnabled = !Boolean.parseBoolean(System.getProperty("optimize"));
+boolean isMCEnabled = !Boolean.parseBoolean(System.getProperty("optimize")) && !CarbonUtils.disableAdminServices();
 
 boolean enableBanner = false;
 String bannerContent = "";

--- a/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/CarbonUtils.java
+++ b/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/CarbonUtils.java
@@ -1258,6 +1258,17 @@ public class CarbonUtils {
      }
 
     /**
+     * Check if admin services are disabled or not.
+     * Enabled by default for latest IS versions.
+     * @return disableAdminServices.
+     */
+    public static boolean disableAdminServices() {
+
+        return Boolean.parseBoolean(ServerConfiguration.getInstance()
+                .getFirstProperty(ServerConfiguration.AXIS2_CONFIG_DISABLE_ADMIN_SERVICES));
+    }
+
+    /**
      * utility method to check whether deployment synchronizer enabled.
      * @return
      */

--- a/distribution/kernel/carbon-home/repository/conf/carbon.xml
+++ b/distribution/kernel/carbon-home/repository/conf/carbon.xml
@@ -316,6 +316,11 @@
         <DeploymentUpdateInterval>15</DeploymentUpdateInterval>
 
         <!--
+          Disable registering admin services.
+        -->
+        <DisableAdminServices>true</DisableAdminServices>
+
+        <!--
             Location of the main Axis2 configuration descriptor file, a.k.a. axis2.xml file
 
             This can be a file on the local file system, or a URL

--- a/distribution/kernel/carbon-home/repository/resources/conf/default.json
+++ b/distribution/kernel/carbon-home/repository/resources/conf/default.json
@@ -10,6 +10,7 @@
   "server.max_items_per_page": "100",
   "server.enable_shutdown_from_api": false,
   "server.enable_restart_from_api": false,
+  "server.disable_admin_services": true,
   "user_store.type": "database",
   "super_admin.admin_role": "admin",
   "everyone.rolename": "everyone",

--- a/distribution/kernel/carbon-home/repository/resources/conf/default.json
+++ b/distribution/kernel/carbon-home/repository/resources/conf/default.json
@@ -10,7 +10,6 @@
   "server.max_items_per_page": "100",
   "server.enable_shutdown_from_api": false,
   "server.enable_restart_from_api": false,
-  "server.disable_admin_services": true,
   "user_store.type": "database",
   "super_admin.admin_role": "admin",
   "everyone.rolename": "everyone",

--- a/distribution/kernel/carbon-home/repository/resources/conf/templates/repository/conf/carbon.xml.j2
+++ b/distribution/kernel/carbon-home/repository/resources/conf/templates/repository/conf/carbon.xml.j2
@@ -351,6 +351,13 @@
         <DeploymentUpdateInterval>15</DeploymentUpdateInterval>
 
         <!--
+            Disable registering admin services.
+        -->
+        {% if server.disable_admin_services is defined %}
+        <DisableAdminServices>{{server.disable_admin_services}}</DisableAdminServices>
+        {% endif %}
+
+        <!--
             Location of the main Axis2 configuration descriptor file, a.k.a. axis2.xml file
 
             This can be a file on the local file system, or a URL


### PR DESCRIPTION
## Purpose

Related issue https://github.com/wso2/product-is/issues/20755

In the previous improvement, we used `-Doptimize=true` to disable the admin services. With this fix, we are introducing a new server-level configuration to achieve the same

```
[server]
...
disable_admin_services = false
```
From now on, both this configuration and the `-Doptimize=true` system property will be honored.
