### PR TITLE
Add accessing organization ID to privileged carbon context

### DIFF
--- a/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/context/PrivilegedCarbonContext.java
+++ b/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/context/PrivilegedCarbonContext.java
@@ -476,4 +476,25 @@ public class PrivilegedCarbonContext extends CarbonContext {
 
         return getCarbonContextDataHolder().getOperationScopeValidationContext();
     }
+
+    /**
+     * Set the accessing organization id.
+     *
+     * @param accessingOrganizationId Accessing organization id.
+     */
+    public void setAccessingOrganizationId(String accessingOrganizationId) {
+
+        getCarbonContextDataHolder().setAccessingOrganizationId(accessingOrganizationId);
+    }
+
+    /**
+     * Get the accessing organization id.
+     * This represents the organization id of the accessing organization of the current request.
+     *
+     * @return Accessing organization id.
+     */
+    public String getAccessingOrganizationId() {
+
+        return getCarbonContextDataHolder().getAccessingOrganizationId();
+    }
 }

--- a/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/context/internal/CarbonContextDataHolder.java
+++ b/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/context/internal/CarbonContextDataHolder.java
@@ -150,6 +150,7 @@ public final class CarbonContextDataHolder {
     private String applicationName;
     private String applicationResidentOrganizationId;
     private OperationScopeValidationContext operationScopeValidationContext;
+    private String accessingOrganizationId;
 
     private Map<String, Object> properties;
 
@@ -1554,6 +1555,28 @@ public final class CarbonContextDataHolder {
             OperationScopeValidationContext operationScopeValidationContext) {
 
         this.operationScopeValidationContext = operationScopeValidationContext;
+    }
+
+    /**
+     * Get the accessing organization id.
+     * This represents the organization id of the accessing organization of the current request.
+     *
+     * @return Accessing organization id.
+     */
+    public String getAccessingOrganizationId() {
+
+        return accessingOrganizationId;
+    }
+
+    /**
+     * Set the accessing organization id.
+     *
+     * @param accessingOrganizationId Accessing organization id.
+     */
+    public void setAccessingOrganizationId(String accessingOrganizationId) {
+
+        CarbonUtils.checkSecurity();
+        this.accessingOrganizationId = accessingOrganizationId;
     }
 
     /**


### PR DESCRIPTION
## Purpose

With the b2b direct login without federation, following path pattern will be introduced.
```
/t/<root-org-handle>/o/<accessing-organization-id>
```

Here accessing organization denotes currently accessing organization in the request.

Issue - https://github.com/wso2/product-is/issues/26385
https://github.com/wso2/product-is/issues/24364