### PR TITLE
[4.9.x] Prepare for 4.9.32 release

### DIFF
--- a/core/org.wso2.carbon.ui/src/main/resources/web/docs/about.html
+++ b/core/org.wso2.carbon.ui/src/main/resources/web/docs/about.html
@@ -21,7 +21,7 @@
 <link href="../admin/css/documentation.css" rel="stylesheet" type="text/css" media="all"/>
 </head>
 <body>
-<h1>Version 4.9.32-SNAPSHOT</h1>
+<h1>Version 4.9.32</h1>
 <h2>About WSO2 Carbon </h2>
 <p>WSO2 Carbon is a component based Enterprise SOA platform. The
 design of

--- a/distribution/kernel/carbon.product
+++ b/distribution/kernel/carbon.product
@@ -2,7 +2,7 @@
 <?pde version="3.5"?>
 
 <product name="Carbon Product" uid="carbon.product.id" id="carbon.product" application="carbon.application"
-version="4.9.32.SNAPSHOT" useFeatures="true" includeLaunchers="true">
+version="4.9.32" useFeatures="true" includeLaunchers="true">
 
    <configIni use="default">
    </configIni>
@@ -14,7 +14,7 @@ version="4.9.32.SNAPSHOT" useFeatures="true" includeLaunchers="true">
    </plugins>
 
    <features>
-      <feature id="org.wso2.carbon.core.runtime" version="4.9.32.SNAPSHOT"/>
+      <feature id="org.wso2.carbon.core.runtime" version="4.9.32"/>
    </features>
 
   <configurations>

--- a/distribution/kernel/src/assembly/filter.properties
+++ b/distribution/kernel/src/assembly/filter.properties
@@ -1,2 +1,2 @@
-carbon.version=4.9.32-SNAPSHOT
+carbon.version=4.9.32
 p2.repo.url=http://product-dist.wso2.com/p2/carbon/releases/wilkes/

--- a/distribution/product/modules/distribution/src/assembly/filter.properties
+++ b/distribution/product/modules/distribution/src/assembly/filter.properties
@@ -1,8 +1,8 @@
 product.name=WSO2 Carbon
-product.version=4.9.32-SNAPSHOT
+product.version=4.9.32
 product.key=Carbon
-carbon.product.version=4.9.32-SNAPSHOT
-carbon.version=4.9.32-SNAPSHOT
+carbon.product.version=4.9.32
+carbon.version=4.9.32
 default.server.role=CarbonServer
 hotdeployment=true
 hotupdate=true


### PR DESCRIPTION
## Purpose
This pull request updates the version information for WSO2 Carbon from `4.9.32-SNAPSHOT` to the stable release version `4.9.32` across documentation and configuration files. This change ensures consistency in versioning and signals that the software is now in a stable release state.

Version updates:

* Updated the displayed version in the `about.html` documentation page to `4.9.32`.
* Changed the `carbon.version` property in `distribution/kernel/src/assembly/filter.properties` from `4.9.32-SNAPSHOT` to `4.9.32`.
* Updated multiple version-related properties in `distribution/product/modules/distribution/src/assembly/filter.properties` from `4.9.32-SNAPSHOT` to `4.9.32`, including `product.version`, `carbon.product.version`, and `carbon.version`.