### PR TITLE
[4.9.x] Prepare for next development version

### DIFF
--- a/core/org.wso2.carbon.logging/pom.xml
+++ b/core/org.wso2.carbon.logging/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon</groupId>
         <artifactId>carbon-kernel</artifactId>
-        <version>4.9.30-SNAPSHOT</version>
+        <version>4.9.31-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/org.wso2.carbon.ui/src/main/resources/web/docs/about.html
+++ b/core/org.wso2.carbon.ui/src/main/resources/web/docs/about.html
@@ -21,7 +21,7 @@
 <link href="../admin/css/documentation.css" rel="stylesheet" type="text/css" media="all"/>
 </head>
 <body>
-<h1>Version 4.9.30</h1>
+<h1>Version 4.9.31-SNAPSHOT</h1>
 <h2>About WSO2 Carbon </h2>
 <p>WSO2 Carbon is a component based Enterprise SOA platform. The
 design of

--- a/distribution/kernel/carbon.product
+++ b/distribution/kernel/carbon.product
@@ -2,7 +2,7 @@
 <?pde version="3.5"?>
 
 <product name="Carbon Product" uid="carbon.product.id" id="carbon.product" application="carbon.application"
-version="4.9.30" useFeatures="true" includeLaunchers="true">
+version="4.9.31.SNAPSHOT" useFeatures="true" includeLaunchers="true">
 
    <configIni use="default">
    </configIni>
@@ -14,7 +14,7 @@ version="4.9.30" useFeatures="true" includeLaunchers="true">
    </plugins>
 
    <features>
-      <feature id="org.wso2.carbon.core.runtime" version="4.9.30"/>
+      <feature id="org.wso2.carbon.core.runtime" version="4.9.31.SNAPSHOT"/>
    </features>
 
   <configurations>

--- a/distribution/kernel/src/assembly/filter.properties
+++ b/distribution/kernel/src/assembly/filter.properties
@@ -1,2 +1,2 @@
-carbon.version=4.9.30
+carbon.version=4.9.31-SNAPSHOT
 p2.repo.url=http://product-dist.wso2.com/p2/carbon/releases/wilkes/

--- a/distribution/product/modules/distribution/src/assembly/filter.properties
+++ b/distribution/product/modules/distribution/src/assembly/filter.properties
@@ -1,8 +1,8 @@
 product.name=WSO2 Carbon
-product.version=4.9.30
+product.version=4.9.31-SNAPSHOT
 product.key=Carbon
-carbon.product.version=4.9.30
-carbon.version=4.9.30
+carbon.product.version=4.9.31-SNAPSHOT
+carbon.version=4.9.31-SNAPSHOT
 default.server.role=CarbonServer
 hotdeployment=true
 hotupdate=true


### PR DESCRIPTION
## Purpose
This pull request updates the WSO2 Carbon product version from `4.9.30` to `4.9.31-SNAPSHOT` throughout the codebase. The main changes ensure that all relevant files and metadata reflect the new snapshot version for the next release cycle.

Version bump across the platform:

* Updated parent version in `core/org.wso2.carbon.logging/pom.xml` to `4.9.31-SNAPSHOT` to align with the new release.
* Changed displayed version in `core/org.wso2.carbon.ui/src/main/resources/web/docs/about.html` to `4.9.31-SNAPSHOT` for documentation accuracy.

Product and feature metadata updates:

* Updated product version and feature version in `distribution/kernel/carbon.product` to `4.9.31-SNAPSHOT`. [[1]](diffhunk://#diff-0adf2f05a62ab856e199901119b972cc833a6764a05b266c7ddf7aa281771f61L5-R5) [[2]](diffhunk://#diff-0adf2f05a62ab856e199901119b972cc833a6764a05b266c7ddf7aa281771f61L17-R17)
* Updated version properties in `distribution/kernel/src/assembly/filter.properties` and `distribution/product/modules/distribution/src/assembly/filter.properties` to `4.9.31-SNAPSHOT`. [[1]](diffhunk://#diff-80e7bcccf99793ef19bdb73b25d3126d874a359c05739b9242d71c90e45aa06aL1-R1) [[2]](diffhunk://#diff-18ea60061b9a942caa10b97d6c57597073609aeaf9119b3f6e94c77f08ad643dL2-R5)