### PR TITLE
Fix NPEs in auth flow due to uninitialized instance variables when user store preference order is enabled with non-unique id user stores

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/IterativeUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/IterativeUserStoreManager.java
@@ -35,14 +35,17 @@ public class IterativeUserStoreManager extends AbstractUserStoreManager {
     AbstractUserStoreManager abstractUserStoreManager;
     private IterativeUserStoreManager nextUserStoreManager;
 
-    public IterativeUserStoreManager(AbstractUserStoreManager abstractUserStoreManager) {
+    public IterativeUserStoreManager(AbstractUserStoreManager abstractUserStoreManager) throws UserStoreException {
         this.abstractUserStoreManager = abstractUserStoreManager;
+        this.claimManager = abstractUserStoreManager.getClaimManager();
+        this.realmConfig = abstractUserStoreManager.getRealmConfiguration();
+        this.tenantId = abstractUserStoreManager.getTenantId();
     }
 
     /**
      * Set the next user store manager to create the ordered user store chain.
      */
-    public void setNextUserStoreManager(AbstractUserStoreManager nextUserStoreManager) {
+    public void setNextUserStoreManager(AbstractUserStoreManager nextUserStoreManager) throws UserStoreException {
         if (nextUserStoreManager instanceof IterativeUserStoreManager) {
             this.nextUserStoreManager = (IterativeUserStoreManager) nextUserStoreManager;
         } else {


### PR DESCRIPTION
Port https://github.com/wso2/carbon-kernel/pull/3666
Fixes https://github.com/wso2/api-manager/issues/4149