### PR TITLE
Add tenant manager method to return tenant from the tenant domain.

### DIFF
--- a/core/org.wso2.carbon.user.api/src/main/java/org/wso2/carbon/user/api/TenantManager.java
+++ b/core/org.wso2.carbon.user.api/src/main/java/org/wso2/carbon/user/api/TenantManager.java
@@ -127,4 +127,17 @@ public interface TenantManager {
      * @throws UserStoreException
      */
     String getSuperTenantDomain() throws UserStoreException;
+
+    /**
+     * Gets a Tenant object by tenant domain.
+     *
+     * @param tenantDomain tenant domain.
+     * @return Tenant.
+     * @throws UserStoreException if there is an error in tenant retrieval.
+     */
+    default Tenant getTenantByDomain(String tenantDomain) throws UserStoreException {
+
+        int tenantID = getTenantId(tenantDomain);
+        return getTenant(tenantID);
+    }
 }

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/tenant/JDBCTenantManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/tenant/JDBCTenantManager.java
@@ -824,26 +824,7 @@ public class JDBCTenantManager implements TenantManager {
                 tenant.setRealmConfig(realmConfig);
                 setSecondaryUserStoreConfig(realmConfig, id);
                 tenant.setAdminName(realmConfig.getAdminUserName());
-                if (StringUtils.isNotBlank(tenant.getAssociatedOrganizationUUID())) {
-                    String adminId = realmConfig.getAdminUserId();
-                    if (StringUtils.isNotBlank(adminId)) {
-                        tenant.setAdminUserId(adminId);
-                    } else {
-                        // If realms were not migrated after https://github.com/wso2/product-is/issues/14001.
-                        try {
-                            /*
-                            Try to resolve user id from username. This get successful if the user store manager
-                            can resolve the user id even when the user does not belong to the tenant user store
-                             */
-                            tenant.setAdminUserId(getUserId(realmConfig.getAdminUserName(), id));
-                        } catch (UserStoreException ex) {
-                            // Failure to resolve user id from username means the user id is stored as the username.
-                            tenant.setAdminUserId(realmConfig.getAdminUserName());
-                        }
-                    }
-                } else {
-                    tenant.setAdminUserId(getUserId(realmConfig.getAdminUserName(), id));
-                }
+                setTenantAdminUserId(tenant, realmConfig);
                 if (log.isDebugEnabled()) {
                     log.debug("Obtained tenant from database for the given UUID: " + uniqueId
                             + ", hence adding tenant to cache where tenantDomain: {" + domain + "}");
@@ -864,6 +845,28 @@ public class JDBCTenantManager implements TenantManager {
             throw new UserStoreException(msg, e);
         } finally {
             DatabaseUtil.closeAllConnections(dbConnection, result, prepStmt);
+        }
+        return tenant;
+    }
+
+    public Tenant getTenantByDomain(String tenantDomain) throws UserStoreException {
+
+        if (StringUtils.isBlank(tenantDomain)) {
+            throw new UserStoreException("Tenant domain cannot be null or empty.");
+        }
+
+        Tenant tenant = getTenant(getTenantId(tenantDomain));
+        if (tenant == null) {
+            return null;
+        }
+
+        // Set the tenant admin user id if it is not already set.
+        if (StringUtils.isBlank(tenant.getAdminUserId())) {
+            if (log.isDebugEnabled()) {
+                log.debug("Tenant owner user ID is not set for tenant domain: " + tenantDomain +
+                        ". Attempting to resolve the tenant owner user ID using user store manager.");
+            }
+            setTenantAdminUserId(tenant, tenant.getRealmConfig());
         }
         return tenant;
     }
@@ -1634,5 +1637,38 @@ public class JDBCTenantManager implements TenantManager {
             }
         }
         return false;
+    }
+
+    /**
+     * Sets the tenant admin user id in the tenant object.
+     *
+     * @param tenant      Tenant object to set the admin user id.
+     * @param realmConfig RealmConfiguration object of the tenant.
+     * @throws UserStoreException if an error occurs while retrieving the user id.
+     */
+    private void setTenantAdminUserId(Tenant tenant, RealmConfiguration realmConfig) throws UserStoreException {
+
+        if (tenant == null || realmConfig == null) return;
+        int tenantId = tenant.getId();
+        if (StringUtils.isNotBlank(tenant.getAssociatedOrganizationUUID())) {
+            String adminId = realmConfig.getAdminUserId();
+            if (StringUtils.isNotBlank(adminId)) {
+                tenant.setAdminUserId(adminId);
+            } else {
+                /*
+                 * If realms were not migrated after https://github.com/wso2/product-is/issues/14001,
+                 * try to resolve the user ID from the username. This will succeed if the user store
+                 * manager can resolve the user ID even when the user does not belong to the tenant user store.
+                 */
+                try {
+                    tenant.setAdminUserId(getUserId(realmConfig.getAdminUserName(), tenantId));
+                } catch (UserStoreException ex) {
+                    // Failure to resolve user id from username means the user id is stored as the username.
+                    tenant.setAdminUserId(realmConfig.getAdminUserName());
+                }
+            }
+        } else {
+            tenant.setAdminUserId(getUserId(realmConfig.getAdminUserName(), tenantId));
+        }
     }
 }


### PR DESCRIPTION
### Purpose
Currently, when the getTenantByDomain method [[1]](https://is.docs.wso2.com/en/latest/apis/tenant-management-rest-api/#tag/Tenants/operation/getTenantByDomain) is called, the response returns the tenant owner ID as an empty string.

Example (current behavior):
```
{
    "id": "476029d2-1548-4489-8f0c-27e9802edd06",
    "domain": "abc.com",
    "owners": [
        {
            "id": "",
            "username": "admin"
        }
    ],
    "createdDate": "2025-09-16T09:14:08.896Z",
    "lifecycleStatus": {
        "activated": true
    }
}
```

### Implementation

Inside the getTenantByDomain method, it first retrieves the tenant ID from the tenant domain [[2]](https://github.com/wso2/carbon-multitenancy/blob/a780a09badcf9d6c85956d824edb8b6cd66e7e67/components/tenant-mgt/org.wso2.carbon.tenant.mgt/src/main/java/org/wso2/carbon/tenant/mgt/services/TenantMgtImpl.java#L182), and then fetches the tenant using the tenant ID [[3]](https://github.com/wso2/carbon-multitenancy/blob/a780a09badcf9d6c85956d824edb8b6cd66e7e67/components/tenant-mgt/org.wso2.carbon.tenant.mgt/src/main/java/org/wso2/carbon/tenant/mgt/services/TenantMgtImpl.java#L183). However, when retrieving the tenant by tenant ID, it is unable to resolve the tenant owner’s ID properly.

With the addition of support to persist the tenant creator ID in the UM_TENANT data model [product-is#14001 [4]](https://github.com/wso2/product-is/issues/14001), the getTenant method by tenant UUID was updated to correctly resolve the tenant owner’s ID [[5]](https://github.com/wso2/carbon-kernel/pull/3403).

In this implementation, we adopt the same approach as in [[6]](https://github.com/wso2/carbon-kernel/blob/666e3722453554b55c8535dbafc0b4d96cb8e309/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/tenant/JDBCTenantManager.java#L823-L843) to properly resolve the tenant owner’s user ID.

Additionally, to avoid issues where the abstract method might not be implemented in child classes of `org.wso2.carbon.user.api.TenantManager`, the abstract method is updated by default to first retrieve the tenant ID and then fetch the tenant using that ID (as per the initial implementation logic).

With this change, the corrected response will be as follows:
```
{
    "id": "476029d2-1548-4489-8f0c-27e9802edd06",
    "domain": "abc.com",
    "owners": [
        {
            "id": "48f171e1-cdce-4009-9101-045e27e79219",
            "username": "admin"
        }
    ],
    "createdDate": "2025-09-16T09:14:08.896Z",
    "lifecycleStatus": {
        "activated": true
    }
}
```


[1] - https://is.docs.wso2.com/en/latest/apis/tenant-management-rest-api/#tag/Tenants/operation/getTenantByDomain
[2] - https://github.com/wso2/carbon-multitenancy/blob/a780a09badcf9d6c85956d824edb8b6cd66e7e67/components/tenant-mgt/org.wso2.carbon.tenant.mgt/src/main/java/org/wso2/carbon/tenant/mgt/services/TenantMgtImpl.java#L182
[3] - https://github.com/wso2/carbon-multitenancy/blob/a780a09badcf9d6c85956d824edb8b6cd66e7e67/components/tenant-mgt/org.wso2.carbon.tenant.mgt/src/main/java/org/wso2/carbon/tenant/mgt/services/TenantMgtImpl.java#L183
[4] - https://github.com/wso2/product-is/issues/14001
[5] - https://github.com/wso2/carbon-kernel/pull/3403
[6] - https://github.com/wso2/carbon-kernel/blob/666e3722453554b55c8535dbafc0b4d96cb8e309/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/tenant/JDBCTenantManager.java#L823-L843

### Related Issue
- https://github.com/wso2/product-is/issues/24735