### PR TITLE
[4.9.x] Upgrade axis2 and axiom versions

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -455,7 +455,7 @@
         <version.spring>3.1.0.RELEASE</version.spring>
 
         <!-- Apache Axis2 -->
-        <version.axis2>1.6.1-wso2v105</version.axis2>
+        <version.axis2>1.6.1-wso2v108</version.axis2>
         <imp.pkg.version.axis2>[1.6.1, 1.7.0)</imp.pkg.version.axis2>
         <version.addressing>${version.axis2}</version.addressing>
         <orbit.version.axis2>${version.axis2}</orbit.version.axis2>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -439,14 +439,10 @@
         <imp.pkg.version.neethi>[2.0.4.wso2v4, 3.0.0)</imp.pkg.version.neethi>
 
         <!-- Apache Axiom -->
-        <orbit.version.axiom>1.2.11-wso2v29</orbit.version.axiom>
+        <orbit.version.axiom>1.2.11-wso2v30</orbit.version.axiom>
         <imp.pkg.version.axiom>[1.2.11, 1.3.0)</imp.pkg.version.axiom>
-        <version.axiom>1.2.11-wso2v29</version.axiom>
-        <axiom.osgi.version>1.2.11-wso2v29</axiom.osgi.version>
-        <axiom.osgi.version.range>[1.2.11, 1.3.0)</axiom.osgi.version.range>
         <commons-text.orbit.version>1.10.0.wso2v2</commons-text.orbit.version>
         <commons-lang3.version>3.18.0.wso2v1</commons-lang3.version>
-
 
         <!-- Spring Framework -->
         <orbit.version.spring>3.1.0.wso2v2</orbit.version.spring>


### PR DESCRIPTION
## Purpose

This pull request updates dependency versions in the `parent/pom.xml` file to ensure the project uses the latest compatible releases. The most important changes are version bumps for key libraries.

Dependency version updates:

* Updated `orbit.version.axiom` from `1.2.11-wso2v29` to `1.2.11-wso2v30` to use a newer release of Apache Axiom.
* Updated `version.axis2` from `1.6.1-wso2v105` to `1.6.1-wso2v108` to use a newer release of Apache Axis2.
This pull request updates the Axis2 dependency version in the `parent/pom.xml` file to ensure compatibility with the latest bug fixes and improvements.

Dependency version update:

* Changed the value of `version.axis2` from `1.6.1-wso2v105` to `1.6.1-wso2v108` in `parent/pom.xml`, which will apply the latest patch release for Axis2 throughout the project.