### PR TITLE
Add validateHash() to HashProvider

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/hash/HashProvider.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/hash/HashProvider.java
@@ -20,6 +20,7 @@ package org.wso2.carbon.user.core.hash;
 
 import org.wso2.carbon.user.core.exceptions.HashProviderException;
 
+import java.security.MessageDigest;
 import java.util.Map;
 
 /**
@@ -49,6 +50,39 @@ public interface HashProvider {
      * @throws HashProviderException If an error occurred while getting the hash value.
      */
     byte[] calculateHash(char[] plainText, String salt) throws HashProviderException;
+
+    /**
+     * Checks if this HashProvider implementation supports the built-in
+     * {@link #validateHash(char[], byte[], String)} method.
+     * <p>
+     * This method serves as a feature flag for callers, allowing them to
+     * determine whether they should use the provider's native validation
+     * logic or fall back to a manual validation process.
+     * </p>
+     *
+     * @return true if the provider offers a built-in validation method, false otherwise.
+     */
+    default boolean supportsValidateHash() {
+
+        return false;
+    }
+
+    /**
+     * Validate the plain text password against a hashed password with the given salt.
+     *
+     * @param plainText The plain text password to validate.
+     * @param hashedPassword The stored hashed password to compare against.
+     * @param salt The salt used to hash the password.
+     * @return true if the passwords match, false otherwise.
+     * @throws HashProviderException If an error occurred during validation.
+     */
+    default boolean validateHash(char[] plainText, byte[] hashedPassword, String salt) throws HashProviderException {
+
+        if (plainText == null || hashedPassword == null) {
+            return false;
+        }
+        return MessageDigest.isEqual(hashedPassword, calculateHash(plainText, salt));
+    }
 
     /**
      * Get HashProvider parameters.

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/hash/PasswordHashProcessor.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/hash/PasswordHashProcessor.java
@@ -144,6 +144,77 @@ public class PasswordHashProcessor {
     }
 
     /**
+     * Checks if a pluggable {@link HashProvider} is configured and supports
+     * its own built-in validation logic.
+     * <p>
+     * This method allows callers to determine whether they should delegate the
+     * password validation to this processor or handle it manually.
+     * </p>
+     *
+     * @return true if a custom provider with a supported validation method is configured;
+     * false otherwise.
+     */
+    public boolean hasCustomValidator() {
+
+        return hashProvider != null && hashProvider.supportsValidateHash();
+    }
+
+    /**
+     * Validates a given password against a stored hashed password using a salt.
+     * <p>
+     * If a pluggable {@link HashProvider} is configured, it will be used for validation.
+     * Otherwise, the method falls back to standard {@link MessageDigest} validation.
+     * </p>
+     *
+     * @param password       The password object to be validated (e.g., char[], String).
+     * @param hashedPassword The stored password hash as a String.
+     * @param saltValue      Optional salt value used during hashing.
+     * @return True if the password is valid, false otherwise.
+     * @throws PasswordHashingException If validation fails due to an unsupported algorithm,
+     * a configuration error, or a runtime issue with the provider.
+     */
+    public boolean validatePassword(Object password, String hashedPassword, String saltValue)
+            throws PasswordHashingException {
+
+        if (hashedPassword == null) {
+            return false;
+        }
+        Secret credentialObj = getSecret(password);
+        try {
+            String digestFunction = hashConfigProperties.get(PASSWORD_HASH_DIGEST_FUNCTION);
+            if (digestFunction == null || digestFunction.equals(PASSWORD_HASH_METHOD_PLAIN_TEXT)) {
+                return hashedPassword.equals(new String(credentialObj.getChars()));
+            }
+            if (hashProvider != null && hashProvider.supportsValidateHash()) {
+                return validatePasswordWithProvider(credentialObj, hashedPassword, saltValue);
+            } else {
+                return hashedPassword.equals(hashPassword(password, saltValue));
+            }
+        } finally {
+            credentialObj.clear();
+        }
+    }
+
+    /**
+     * Performs password validation using a pluggable {@link HashProvider} implementation.
+     *
+     * @param credentialObj  Secret-wrapped password object.
+     * @param hashedPassword The stored password hash as a String.
+     * @param saltValue      Optional salt value to apply.
+     * @return True if the password is valid, false otherwise.
+     * @throws PasswordHashingServerException If the validation process fails at runtime.
+     */
+    private boolean validatePasswordWithProvider(Secret credentialObj, String hashedPassword, String saltValue)
+            throws PasswordHashingServerException {
+
+        try {
+            return hashProvider.validateHash(credentialObj.getChars(), Base64.decode(hashedPassword), saltValue);
+        } catch (HashProviderException e) {
+            throw new PasswordHashingServerException("Error occurred while validating password with HashProvider.", e);
+        }
+    }
+
+    /**
      * Converts the provided password object to a {@link Secret} for secure handling.
      *
      * @param password The password object (char[], String, etc.).

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/JDBCUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/JDBCUserStoreManager.java
@@ -1528,7 +1528,6 @@ public class JDBCUserStoreManager extends AbstractUserStoreManager {
         ResultSet rs = null;
         PreparedStatement prepStmt = null;
         String sqlstmt = null;
-        String password = null;
         boolean isAuthed = false;
 
         try {
@@ -1571,8 +1570,7 @@ public class JDBCUserStoreManager extends AbstractUserStoreManager {
                 if (requireChange == true && changedTime.before(date)) {
                     isAuthed = false;
                 } else {
-                    password = this.preparePassword(credential, saltValue);
-                    if ((storedPassword != null) && (storedPassword.equals(password))) {
+                    if (this.validatePassword(credential, storedPassword, saltValue)) {
                         isAuthed = true;
                     }
                 }
@@ -3049,6 +3047,33 @@ public class JDBCUserStoreManager extends AbstractUserStoreManager {
 
         try {
             return passwordHashProcessor.hashPassword(password, saltValue);
+        } catch (PasswordHashingException e) {
+            throw new UserStoreException(e);
+        }
+    }
+
+    /**
+     * Validates a given password against a stored hashed password using a salt.
+     *
+     * @param password The original password value, which can be a String or a character array.
+     * @param storedPassword The stored password hash as a String.
+     * @param saltValue The salt used during the hashing of the original password.
+     * @return A boolean value indicating whether the password is valid (true) or not (false).
+     * @throws UserStoreException If an error occurs during the validation process.
+     */
+    protected boolean validatePassword(Object password, String storedPassword, String saltValue)
+            throws UserStoreException {
+
+        if (passwordHashProcessor == null) {
+            throw new UserStoreException("PasswordHashProcessor is not initialized.");
+        }
+
+        if (!passwordHashProcessor.hasCustomValidator()) {
+            return storedPassword != null && storedPassword.equals(preparePassword(password, saltValue));
+        }
+
+        try {
+            return passwordHashProcessor.validatePassword(password, storedPassword, saltValue);
         } catch (PasswordHashingException e) {
             throw new UserStoreException(e);
         }

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCUserStoreManager.java
@@ -808,7 +808,6 @@ public class UniqueIDJDBCUserStoreManager extends JDBCUserStoreManager {
         ResultSet rs = null;
         PreparedStatement prepStmt = null;
         String sqlstmt;
-        String password;
         boolean isAuthed = false;
 
         try {
@@ -869,8 +868,7 @@ public class UniqueIDJDBCUserStoreManager extends JDBCUserStoreManager {
                     authenticationResult = new AuthenticationResult(AuthenticationResult.AuthenticationStatus.FAIL);
                     authenticationResult.setFailureReason(new FailureReason("Password change required."));
                 } else {
-                    password = preparePassword(credential, saltValue);
-                    if ((storedPassword != null) && (storedPassword.equals(password))) {
+                    if (validatePassword(credential, storedPassword, saltValue)) {
                         isAuthed = true;
                         user = new User(userID, userName, userName, null, null, null, null);
                         try {
@@ -950,7 +948,6 @@ public class UniqueIDJDBCUserStoreManager extends JDBCUserStoreManager {
         ResultSet rs = null;
         PreparedStatement prepStmt = null;
         String sqlstmt;
-        String password;
         boolean isAuthed = false;
 
         try {
@@ -1018,8 +1015,7 @@ public class UniqueIDJDBCUserStoreManager extends JDBCUserStoreManager {
                     authenticationResult = new AuthenticationResult(AuthenticationResult.AuthenticationStatus.FAIL);
                     authenticationResult.setFailureReason(new FailureReason("Password change required."));
                 } else {
-                    password = preparePassword(credential, saltValue);
-                    if ((storedPassword != null) && (storedPassword.equals(password))) {
+                    if (validatePassword(credential, storedPassword, saltValue)) {
                         isAuthed = true;
                         user = getUser(userID, userName);
                         user.setPreferredUsername(preferredUserNameProperty);
@@ -1066,7 +1062,6 @@ public class UniqueIDJDBCUserStoreManager extends JDBCUserStoreManager {
         ResultSet rs = null;
         PreparedStatement prepStmt = null;
         String sqlstmt;
-        String password;
         boolean isAuthed = false;
 
         try {
@@ -1106,8 +1101,7 @@ public class UniqueIDJDBCUserStoreManager extends JDBCUserStoreManager {
                     authenticationResult = new AuthenticationResult(AuthenticationResult.AuthenticationStatus.FAIL);
                     authenticationResult.setFailureReason(new FailureReason("Password change required."));
                 } else {
-                    password = preparePassword(credential, saltValue);
-                    if ((storedPassword != null) && (storedPassword.equals(password))) {
+                    if (validatePassword(credential, storedPassword, saltValue)) {
                         isAuthed = true;
                         user = getUser(userID, userName);
                         authenticationResult = new AuthenticationResult(
@@ -1167,7 +1161,6 @@ public class UniqueIDJDBCUserStoreManager extends JDBCUserStoreManager {
         ResultSet rs = null;
         PreparedStatement prepStmt = null;
         String sqlstmt;
-        String password;
         boolean isAuthed = false;
 
         try {
@@ -1212,8 +1205,7 @@ public class UniqueIDJDBCUserStoreManager extends JDBCUserStoreManager {
                     authenticationResult = new AuthenticationResult(AuthenticationResult.AuthenticationStatus.FAIL);
                     authenticationResult.setFailureReason(new FailureReason("Password change required."));
                 } else {
-                    password = preparePassword(credential, saltValue);
-                    if ((storedPassword != null) && (storedPassword.equals(password))) {
+                    if (validatePassword(credential, storedPassword, saltValue)) {
                         isAuthed = true;
                         user = getUser(userID, userName);
                         authenticationResult = new AuthenticationResult(

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/model/SqlBuilder.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/model/SqlBuilder.java
@@ -103,7 +103,9 @@ public class SqlBuilder {
     }
 
     public SqlBuilder where(String expr, Timestamp value) {
-
+        if (value == null) {
+            throw new IllegalArgumentException("Timestamp value cannot be null");
+        }
         wheres.add(expr);
         timestampParameters.put(count, value);
         count++;

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/model/SqlBuilder.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/model/SqlBuilder.java
@@ -181,6 +181,17 @@ public class SqlBuilder {
 
     public void setTail(String tail, Timestamp... placeHolders) {
 
+        if (tail == null) {
+            throw new IllegalArgumentException("tail parameter cannot be null");
+        }
+        if (placeHolders == null) {
+            throw new IllegalArgumentException("placeHolders array cannot be null");
+        }
+        for (Timestamp value : placeHolders) {
+            if (value == null) {
+                throw new IllegalArgumentException("Timestamp value in placeHolders cannot be null");
+            }
+        }
         if (this.tail == null) {
             this.tail = new StringBuilder(tail);
         } else {

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/model/SqlBuilder.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/model/SqlBuilder.java
@@ -103,6 +103,7 @@ public class SqlBuilder {
     }
 
     public SqlBuilder where(String expr, Timestamp value) {
+
         if (value == null) {
             throw new IllegalArgumentException("Timestamp value cannot be null");
         }
@@ -182,10 +183,10 @@ public class SqlBuilder {
     public void setTail(String tail, Timestamp... placeHolders) {
 
         if (tail == null) {
-            throw new IllegalArgumentException("tail parameter cannot be null");
+            throw new IllegalArgumentException("Tail parameter cannot be null");
         }
         if (placeHolders == null) {
-            throw new IllegalArgumentException("placeHolders array cannot be null");
+            throw new IllegalArgumentException("PlaceHolders array cannot be null");
         }
         for (Timestamp value : placeHolders) {
             if (value == null) {

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/model/SqlBuilder.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/model/SqlBuilder.java
@@ -20,6 +20,7 @@ package org.wso2.carbon.user.core.model;
 import org.apache.commons.lang.StringUtils;
 import org.wso2.carbon.user.core.UserCoreConstants;
 
+import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -38,6 +39,7 @@ public class SqlBuilder {
     private Map<Integer, Integer> integerParameters = new HashMap<>();
     private Map<Integer, String> stringParameters = new HashMap<>();
     private Map<Integer, Long> longParameters = new HashMap<>();
+    private Map<Integer, Timestamp> timestampParameters = new HashMap<>();
     private final List<Integer> attrValueIndexes = new ArrayList<>();
     private boolean addedWhereStatement = false;
 
@@ -100,6 +102,14 @@ public class SqlBuilder {
         return this;
     }
 
+    public SqlBuilder where(String expr, Timestamp value) {
+
+        wheres.add(expr);
+        timestampParameters.put(count, value);
+        count++;
+        return this;
+    }
+
     public List<Integer> getAttributeValueIndexes() {
 
         return attrValueIndexes;
@@ -118,6 +128,11 @@ public class SqlBuilder {
     public Map<Integer, Long> getLongParameters() {
 
         return longParameters;
+    }
+
+    public Map<Integer, Timestamp> getTimestampParameters() {
+
+        return timestampParameters;
     }
 
     public void setTail(String tail, Integer... placeHolders) {
@@ -162,6 +177,20 @@ public class SqlBuilder {
         }
     }
 
+    public void setTail(String tail, Timestamp... placeHolders) {
+
+        if (this.tail == null) {
+            this.tail = new StringBuilder(tail);
+        } else {
+            this.tail.append(tail);
+        }
+
+        for (Timestamp value : placeHolders) {
+            timestampParameters.put(count, value);
+            count++;
+        }
+    }
+
     /**
      * Get sql statement part only.
      *
@@ -196,6 +225,8 @@ public class SqlBuilder {
             integerParameters.put(count, (Integer) value);
         } else if (value instanceof Long) {
             longParameters.put(count, (Long) value);
+        } else if (value instanceof Timestamp) {
+            timestampParameters.put(count, (Timestamp) value);
         }
         count++;
     }
@@ -238,6 +269,7 @@ public class SqlBuilder {
         integerParameters.forEach((idx, val) -> parametersArray[idx - 1] = val);
         stringParameters.forEach((idx, val) -> parametersArray[idx - 1] = val);
         longParameters.forEach((idx, val) -> parametersArray[idx - 1] = val);
+        timestampParameters.forEach((idx, val) -> parametersArray[idx - 1] = val);
 
         return new ArrayList<>(Arrays.asList(parametersArray));
     }
@@ -268,6 +300,8 @@ public class SqlBuilder {
                     integerParameters.put(count, (Integer) param);
                 } else if (param instanceof Long) {
                     longParameters.put(count, (Long) param);
+                } else if (param instanceof Timestamp) {
+                    timestampParameters.put(count, (Timestamp) param);
                 }
                 count++;
             }


### PR DESCRIPTION
## Purpose
Currently, password validation primarily relies on calculating a hash from user input and comparing it to a stored hash. This approach can be inefficient or problematic for certain hashing algorithms (e.g., bcrypt) that embed salt directly within the hash and prefer a single, atomic validation operation. We need a way to delegate validation directly to the HashProvider when it's capable.

Resolves https://github.com/wso2/product-is/issues/25460

## Approach
We're adding a new method to the HashProvider interface that accepts user input, the stored hash, and a salt value, returning a boolean indicating a match. This new method will allow providers to encapsulate their specific validation logic, optimizing for algorithms like bcrypt where the salt is often part of the hash itself and can be ignored as a separate parameter by the provider's implementation.

```
boolean validateHash(char[] plainText, byte[] storedHashedPassword, String salt) throws HashProviderException;
```

The new validateHash method will accept the storedHashedPassword as a byte array. This is consistent with the calculateHash() method's return type and means the Base64 decoding (if applied during storage) will occur before passing the hash to the provider, simplifying the provider's implementation.

For algorithms like bcrypt, the salt parameter passed to validateHash might be ignored by the provider, as bcrypt embeds the salt within the hash string itself. The provider's implementation will handle this internally.


#### Backward Compatibility Strategy 
Ensuring backward compatibility is paramount for this improvement. We've designed the solution to gracefully handle existing HashProvider implementations and custom user store managers:

1. Default Method for Existing Providers: The validateHash method will have a default implementation in the HashProvider interface. This ensures that any existing provider not explicitly implementing this new method will still function without breaking changes.

2. New Feature Flag Method: We are introducing an additional method, boolean supportsValidateHash(), to the HashProvider interface. This method will act as a feature flag:

- If a HashProvider implementation returns true for supportsValidateHash(), the PasswordHashProcessor will invoke its validateHash() method directly for password validation.

- If supportsValidateHash() returns false (which will be the default), the system will fall back to the previous validation mechanism. This involves using the preparePassword() method in the user store manager to generate a hash for the user's input and then comparing it with the hash stored in the database.

3. Preserving preparePassword() Overrides: Critically, for custom JDBC user store managers that have overridden the preparePassword() method, this fallback mechanism ensures that their custom logic is respected. Even if a HashProvider is configured, if supportsValidateHash() is false, preparePassword() will continue to be used, preventing unintended changes in validation behavior.

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
https://github.com/wso2/carbon-kernel/pull/2930
https://github.com/wso2/carbon-kernel/pull/4335

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.