### PR TITLE
[APIM 4.5.0] Templating enable http for carbon console

### DIFF
--- a/distribution/kernel/carbon-home/repository/resources/conf/templates/repository/conf/carbon.xml.j2
+++ b/distribution/kernel/carbon-home/repository/resources/conf/templates/repository/conf/carbon.xml.j2
@@ -750,7 +750,9 @@
     <StatisticsReporterDisabled>true</StatisticsReporterDisabled>
 
     <!-- Enable accessing Admin Console via HTTP -->
-    <!-- EnableHTTPAdminConsole>true</EnableHTTPAdminConsole -->
+    {% if http_admin_console.enable is defined %}
+    <EnableHTTPAdminConsole>{{http_admin_console.enable}}</EnableHTTPAdminConsole>
+    {% endif %}
 
     <!-- Enable resolving absolute URLs for Admin Console -->
     <AdminConsole>


### PR DESCRIPTION
## Purpose
- This PR resolves the issue "Unable to Access Carbon Console over HTTP" by templating the previously hardcoded configuration to read the value dynamically from the deployment.toml file.

#### Changes introduced: 
> Updated the Carbon configuration to use a template-based approach for enabling HTTP access to the Admin Console. The value of <EnableHTTPAdminConsole> is now determined by the http_admin_console.enable property defined in deployment.toml.

> **Below config should be added in deployment.toml file to enable HTTP for carbon console**
>
> [http_admin_console]
> enable = true

- Fix for: https://github.com/wso2/api-manager/issues/4479