### PR TITLE
[4.9.x] Avoid unnecessary userstore calls for identity claims when an identity database is configured and when the claims list is empty

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
@@ -2134,13 +2134,42 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
         if (claims == null) {
             claims = new String[0];
         }
+        Map<String, String> finalValues = new HashMap<>();
+        String[] allClaims = claims.clone();
 
-        Map<String, String> finalValues;
+        // #################### <PreListeners> ###################################################
+        try {
+            for (UserOperationEventListener listener : UMListenerServiceComponent.getUserOperationEventListeners()) {
+                if (listener instanceof AbstractUserOperationEventListener) {
+                    AbstractUserOperationEventListener newListener = (AbstractUserOperationEventListener) listener;
+                    if (!newListener
+                            .doPreGetUserClaimValues(userStore.getDomainFreeName(), claims, profileName, finalValues,
+                                    this)) {
+                        handleGetUserClaimValuesFailure(
+                                ErrorMessages.ERROR_CODE_ERROR_IN_PRE_GET_CLAIM_VALUES.getCode(),
+                                String.format(ErrorMessages.ERROR_CODE_ERROR_IN_PRE_GET_CLAIM_VALUES.getMessage(),
+                                        UserCoreErrorConstants.POST_LISTENER_TASKS_FAILED_MESSAGE), userName, claims,
+                                profileName);
+                        break;
+                    }
+                }
+            }
+        } catch (UserStoreException ex) {
+            handleGetUserClaimValuesFailure(ErrorMessages.ERROR_CODE_ERROR_IN_PRE_GET_CLAIM_VALUES.getCode(),
+                    String.format(ErrorMessages.ERROR_CODE_ERROR_IN_PRE_GET_CLAIM_VALUES.getMessage(),
+                            ex.getMessage()), userName, claims, profileName);
+            throw ex;
+        }
+        // #################### </PreListeners> ###################################################
+
+        claims = removeNullElements(claims);
+
         try {
             if (isUniqueIdEnabled) {
                 finalValues = doGetUserClaimValuesWithID(userID, claims, userStore.getDomainName(), profileName);
             } else {
-                finalValues = doGetUserClaimValues(userStore.getDomainFreeName(), claims, userStore.getDomainName(), profileName);
+                finalValues = doGetUserClaimValues(userStore.getDomainFreeName(), claims, userStore.getDomainName(),
+                        profileName);
             }
         } catch (UserStoreException ex) {
             handleGetUserClaimValuesFailure(ErrorMessages.ERROR_CODE_ERROR_WHILE_GETTING_CLAIM_VALUES.getCode(),
@@ -2149,14 +2178,14 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
             throw ex;
         }
 
-        // #################### <Listeners> #####################################################
+        // #################### <PostListeners> #####################################################
         try {
             for (UserOperationEventListener listener : UMListenerServiceComponent.getUserOperationEventListeners()) {
                 if (listener instanceof AbstractUserOperationEventListener) {
                     AbstractUserOperationEventListener newListener = (AbstractUserOperationEventListener) listener;
                     if (!newListener
-                            .doPostGetUserClaimValues(userStore.getDomainFreeName(), claims, profileName, finalValues,
-                                    this)) {
+                            .doPostGetUserClaimValues(userStore.getDomainFreeName(), allClaims, profileName,
+                                    finalValues, this)) {
                         handleGetUserClaimValuesFailure(
                                 ErrorMessages.ERROR_CODE_ERROR_IN_POST_GET_CLAIM_VALUES.getCode(),
                                 String.format(ErrorMessages.ERROR_CODE_ERROR_IN_POST_GET_CLAIM_VALUES.getMessage(),
@@ -2172,9 +2201,20 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
                             ex.getMessage()), userName, claims, profileName);
             throw ex;
         }
-        // #################### </Listeners> #####################################################
+        // #################### </PostListeners> #####################################################
 
         return finalValues;
+    }
+
+    /**
+     * Removes all null elements from the given String array.
+     *
+     * @param array Array The input String array.
+     * @return A new String array containing only non-null elements.
+     */
+    private static String[] removeNullElements(String[] array) {
+
+        return Arrays.stream(array).filter(Objects::nonNull).toArray(String[]::new);
     }
 
     /**

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/constants/UserCoreErrorConstants.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/constants/UserCoreErrorConstants.java
@@ -71,6 +71,7 @@ public class UserCoreErrorConstants {
         ERROR_CODE_ERROR_WHILE_GETTING_CLAIM_URI("33001", "Un-expected error while getting claim uri, %s"),
         ERROR_CODE_ERROR_WHILE_GETTING_CLAIM_VALUES("33002", "Un-expected error while getting claim values, %s"),
         ERROR_CODE_ERROR_IN_POST_GET_CLAIM_VALUES("33003", "Un-expected error during post get claim values, %s"),
+        ERROR_CODE_ERROR_IN_PRE_GET_CLAIM_VALUES("33005", "Un-expected error during pre get claim values, %s"),
 
         // Error code related with Add ClaimValues
         ERROR_CODE_DUPLICATE_ERROR_WHILE_ADDING_CLAIM_MAPPINGS("33004", "Duplicate entries are found when adding " +

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/ReadOnlyLDAPUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/ReadOnlyLDAPUserStoreManager.java
@@ -640,9 +640,14 @@ public class ReadOnlyLDAPUserStoreManager extends AbstractUserStoreManager {
                     } catch (NamingException e) {
                         log.debug("Error while getting DN of search base", e);
                     }
-                    if (propertyNames == null) {
+                }
+                if (propertyNames == null || propertyNames.length == 0) {
+                    if (log.isDebugEnabled()) {
                         log.debug("No attributes requested");
-                    } else {
+                    }
+                    return values;
+                } else {
+                    if (log.isDebugEnabled()) {
                         for (String attribute : propertyNames) {
                             log.debug("Requesting attribute :" + attribute);
                         }


### PR DESCRIPTION
## Purpose

**This is a port of the fix : https://github.com/wso2/carbon-kernel/pull/4015**

In the current implementation, all the local claims configured are resolved for attributes and sent to the user stores to fetch data. This includes Identity claims which should not be sent if an Identity Database is configured. Here we use config [1],

```
[event.default_listener.governance_identity_store] 
enable_hybrid_data_store = false 
```

to stop sending identity claims to the user store.

[1] https://security.docs.wso2.com/en/latest/security-announcements/security-advisories/2023/WSO2-2022-2101/

### Related Issue 

https://github.com/wso2/api-manager/issues/4310

### Related PR
https://github.com/wso2-extensions/identity-governance/pull/1066
