### PR TITLE
[4.9.x] Upgrade axis2 version to 1.6.1-wso2v111

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -451,7 +451,7 @@
         <version.spring>3.1.0.RELEASE</version.spring>
 
         <!-- Apache Axis2 -->
-        <version.axis2>1.6.1-wso2v108</version.axis2>
+        <version.axis2>1.6.1-wso2v111</version.axis2>
         <imp.pkg.version.axis2>[1.6.1, 1.7.0)</imp.pkg.version.axis2>
         <version.addressing>${version.axis2}</version.addressing>
         <orbit.version.axis2>${version.axis2}</orbit.version.axis2>


### PR DESCRIPTION
## Purpose
This pull request makes a minor update to the Axis2 library version in the `parent/pom.xml` file. The version is incremented from `1.6.1-wso2v108` to `1.6.1-wso2v111`, which likely includes bug fixes or minor improvements.

* Updated the Axis2 dependency version from `1.6.1-wso2v108` to `1.6.1-wso2v111` in `parent/pom.xml` to ensure the project uses the latest compatible release.