### PR TITLE
Dependency updates

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -523,8 +523,8 @@
         <version.commons.logging>1.2</version.commons.logging>
 
         <!--PAX Logging related dependency versions-->
-        <pax.logging.api.version>2.2.1-wso2v2</pax.logging.api.version>
-        <pax.logging.log4j2.version>2.2.1-wso2v2</pax.logging.log4j2.version>
+        <pax.logging.api.version>2.3.0-wso2v1</pax.logging.api.version>
+        <pax.logging.log4j2.version>2.3.0-wso2v1</pax.logging.log4j2.version>
 
         <!--<version.opensaml2>2.4.1.wso2v1</version.opensaml2>-->
         <version.compass>2.0.1.wso2v2</version.compass>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -554,8 +554,8 @@
         <version.drools>5.1.1</version.drools>
         <version.jsr94>1.1</version.jsr94>
 
-        <version.log4j.core>2.17.1</version.log4j.core>
-        <version.log4j.jul>2.17.1</version.log4j.jul>
+        <version.log4j.core>2.24.3</version.log4j.core>
+        <version.log4j.jul>2.24.3</version.log4j.jul>
         <version.commons.logging>1.2</version.commons.logging>
         <version.xmlunit>1.1</version.xmlunit>
         <version.jaxen>1.1.1</version.jaxen>


### PR DESCRIPTION
This PR updates logging-related dependencies to their latest stable versions to improve security, performance, and compatibility.

### Changes Made

**Logging Libraries:**
- **pax-logging**: `2.2.1-wso2v2` → `2.3.0-wso2v1`
- **log4j**: `2.17.1` → `2.24.3`

Related Issue : https://github.com/wso2/api-manager/issues/3870
