### PR TITLE
[Next] Fix Agent throwing NullPointerException when creating a user

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/UniqueIDReadWriteLDAPUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/UniqueIDReadWriteLDAPUserStoreManager.java
@@ -452,7 +452,7 @@ public class UniqueIDReadWriteLDAPUserStoreManager extends UniqueIDReadOnlyLDAPU
                     continue;
                 }
 
-                if (attributeName == null || attributeName.equals(EMPTY_ATTRIBUTE_STRING)) {
+                if (StringUtils.isBlank(attributeName)) {
                     if (log.isDebugEnabled()) {
                         log.debug("No attribute mapping defined for claim: " + claimURI + ". Hence skipping it.");
                     }

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/UniqueIDReadWriteLDAPUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/UniqueIDReadWriteLDAPUserStoreManager.java
@@ -452,6 +452,13 @@ public class UniqueIDReadWriteLDAPUserStoreManager extends UniqueIDReadOnlyLDAPU
                     continue;
                 }
 
+                if (attributeName == null || attributeName.equals(EMPTY_ATTRIBUTE_STRING)) {
+                    if (log.isDebugEnabled()) {
+                        log.debug("No attribute mapping defined for claim: " + claimURI + ". Hence skipping it.");
+                    }
+                    continue;
+                }
+
                 if (log.isDebugEnabled()) {
                     log.debug("Mapped attribute: " + attributeName);
                     log.debug("Attribute value: " + claims.get(entry.getKey()));


### PR DESCRIPTION
## Related Issue
- Internally mentioned

## Demo

https://github.com/user-attachments/assets/f7c4e3e8-1d4b-4884-b523-e3b0de4ef437


## Implementation
This pull request introduces a minor improvement to the `setUserClaimsWithID` method in `UniqueIDReadWriteLDAPUserStoreManager.java`. The change ensures that if `attributeName` is `null`, the loop breaks early, preventing potential issues with null attribute handling.

* Added a null check for `attributeName` in the attribute mapping loop to improve robustness.