### PR TITLE
[4.9.x] Upgrade jinjava version to 2.7.5

### DIFF
--- a/distribution/kernel/src/assembly/bin.xml
+++ b/distribution/kernel/src/assembly/bin.xml
@@ -140,6 +140,8 @@
                 <include>org.antlr:antlr4-runtime:jar</include>
                 <include>com.google.code.gson:gson:jar</include>
                 <include>com.hubspot.jinjava:jinjava:jar</include>
+                <include>com.hubspot.immutables:immutables-exceptions:jar</include>
+                <include>com.fasterxml.jackson.datatype:jackson-datatype-jdk8:jar</include>
                 <include>com.google.guava:guava:jar</include>
                 <include>org.slf4j:slf4j-api:jar</include>
                 <include>org.wso2.orbit.org.apache.commons:commons-lang3:jar</include>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -631,12 +631,9 @@
         <maven.spotbugs.dependency.version>3.1.11</maven.spotbugs.dependency.version>
         <version.jinjava>2.7.5</version.jinjava>
         <version.immutables-exceptions>1.11.2</version.immutables-exceptions>
-        <version.jackson-datatype-jdk8>2.17.2</version.jackson-datatype-jdk8>
         <version.cava-toml>0.5.0</version.cava-toml>
         <version.checkstyle>7.8.2</version.checkstyle>
         <version.jackson>2.17.2</version.jackson>
-        <version.jackson.databind>2.17.2</version.jackson.databind>
-        <version.jackson.dataformat>2.17.2</version.jackson.dataformat>
         <version.guava>33.0.0-jre</version.guava>
         <version.ciphertool>1.1.0</version.ciphertool>
         <xml.unit.verions>2.6.2</xml.unit.verions>
@@ -1828,7 +1825,7 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.datatype</groupId>
                 <artifactId>jackson-datatype-jdk8</artifactId>
-                <version>${version.jackson-datatype-jdk8}</version>
+                <version>${version.jackson}</version>
             </dependency>
             <dependency>
                 <groupId>net.consensys.cava</groupId>
@@ -1843,7 +1840,7 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
-                <version>${version.jackson.databind}</version>
+                <version>${version.jackson}</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
@@ -1853,7 +1850,7 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.dataformat</groupId>
                 <artifactId>jackson-dataformat-yaml</artifactId>
-                <version>${version.jackson.dataformat}</version>
+                <version>${version.jackson}</version>
             </dependency>
             <dependency>
                 <groupId>com.google.guava</groupId>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -629,7 +629,9 @@
         <maven.spotbugsplugin.version>3.1.10</maven.spotbugsplugin.version>
         <maven.spotbugsplugin.exclude.file>spotbugs-exclude.xml</maven.spotbugsplugin.exclude.file>
         <maven.spotbugs.dependency.version>3.1.11</maven.spotbugs.dependency.version>
-        <version.jinjava>2.7.2</version.jinjava>
+        <version.jinjava>2.7.5</version.jinjava>
+        <version.immutables-exceptions>1.11.2</version.immutables-exceptions>
+        <version.jackson-datatype-jdk8>2.17.2</version.jackson-datatype-jdk8>
         <version.cava-toml>0.5.0</version.cava-toml>
         <version.checkstyle>7.8.2</version.checkstyle>
         <version.jackson>2.17.2</version.jackson>
@@ -1817,6 +1819,16 @@
                         <artifactId>commons-lang3</artifactId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>com.hubspot.immutables</groupId>
+                <artifactId>immutables-exceptions</artifactId>
+                <version>${version.immutables-exceptions}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.datatype</groupId>
+                <artifactId>jackson-datatype-jdk8</artifactId>
+                <version>${version.jackson-datatype-jdk8}</version>
             </dependency>
             <dependency>
                 <groupId>net.consensys.cava</groupId>


### PR DESCRIPTION
## Purpose

This pull request makes a minor update to a dependency version in the project configuration. The version of the `jinjava` library has been updated from 2.7.2 to 2.7.5 in the `parent/pom.xml` file.