### PR TITLE
Upgrade versions

### DIFF
--- a/core/org.wso2.carbon.ndatasource.common/pom.xml
+++ b/core/org.wso2.carbon.ndatasource.common/pom.xml
@@ -47,6 +47,10 @@
                         <Export-Package>
                             org.wso2.carbon.ndatasource.common.*
                         </Export-Package>
+                        <Import-Package>
+                            org.apache.commons.logging.*;version="${import.package.version.commons.logging}",
+                            *;resolution:=optional
+                        </Import-Package>
                         <DynamicImport-Package>*</DynamicImport-Package>
                     </instructions>
                 </configuration>

--- a/core/org.wso2.carbon.server/pom.xml
+++ b/core/org.wso2.carbon.server/pom.xml
@@ -43,6 +43,10 @@
             <groupId>org.wso2.config.mapper</groupId>
             <artifactId>config-mapper</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.orbit.org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/distribution/kernel/src/assembly/bin.xml
+++ b/distribution/kernel/src/assembly/bin.xml
@@ -142,7 +142,7 @@
                 <include>com.hubspot.jinjava:jinjava:jar</include>
                 <include>com.google.guava:guava:jar</include>
                 <include>org.slf4j:slf4j-api:jar</include>
-                <include>org.apache.commons:commons-lang3:jar</include>
+                <include>org.wso2.orbit.org.apache.commons:commons-lang3:jar</include>
                 <include>com.fasterxml.jackson.core:jackson-core:jar</include>
                 <include>com.fasterxml.jackson.core:jackson-databind:jar</include>
                 <include>com.fasterxml.jackson.core:jackson-annotations:jar</include>

--- a/features/org.wso2.carbon.core.common.feature/pom.xml
+++ b/features/org.wso2.carbon.core.common.feature/pom.xml
@@ -111,7 +111,7 @@
                                 <bundleDef>com.google.code.gson:gson:${version.com.google.code.gson}</bundleDef>
                                 <!--commons-text and commons-lang3 required for axiom-->
                                 <bundleDef>org.wso2.orbit.commons-text:commons-text:${commons-text.orbit.version}</bundleDef>
-                                <bundleDef>org.apache.commons:commons-lang3:${commons-lang3.version}</bundleDef>
+                                <bundleDef>org.wso2.orbit.org.apache.commons:commons-lang3:${commons-lang3.version}</bundleDef>
 
                                 <!--Kernel bundles-->
                                 <bundleDef>org.wso2.carbon:org.wso2.carbon.utils:${carbon.kernel.version}</bundleDef>

--- a/features/org.wso2.carbon.core.common.feature/pom.xml
+++ b/features/org.wso2.carbon.core.common.feature/pom.xml
@@ -111,7 +111,7 @@
                                 <bundleDef>com.google.code.gson:gson:${version.com.google.code.gson}</bundleDef>
                                 <!--commons-text and commons-lang3 required for axiom-->
                                 <bundleDef>org.wso2.orbit.commons-text:commons-text:${commons-text.orbit.version}</bundleDef>
-                                <bundleDef>org.wso2.orbit.org.apache.commons:commons-lang3:${commons-lang3.orbit.version}</bundleDef>
+                                <bundleDef>org.apache.commons:commons-lang3:${commons-lang3.version}</bundleDef>
 
                                 <!--Kernel bundles-->
                                 <bundleDef>org.wso2.carbon:org.wso2.carbon.utils:${carbon.kernel.version}</bundleDef>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -445,7 +445,7 @@
         <axiom.osgi.version>1.2.11-wso2v29</axiom.osgi.version>
         <axiom.osgi.version.range>[1.2.11, 1.3.0)</axiom.osgi.version.range>
         <commons-text.orbit.version>1.10.0.wso2v2</commons-text.orbit.version>
-        <commons-lang3.version>3.18.0</commons-lang3.version>
+        <commons-lang3.version>3.18.0.wso2v1</commons-lang3.version>
 
 
         <!-- Spring Framework -->
@@ -1131,6 +1131,11 @@
                 <version>${version.commons.codec}</version>
             </dependency>
             <dependency>
+                <groupId>org.wso2.orbit.org.apache.commons</groupId>
+                <artifactId>commons-lang3</artifactId>
+                <version>${commons-lang3.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>annogen.wso2</groupId>
                 <artifactId>annogen</artifactId>
                 <version>${version.annogen}</version>
@@ -1230,6 +1235,12 @@
                 <artifactId>addressing</artifactId>
                 <version>${version.addressing}</version>
                 <type>mar</type>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.apache.commons</groupId>
+                        <artifactId>commons-lang3</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>taglibs.wso2</groupId>
@@ -1793,11 +1804,23 @@
                 <groupId>org.wso2.config.mapper</groupId>
                 <artifactId>config-mapper</artifactId>
                 <version>${config.mapper.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.apache.commons</groupId>
+                        <artifactId>commons-lang3</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>com.hubspot.jinjava</groupId>
                 <artifactId>jinjava</artifactId>
                 <version>${version.jinjava}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.apache.commons</groupId>
+                        <artifactId>commons-lang3</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>net.consensys.cava</groupId>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -445,7 +445,7 @@
         <axiom.osgi.version>1.2.11-wso2v29</axiom.osgi.version>
         <axiom.osgi.version.range>[1.2.11, 1.3.0)</axiom.osgi.version.range>
         <commons-text.orbit.version>1.10.0.wso2v2</commons-text.orbit.version>
-        <commons-lang3.orbit.version>3.4.0.wso2v1</commons-lang3.orbit.version>
+        <commons-lang3.version>3.18.0</commons-lang3.version>
 
 
         <!-- Spring Framework -->
@@ -520,7 +520,7 @@
 
         <!-- findbugs -->
         <version.findbugs.annotations>1.3.2</version.findbugs.annotations>
-        <version.commons.logging>1.2</version.commons.logging>
+        <version.commons.logging>1.3.5</version.commons.logging>
 
         <!--PAX Logging related dependency versions-->
         <pax.logging.api.version>2.3.0-wso2v1</pax.logging.api.version>
@@ -556,7 +556,6 @@
 
         <version.log4j.core>2.24.3</version.log4j.core>
         <version.log4j.jul>2.24.3</version.log4j.jul>
-        <version.commons.logging>1.2</version.commons.logging>
         <version.xmlunit>1.1</version.xmlunit>
         <version.jaxen>1.1.1</version.jaxen>
         <version.junit>4.11</version.junit>


### PR DESCRIPTION
This pull request updates dependency management for Apache Commons libraries, particularly `commons-lang3` and `commons-logging`, across multiple Maven POM files in the codebase. The changes ensure consistent versions, improve compatibility, and prevent duplicate or conflicting dependencies by using exclusions where necessary.

**Dependency Version Updates**

* Updated the version of `commons-lang3` to `3.18.0.wso2v1` in `parent/pom.xml` and replaced the old property `commons-lang3.orbit.version` with `commons-lang3.version` throughout the project. [[1]](diffhunk://#diff-b5a06276719e759fe07dfe6f75d781be5f83d2215179d82bdb195ad035348214L448-R448) [[2]](diffhunk://#diff-85265d98bafa6c3b8bc4361338502bbab0069317b1680f9b3670f77dfd332ed4L114-R114)
* Updated the version of `commons-logging` to `1.3.5` in `parent/pom.xml` for improved logging compatibility.

**Dependency Additions and Import Package Management**

* Added `commons-lang3` as a direct dependency in both `parent/pom.xml` and `core/org.wso2.carbon.server/pom.xml`, ensuring it is available for all modules that require it. [[1]](diffhunk://#diff-b5a06276719e759fe07dfe6f75d781be5f83d2215179d82bdb195ad035348214R1133-R1137) [[2]](diffhunk://#diff-f4bad284850b7caf33a4a695f161587ec4c805e3f45b4d5451772d336bb47b4eR46-R49)
* Added explicit `Import-Package` instructions for `org.apache.commons.logging` in `core/org.wso2.carbon.ndatasource.common/pom.xml` to manage OSGi imports more reliably.

**Dependency Exclusions**

* Added exclusions for `commons-lang3` in several dependencies (`addressing`, `config-mapper`, and `jinjava`) in `parent/pom.xml` to avoid redundant or conflicting transitive dependencies. [[1]](diffhunk://#diff-b5a06276719e759fe07dfe6f75d781be5f83d2215179d82bdb195ad035348214R1238-R1243) [[2]](diffhunk://#diff-b5a06276719e759fe07dfe6f75d781be5f83d2215179d82bdb195ad035348214R1807-R1823)