### PR TITLE
Introduce soap admin service deny list

### DIFF
--- a/core/org.wso2.carbon.base/src/main/java/org/wso2/carbon/base/ServerConfiguration.java
+++ b/core/org.wso2.carbon.base/src/main/java/org/wso2/carbon/base/ServerConfiguration.java
@@ -1,17 +1,17 @@
-/* 
+/*
  * Copyright 2005,2006 WSO2, Inc. http://www.wso2.org
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
- * You may obtain a copy of the License at 
- * 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
- * limitations under the License. 
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.wso2.carbon.base;
 
@@ -41,9 +41,11 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.Stack;
 import java.util.StringTokenizer;
 import javax.xml.namespace.QName;
@@ -97,6 +99,8 @@ public class ServerConfiguration implements ServerConfigurationService {
 			.getLog(ServerConfigurationService.class);
 
 	private Map<String, List<String>> configuration = new HashMap<String, List<String>>();
+
+	private final Set<String> deniedAdminServices = new HashSet<>();
 	private boolean isInitialized;
 	private boolean isLoadedConfigurationPreserved = false;
 	private String documentXML;
@@ -109,7 +113,7 @@ public class ServerConfiguration implements ServerConfigurationService {
 
 	/**
 	 * Method to retrieve an instance of the server configuration.
-	 * 
+	 *
 	 * @return instance of the server configuration
 	 */
 	public static ServerConfiguration getInstance() {
@@ -126,10 +130,10 @@ public class ServerConfiguration implements ServerConfigurationService {
 	/**
 	 * This initializes the server configuration. This method should only be
 	 * called once, for successive calls, it will be checked.
-	 * 
+	 *
 	 * @param xmlInputStream
 	 *            the server configuration file stream.
-	 * 
+	 *
 	 * @throws org.wso2.carbon.base.ServerConfigurationException
 	 *             if the operation failed.
 	 */
@@ -165,10 +169,10 @@ public class ServerConfiguration implements ServerConfigurationService {
 	/**
 	 * This initializes the server configuration. This method should only be
 	 * called once, for successive calls, it will be checked.
-	 * 
+	 *
 	 * @param configurationXMLLocation
 	 *            the location of the server configuration file (carbon.xml).
-	 * 
+	 *
 	 * @throws ServerConfigurationException
 	 *             if the operation failed.
 	 */
@@ -232,10 +236,10 @@ public class ServerConfiguration implements ServerConfigurationService {
 	/**
 	 * Method to forcibly initialize the server configuration. If there is any
 	 * configuration loaded, it will not be preserved.
-	 * 
+	 *
 	 * @param xmlInputStream
 	 *            the server configuration file stream.
-	 * 
+	 *
 	 * @throws ServerConfigurationException
 	 *             if the operation failed.
 	 */
@@ -248,10 +252,10 @@ public class ServerConfiguration implements ServerConfigurationService {
 	/**
 	 * Method to forcibly initialize the server configuration. If there is any
 	 * configuration loaded, it will not be preserved.
-	 * 
+	 *
 	 * @param configurationXMLLocation
 	 *            the location of the server configuration file (carbon.xml).
-	 * 
+	 *
 	 * @throws ServerConfigurationException
 	 *             if the operation failed.
 	 */
@@ -263,12 +267,12 @@ public class ServerConfiguration implements ServerConfigurationService {
 
 	/**
 	 * Method to forcibly initialize the server configuration.
-	 * 
+	 *
 	 * @param configurationXMLLocation
 	 *            the location of the server configuration file (carbon.xml).
 	 * @param isLoadedConfigurationPreserved
 	 *            whether the currently loaded configuration is preserved.
-	 * 
+	 *
 	 * @throws ServerConfigurationException
 	 *             if the operation failed.
 	 */
@@ -285,6 +289,19 @@ public class ServerConfiguration implements ServerConfigurationService {
 		for (Iterator childElements = serverConfig.getChildElements(); childElements.hasNext(); ) {
 			OMElement element = (OMElement) childElements.next();
 			nameStack.push(element.getLocalName());
+			if ("DeniedAdminServices".equals(element.getLocalName())){
+				for (Iterator denyServices = element.getChildElements(); denyServices.hasNext(); ) {
+					OMElement denyService = (OMElement) denyServices.next();
+					if ("Service".equals(denyService.getLocalName()) && elementHasText(denyService)) {
+						deniedAdminServices.add(denyService.getText().trim());
+					}
+				}
+				String key = getKey(nameStack);
+				String value = String.join(",", deniedAdminServices);
+				addToConfiguration(key, value);
+				nameStack.pop();
+				continue;
+			}
 			if (elementHasText(element)) {
 				String key = getKey(nameStack);
 				String value;
@@ -356,7 +373,7 @@ public class ServerConfiguration implements ServerConfigurationService {
 
 	/**
 	 * Method to a given key, value pair into the configuration.
-	 * 
+	 *
 	 * @param key
 	 *            the key to add
 	 * @param value
@@ -386,7 +403,7 @@ public class ServerConfiguration implements ServerConfigurationService {
 	/**
 	 * overrides the configuration property instead of adding the value to the
 	 * list
-	 * 
+	 *
 	 * @param key
 	 * @param value
 	 */
@@ -429,10 +446,10 @@ public class ServerConfiguration implements ServerConfigurationService {
 	/**
 	 * There can be multiple objects with the same key. This will return the
 	 * first String from them
-	 * 
+	 *
 	 * @param key
 	 *            the search key
-	 * 
+	 *
 	 * @return value corresponding to the given key
 	 */
 	@Override
@@ -446,10 +463,10 @@ public class ServerConfiguration implements ServerConfigurationService {
 
 	/**
 	 * There can be multiple object corresponding to the same object.
-	 * 
+	 *
 	 * @param key
 	 *            the search key
-	 * 
+	 *
 	 * @return the properties corresponding to the <code>key</code>
 	 */
 	@Override
@@ -463,7 +480,7 @@ public class ServerConfiguration implements ServerConfigurationService {
 
 	/**
 	 * Method to retrieve the Configuration as an XML Document.
-	 * 
+	 *
 	 * @return DOM element containing server configuration.
 	 */
 	@Override
@@ -488,10 +505,10 @@ public class ServerConfiguration implements ServerConfigurationService {
 
 	/**
 	 * Converts a given OMElement to a DOM Element.
-	 * 
+	 *
 	 * @param element
 	 *            the OM element to be converted to DOM.
-	 * 
+	 *
 	 * @return Returns Element.
 	 * @throws Exception
 	 *             if the operation failed.
@@ -538,5 +555,9 @@ public class ServerConfiguration implements ServerConfigurationService {
 
 	protected String getProtectedValue(String key) {
 		return secretResolver.resolve("Carbon." + key);
+	}
+
+	public Set<String> getDeniedAdminServices() {
+		return deniedAdminServices;
 	}
 }

--- a/core/org.wso2.carbon.base/src/main/java/org/wso2/carbon/base/api/ServerConfigurationService.java
+++ b/core/org.wso2.carbon.base/src/main/java/org/wso2/carbon/base/api/ServerConfigurationService.java
@@ -2,6 +2,8 @@ package org.wso2.carbon.base.api;
 
 import org.w3c.dom.Element;
 
+import java.util.Set;
+
 public interface ServerConfigurationService {
     void setConfigurationProperty(String key, String value);
 
@@ -12,5 +14,7 @@ public interface ServerConfigurationService {
     String[] getProperties(String key);
 
     Element getDocumentElement();
+
+    public Set<String> getDeniedAdminServices();
 
 }

--- a/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/deployment/Axis2ServiceRegistry.java
+++ b/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/deployment/Axis2ServiceRegistry.java
@@ -15,6 +15,19 @@
  */
 package org.wso2.carbon.utils.deployment;
 
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.Dictionary;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import org.apache.axiom.om.OMElement;
 import org.apache.axis2.AxisFault;
 import org.apache.axis2.context.ConfigurationContext;
@@ -35,19 +48,13 @@ import org.apache.commons.logging.LogFactory;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleEvent;
 import org.wso2.carbon.base.CarbonBaseConstants;
+import org.wso2.carbon.base.api.ServerConfigurationService;
+import org.wso2.carbon.utils.CarbonUtils;
 import org.wso2.carbon.utils.IOStreamUtils;
 
 import javax.xml.stream.XMLStreamException;
-import java.io.*;
 import java.net.URL;
 import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.Dictionary;
-import java.util.Enumeration;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 import static org.wso2.carbon.utils.WSO2Constants.BUNDLE_ID;
@@ -164,6 +171,9 @@ public class Axis2ServiceRegistry {
     }
 
     private void addServices(Bundle bundle) {
+
+        ServerConfigurationService serverConfigurationService = CarbonUtils.getServerConfiguration();
+        Set<String> denyServiceList = serverConfigurationService.getDeniedAdminServices();
         if (!serviceGroupMap.containsKey(bundle)) {
             Enumeration enumeration = bundle.findEntries("META-INF", "*services.xml", true);
             List<AxisServiceGroup> axisServiceGroupList = null;
@@ -207,10 +217,13 @@ public class Axis2ServiceRegistry {
                         ServiceBuilder serviceBuilder = new ServiceBuilder(configCtx, axisService);
                         serviceBuilder.setWsdlServiceMap(wsdlServicesMap);
                         AxisService service = serviceBuilder.populateService(rootElement);
-                        ArrayList<AxisService> serviceList = new ArrayList<AxisService>();
-                        serviceList.add(service);
+                        List<AxisService> axisServices = new ArrayList<>();
+                        axisServices.add(service);
+                        ArrayList<? extends AxisService> filteredServices =
+                                retrieveFilteredServices(bundle, denyServiceList, axisServices);
+                        if (filteredServices == null || filteredServices.isEmpty()) continue;
                         DeploymentEngine.addServiceGroup(serviceGroup,
-                                serviceList,
+                                filteredServices,
                                 null,
                                 null,
                                 axisConfig);
@@ -224,8 +237,11 @@ public class Axis2ServiceRegistry {
                                 new ServiceGroupBuilder(rootElement, wsdlServicesMap,
                                         configCtx);
                         ArrayList<? extends AxisService> serviceList = groupBuilder.populateServiceGroup(serviceGroup);
+                        ArrayList<? extends AxisService> filteredServiceList = retrieveFilteredServices(bundle,
+                                denyServiceList, serviceList);
+                        if (filteredServiceList == null || filteredServiceList.isEmpty()) continue;
                         DeploymentEngine.addServiceGroup(serviceGroup,
-                                serviceList,
+                                filteredServiceList,
                                 null,
                                 null,
                                 axisConfig);
@@ -239,7 +255,7 @@ public class Axis2ServiceRegistry {
                 } catch (Exception e) {
                     String msg = "Error building service from bundle : " +
                                  "Symbolic Name: " + bundle.getSymbolicName() +
-                                 ",Bundle Version: " + bundle.getVersion() + 
+                                 ",Bundle Version: " + bundle.getVersion() +
                                  ", ID: " + bundle.getBundleId();
                     log.error(msg, e);
                 }
@@ -248,6 +264,30 @@ public class Axis2ServiceRegistry {
                 serviceGroupMap.put(bundle, axisServiceGroupList);
             }
         }
+    }
+
+    private static ArrayList<? extends AxisService> retrieveFilteredServices(Bundle bundle, Set<String> denyServiceList,
+                                                                   List<? extends AxisService> serviceList) {
+        if (denyServiceList == null || denyServiceList.isEmpty()) {
+            return (ArrayList<? extends AxisService>) serviceList;
+        }
+        ArrayList<AxisService> filteredServiceList = new ArrayList<>();
+        if (denyServiceList.contains("*")) {
+            return filteredServiceList;
+        } else {
+            for (AxisService axisService : serviceList) {
+                if (!denyServiceList.contains(axisService.getName())) {
+                    filteredServiceList.add(axisService);
+                } else {
+                    if (log.isDebugEnabled()) {
+                        log.debug("Service " + axisService.getName() + " is in the deny list. " +
+                                "Hence not deploying this service from the bundle "
+                                + bundle.getSymbolicName());
+                    }
+                }
+            }
+        }
+        return filteredServiceList;
     }
 
     private HashMap processWSDL(Bundle bundle) throws IOException, XMLStreamException {

--- a/core/org.wso2.carbon.utils/src/test/java/org/wso2/carbon/utils/deployment/Axis2ServiceRegistryTest.java
+++ b/core/org.wso2.carbon.utils/src/test/java/org/wso2/carbon/utils/deployment/Axis2ServiceRegistryTest.java
@@ -58,7 +58,7 @@ public class Axis2ServiceRegistryTest extends Axis2ModuleRegistryTest {
         File serviceDirectory = Paths.get(testDir, "services").toFile();
         File wsdlDirectory = Paths.get(testDir, "wsdls").toFile();
         Assert.assertTrue(serviceDirectory.exists() && serviceDirectory.isDirectory() &&
-        wsdlDirectory.exists() && wsdlDirectory.isDirectory());
+                wsdlDirectory.exists() && wsdlDirectory.isDirectory());
         Enumeration<URL> serviceEntries = new Axis2ModuleRegistryTest.
                 ManifestModuleIterator(getFileListFromGiveDirectory(serviceDirectory.getAbsolutePath()));
         Enumeration<URL> wsdlEntries = new Axis2ModuleRegistryTest.

--- a/distribution/kernel/carbon-home/repository/resources/conf/templates/repository/conf/carbon.xml.j2
+++ b/distribution/kernel/carbon-home/repository/resources/conf/templates/repository/conf/carbon.xml.j2
@@ -939,4 +939,10 @@
         </OpenTelemetry>
     </Tracing>
 
+    <DeniedAdminServices>
+        {% for service in admin_service.deny_list %}
+        <Service>{{service}}</Service>
+        {% endfor %}
+    </DeniedAdminServices>
+
 </Server>


### PR DESCRIPTION
This pull request introduces a mechanism to avoid the deployment of specific admin services via configuration in `carbon.xml`. The main changes add support for specifying a deny list of admin services, which are then filtered out during service deployment in the OSGi bundle lifecycle.

### Admin service deny list support

* Added a new `DeniedAdminServices` section to the `carbon.xml` configuration template, allowing administrators to specify a list of services to avoid deploying.

**Configuration for deployment.toml**
```
[admin_service]
deny_list = ["WebappAdmin"]

```