### PR TITLE
Fix race condition during tenant initialization by adding synchronization lock and aborted connection rollback

### DIFF
--- a/core/org.wso2.carbon.registry.core/src/main/java/org/wso2/carbon/registry/core/jdbc/dao/JDBCPathCache.java
+++ b/core/org.wso2.carbon.registry.core/src/main/java/org/wso2/carbon/registry/core/jdbc/dao/JDBCPathCache.java
@@ -138,9 +138,8 @@ public class JDBCPathCache extends PathCache {
                 if (log.isDebugEnabled()) {
                     log.debug("Failed to insert due to already exist in database : " + path);
                 }
-                // we have to be expecting an exception with the duplicate value for the path value
-                // which can be further checked from here..
-                pathId = getPathID(conn, path);
+                // Handle constraint violation by rolling back and retrying pathID lookup.
+                pathId = getPathIDAfterRollback(conn, path);
                 if (pathId > 0) {
                     success = true;
                     return pathId;
@@ -307,9 +306,8 @@ public class JDBCPathCache extends PathCache {
                 if (log.isDebugEnabled()) {
                     log.debug("Failed to insert due to already exist in database : " + path);
                 }
-                // we have to be expecting an exception with the duplicate value for the path value
-                // which can be further checked from here..
-                pathId = getPathID(conn, path);
+                // Handle constraint violation by rolling back and retrying pathID lookup.
+                pathId = getPathIDAfterRollback(conn, path);
                 if (pathId > 0) {
                     success = true;
                     return pathId;
@@ -539,5 +537,32 @@ public class JDBCPathCache extends PathCache {
             }
         }
         return -1;
+    }
+
+    /**
+     * Retrieves the existing path ID after rolling back an aborted transaction
+     * caused by a constraint violation during concurrent path creation.
+     *
+     * @param conn the database connection in aborted transaction state
+     * @param path the path that caused the constraint violation
+     * @return the existing path ID if found, or -1 if not found
+     */
+    private int getPathIDAfterRollback(AbstractConnection conn, String path) throws SQLException {
+
+        try {
+            conn.rollback();
+            if (log.isDebugEnabled()) {
+                log.debug("Rolled back aborted transaction for path: " + path +
+                        " for tenant: " + CurrentSession.getTenantId());
+            }
+        } catch (SQLException rollbackException) {
+            String msg = "Failed to rollback aborted transaction for path: " + path +
+                    ". " + rollbackException.getMessage();
+            log.error(msg, rollbackException);
+
+            // Re-throw to maintain error propagation.
+            throw rollbackException;
+        }
+        return getPathID(conn, path);
     }
 }

--- a/core/org.wso2.carbon.registry.core/src/main/java/org/wso2/carbon/registry/core/utils/RegistryUtils.java
+++ b/core/org.wso2.carbon.registry.core/src/main/java/org/wso2/carbon/registry/core/utils/RegistryUtils.java
@@ -1166,48 +1166,63 @@ public final class RegistryUtils {
 		}
 	}
 
+	/**
+	 * Gets or creates a lock object for the specified tenant initialization.
+	 * Uses String.intern() for memory-efficient synchronization.
+	 *
+	 * @param tenantId  The ID of the tenant.
+	 * @return the lock object for the specified tenant initialization.
+	 */
+	private static Object getTenantInitializationLock(int tenantId) {
+
+		return ("initializeTenant:" + tenantId).intern();
+	}
+
 	// Do tenant-specific initialization.
-	public static void initializeTenant(RegistryService registryService, int tenantId)
-	                                                                                  throws RegistryException {
-		try {
-			UserRegistry systemRegistry = registryService.getConfigSystemRegistry();
-			if (systemRegistry.getRegistryContext() != null) {
-				HandlerManager handlerManager =
-				                                systemRegistry.getRegistryContext()
-				                                              .getHandlerManager();
-				if (handlerManager instanceof HandlerLifecycleManager) {
-					((HandlerLifecycleManager) handlerManager).init(tenantId);
-				}
-			}
-			systemRegistry =
-			                 registryService.getRegistry(CarbonConstants.REGISTRY_SYSTEM_USERNAME,
-			                                             tenantId);
-			addMountCollection(systemRegistry);
-			registerMountPoints(systemRegistry, tenantId);
-			new RegistryCoreServiceComponent().setupMounts(registryService, tenantId);
-			setupMediaTypes(registryService, tenantId);
-			// We need to set the tenant ID for current session. Otherwise the
-			// underlying operations fails
+	public static void initializeTenant(RegistryService registryService, int tenantId) throws RegistryException {
+
+		// Synchronize on the specific tenant to prevent race conditions during tenant initialization.
+		synchronized (getTenantInitializationLock(tenantId)) {
 			try {
-				CurrentSession.setTenantId(tenantId);
-				RegistryContext registryContext = systemRegistry.getRegistryContext();
-				// Adding collection to store user profile information.
-				addUserProfileCollection(systemRegistry,
-				                         getAbsolutePath(registryContext,
-				                                         registryContext.getProfilesPath()));
-				// Adding collection to store services.
-				addServiceStoreCollection(systemRegistry,
-				                          getAbsolutePath(registryContext,
-				                                          registryContext.getServicePath()));
-				// Adding service configuration resources.
-				addServiceConfigResources(systemRegistry);
-			} finally {
-				CurrentSession.removeTenantId();
+				UserRegistry systemRegistry = registryService.getConfigSystemRegistry();
+				if (systemRegistry.getRegistryContext() != null) {
+					HandlerManager handlerManager =
+					                                systemRegistry.getRegistryContext()
+					                                              .getHandlerManager();
+					if (handlerManager instanceof HandlerLifecycleManager) {
+						((HandlerLifecycleManager) handlerManager).init(tenantId);
+					}
+				}
+				systemRegistry =
+				                 registryService.getRegistry(CarbonConstants.REGISTRY_SYSTEM_USERNAME,
+				                                             tenantId);
+				addMountCollection(systemRegistry);
+				registerMountPoints(systemRegistry, tenantId);
+				new RegistryCoreServiceComponent().setupMounts(registryService, tenantId);
+				setupMediaTypes(registryService, tenantId);
+				// We need to set the tenant ID for current session. Otherwise the
+				// underlying operations fails
+				try {
+					CurrentSession.setTenantId(tenantId);
+					RegistryContext registryContext = systemRegistry.getRegistryContext();
+					// Adding collection to store user profile information.
+					addUserProfileCollection(systemRegistry,
+					                         getAbsolutePath(registryContext,
+					                                         registryContext.getProfilesPath()));
+					// Adding collection to store services.
+					addServiceStoreCollection(systemRegistry,
+					                          getAbsolutePath(registryContext,
+					                                          registryContext.getServicePath()));
+					// Adding service configuration resources.
+					addServiceConfigResources(systemRegistry);
+				} finally {
+					CurrentSession.removeTenantId();
+				}
+			} catch (RegistryException e) {
+				log.error("Unable to initialize registry for tenant " + tenantId + ".", e);
+				throw new RegistryException("Unable to initialize registry for tenant " + tenantId +
+				                            ".", e);
 			}
-		} catch (RegistryException e) {
-			log.error("Unable to initialize registry for tenant " + tenantId + ".", e);
-			throw new RegistryException("Unable to initialize registry for tenant " + tenantId +
-			                            ".", e);
 		}
 	}
 


### PR DESCRIPTION
### Purpose
This pull request introduces improvements to concurrency handling and error recovery in the registry codebase. The main changes focus on preventing race conditions during tenant initialization and ensuring robust handling of database constraint violations when adding paths.

**Concurrency and synchronization improvements:**

* Added tenant-specific locking in `RegistryUtils.java` to prevent race conditions during tenant initialization by synchronizing on a per-tenant lock object. (`initializeTenant`, `getTenantInitializationLock`) 

**Database error handling enhancements:**

* Improved handling of constraint violations in `JDBCPathCache.java` by introducing `getPathIDAfterRollback`, which rolls back aborted transactions and retries path ID lookup after a failed insert due to a duplicate path. This change is applied in both overloaded `addEntry` methods.

### Related issue
- https://github.com/wso2/product-is/issues/25649