### PR TITLE
[4.9.x] Prepare for 4.9.33 release

### DIFF
--- a/core/org.wso2.carbon.ui/src/main/resources/web/docs/about.html
+++ b/core/org.wso2.carbon.ui/src/main/resources/web/docs/about.html
@@ -21,7 +21,7 @@
 <link href="../admin/css/documentation.css" rel="stylesheet" type="text/css" media="all"/>
 </head>
 <body>
-<h1>Version 4.9.33-SNAPSHOT</h1>
+<h1>Version 4.9.33</h1>
 <h2>About WSO2 Carbon </h2>
 <p>WSO2 Carbon is a component based Enterprise SOA platform. The
 design of

--- a/distribution/kernel/carbon.product
+++ b/distribution/kernel/carbon.product
@@ -2,7 +2,7 @@
 <?pde version="3.5"?>
 
 <product name="Carbon Product" uid="carbon.product.id" id="carbon.product" application="carbon.application"
-version="4.9.33.SNAPSHOT" useFeatures="true" includeLaunchers="true">
+version="4.9.33" useFeatures="true" includeLaunchers="true">
 
    <configIni use="default">
    </configIni>
@@ -14,7 +14,7 @@ version="4.9.33.SNAPSHOT" useFeatures="true" includeLaunchers="true">
    </plugins>
 
    <features>
-      <feature id="org.wso2.carbon.core.runtime" version="4.9.33.SNAPSHOT"/>
+      <feature id="org.wso2.carbon.core.runtime" version="4.9.33"/>
    </features>
 
   <configurations>

--- a/distribution/kernel/src/assembly/filter.properties
+++ b/distribution/kernel/src/assembly/filter.properties
@@ -1,2 +1,2 @@
-carbon.version=4.9.33-SNAPSHOT
+carbon.version=4.9.33
 p2.repo.url=http://product-dist.wso2.com/p2/carbon/releases/wilkes/

--- a/distribution/product/modules/distribution/src/assembly/filter.properties
+++ b/distribution/product/modules/distribution/src/assembly/filter.properties
@@ -1,8 +1,8 @@
 product.name=WSO2 Carbon
-product.version=4.9.33-SNAPSHOT
+product.version=4.9.33
 product.key=Carbon
-carbon.product.version=4.9.33-SNAPSHOT
-carbon.version=4.9.33-SNAPSHOT
+carbon.product.version=4.9.33
+carbon.version=4.9.33
 default.server.role=CarbonServer
 hotdeployment=true
 hotupdate=true


### PR DESCRIPTION
## Purpose
This pull request updates the product version from `4.9.33-SNAPSHOT` to `4.9.33` across the codebase to prepare for a stable release. The changes ensure consistency in versioning throughout documentation, configuration files, and product metadata.

Version update for release:

* Updated the displayed version in the `about.html` documentation page to `4.9.33`.
* Changed the product version and feature version in `carbon.product` from `4.9.33-SNAPSHOT` to `4.9.33`. [[1]](diffhunk://#diff-0adf2f05a62ab856e199901119b972cc833a6764a05b266c7ddf7aa281771f61L5-R5) [[2]](diffhunk://#diff-0adf2f05a62ab856e199901119b972cc833a6764a05b266c7ddf7aa281771f61L17-R17)
* Updated `carbon.version` in `distribution/kernel/src/assembly/filter.properties` to `4.9.33`.
* Updated multiple version properties in `distribution/product/modules/distribution/src/assembly/filter.properties` to `4.9.33`.