### PR TITLE
Support selective configuration of store of local claims

### DIFF
--- a/core/org.wso2.carbon.user.api/src/main/java/org/wso2/carbon/user/api/Claim.java
+++ b/core/org.wso2.carbon.user.api/src/main/java/org/wso2/carbon/user/api/Claim.java
@@ -19,6 +19,7 @@
 package org.wso2.carbon.user.api;
 
 import java.io.Serializable;
+import java.util.Set;
 
 /**
  * Represents a claim that is associated with an entity usually a user. Claims
@@ -94,7 +95,15 @@ public class Claim implements Serializable {
      */
     private boolean multiValued;
 
-    private boolean userStorePersistenceEnabled;
+    /**
+     * Indicates whether the claim is managed in the user store.
+     */
+    private Boolean managedInUserStore;
+
+    /**
+     * Set of user stores that exclude this claim.
+     */
+    private Set<String> excludedUserStores;
 
     public String getClaimUri() {
         return claimUri;
@@ -195,20 +204,38 @@ public class Claim implements Serializable {
     }
 
     /**
-     * Indicates whether the user store persistence is enabled for this claim.
+     * Indicates whether the claim is managed in the user store.
      * @return true if enabled, false otherwise.
      */
-    public boolean isUserStorePersistenceEnabled() {
+    public Boolean isManagedInUserStore() {
 
-        return userStorePersistenceEnabled;
+        return managedInUserStore;
     }
 
     /**
-     * Sets the user store persistence enabled status for this claim.
-     * @param userStorePersistenceEnabled true to enable, false to disable.
+     * Sets the claim to be managed in the user store.
+     * @param managedInUserStore true to enable, false to disable.
      */
-    public void setUserStorePersistenceEnabled(boolean userStorePersistenceEnabled) {
+    public void setManagedInUserStore(Boolean managedInUserStore) {
 
-        this.userStorePersistenceEnabled = userStorePersistenceEnabled;
+        this.managedInUserStore = managedInUserStore;
+    }
+
+    /**
+     * Get the set of user stores that exclude this claim.
+     * @return Set of excluded user stores.
+     */
+    public Set<String> getExcludedUserStores() {
+
+        return excludedUserStores;
+    }
+
+    /**
+     * Set the user stores that exclude this claim.
+     * @param excludedUserStores Set of excluded user stores.
+     */
+    public void setExcludedUserStores(Set<String> excludedUserStores) {
+
+        this.excludedUserStores = excludedUserStores;
     }
 }

--- a/core/org.wso2.carbon.user.api/src/main/java/org/wso2/carbon/user/api/Claim.java
+++ b/core/org.wso2.carbon.user.api/src/main/java/org/wso2/carbon/user/api/Claim.java
@@ -94,6 +94,8 @@ public class Claim implements Serializable {
      */
     private boolean multiValued;
 
+    private boolean userStorePersistenceEnabled;
+
     public String getClaimUri() {
         return claimUri;
     }
@@ -190,5 +192,23 @@ public class Claim implements Serializable {
     public void setMultiValued(boolean multiValued) {
 
         this.multiValued = multiValued;
+    }
+
+    /**
+     * Indicates whether the user store persistence is enabled for this claim.
+     * @return true if enabled, false otherwise.
+     */
+    public boolean isUserStorePersistenceEnabled() {
+
+        return userStorePersistenceEnabled;
+    }
+
+    /**
+     * Sets the user store persistence enabled status for this claim.
+     * @param userStorePersistenceEnabled true to enable, false to disable.
+     */
+    public void setUserStorePersistenceEnabled(boolean userStorePersistenceEnabled) {
+
+        this.userStorePersistenceEnabled = userStorePersistenceEnabled;
     }
 }

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
@@ -17392,15 +17392,13 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
             return false;
         }
 
-        boolean isIdentityClaim = mappedClaim.getClaim().getClaimUri().contains(IDENTITY_CLAIM_URI);
-
         Boolean managedInUserStoreValue = mappedClaim.getClaim().isManagedInUserStore();
         if (managedInUserStoreValue == null) {
             if (log.isDebugEnabled()) {
                 log.debug("ManagedInUserStore property is not set for the claim: " +
                         mappedClaim.getClaim().getClaimUri() + ". Hence defaulting to claim type storage.");
             }
-            return isIdentityClaim;
+            return mappedClaim.getClaim().getClaimUri().contains(IDENTITY_CLAIM_URI);
         }
         if (!managedInUserStoreValue) {
             if (log.isDebugEnabled()) {

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
@@ -110,6 +110,7 @@ import java.util.stream.Stream;
 import javax.sql.DataSource;
 
 import static org.wso2.carbon.user.core.UserCoreConstants.ClaimTypeURIs.IDENTITY_CLAIM_URI;
+import static org.wso2.carbon.user.core.UserCoreConstants.DEFAULT_CARBON_DIALECT;
 import static org.wso2.carbon.user.core.UserCoreConstants.DOMAIN_SEPARATOR;
 import static org.wso2.carbon.user.core.UserCoreConstants.INTERNAL_DOMAIN;
 import static org.wso2.carbon.user.core.UserCoreConstants.INTERNAL_SYSTEM_ROLE_PREFIX;
@@ -16777,7 +16778,7 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
         getExpressionConditions(duplicateCondition, expressionConditions);
 
         // Check whether the request has IdentityClaims in filters.
-        mapAttributesToLocalIdentityClaims(expressionConditions);
+        mapAttributesToLocalIdentityClaims(expressionConditions, domain);
         boolean identityClaimsExistsInInitialCondition = containsIdentityClaims(expressionConditions);
 
         if (identityClaimsExistsInInitialCondition) {
@@ -16935,7 +16936,7 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
         validation in the next iteration of flow when the domain name is not in query params.*/
         Condition duplicateCondition = getDuplicateCondition(condition);
         getExpressionConditions(duplicateCondition, expressionConditions);
-        mapAttributesToLocalIdentityClaims(expressionConditions);
+        mapAttributesToLocalIdentityClaims(expressionConditions, domain);
 
         /* *****************************************************
          * Logic to Filter Users Based on Identity & Non Identity Claims
@@ -17055,7 +17056,7 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
         getExpressionConditions(duplicateCondition, expressionConditions);
 
         // Check whether the request has IdentityClaims in filters.
-        mapAttributesToLocalIdentityClaims(expressionConditions);
+        mapAttributesToLocalIdentityClaims(expressionConditions, domain);
         boolean identityClaimsExistsInInitialCondition = countIdentityClaims(expressionConditions) > 0;
 
         if (identityClaimsExistsInInitialCondition) {
@@ -17286,12 +17287,12 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
 
         if (condition instanceof ExpressionCondition) {
             ExpressionCondition expressionCondition = (ExpressionCondition) condition;
-            if (expressionCondition.getAttributeName().
-                    contains(IDENTITY_CLAIM_URI)) {
+            if (expressionCondition.getAttributeName().contains(DEFAULT_CARBON_DIALECT)) {
                 String claimUri = expressionCondition.getAttributeName();
                 try {
                     ClaimMapping mapping = (ClaimMapping) claimManager.getClaimMapping(claimUri);
-                    String attribute = mapping.getMappedAttribute(domain);
+                    String attribute = mapping.getMappedAttribute(domain) != null ?
+                            mapping.getMappedAttribute(domain) : mapping.getMappedAttribute();
                     expressionCondition.setAttributeName(attribute);
                 } catch (org.wso2.carbon.user.api.UserStoreException e) {
                     throw new UserStoreException(e);
@@ -17342,8 +17343,8 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
      * @param expressionConditions List of expression conditions.
      * @throws UserStoreException
      */
-    private void mapAttributesToLocalIdentityClaims(List<ExpressionCondition> expressionConditions)
-            throws UserStoreException {
+    private void mapAttributesToLocalIdentityClaims(List<ExpressionCondition> expressionConditions,
+                                                    String userStoreDomain) throws UserStoreException {
 
         List<org.wso2.carbon.user.api.ClaimMapping> claimMapping;
         try {
@@ -17354,16 +17355,19 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
         }
         for (ExpressionCondition expressionCondition : expressionConditions) {
             org.wso2.carbon.user.api.ClaimMapping mappedClaim = claimMapping.stream()
-                    .filter(mapping -> StringUtils.equals(mapping.getMappedAttribute(),
-                            expressionCondition.getAttributeName()))
+                    .filter(mapping -> {
+                        String mappedAttributeName = mapping.getMappedAttribute(userStoreDomain) != null ?
+                                mapping.getMappedAttribute(userStoreDomain) : mapping.getMappedAttribute();
+                        return StringUtils.equals(mappedAttributeName, expressionCondition.getAttributeName());
+                    })
                     .findFirst().orElse(null);
 
             if (mappedClaim == null) {
                 continue;
             }
 
-            // Check if the claimURI are of type 'identity claims'.
-            if (mappedClaim.getClaim().getClaimUri().contains(IDENTITY_CLAIM_URI)) {
+            // Check if the claim is an identity store managed claim and map the attribute name to claim URI.
+            if (isIdentityStoreManagedClaim(mappedClaim, userStoreDomain)) {
                 expressionCondition.setAttributeName(mappedClaim.getClaim().getClaimUri());
                 if (log.isDebugEnabled()) {
                     log.debug("Obtained the ClaimURI " + mappedClaim.getClaim().getClaimUri() +
@@ -17371,6 +17375,46 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
                 }
             }
         }
+    }
+
+    /**
+     * This method checks whether the given claim is an identity store managed claim.
+     * Note: This only checks the `managedInUserStore` property of the claim and `excludedUserStores` property only.
+     * This doesn't check if the identity store is a user-store based or if the given user store is configured
+     * to store identity claims.
+     * @param mappedClaim
+     * @return
+     */
+    private boolean isIdentityStoreManagedClaim(org.wso2.carbon.user.api.ClaimMapping mappedClaim,
+                                                String userStoreDomain) {
+
+        if (mappedClaim == null) {
+            return false;
+        }
+
+        boolean isIdentityClaim = mappedClaim.getClaim().getClaimUri().contains(IDENTITY_CLAIM_URI);
+
+        Boolean managedInUserStoreValue = mappedClaim.getClaim().isManagedInUserStore();
+        if (managedInUserStoreValue == null) {
+            if (log.isDebugEnabled()) {
+                log.debug("ManagedInUserStore property is not set for the claim: " +
+                        mappedClaim.getClaim().getClaimUri() + ". Hence defaulting to claim type storage.");
+            }
+            return isIdentityClaim;
+        }
+        if (!managedInUserStoreValue) {
+            if (log.isDebugEnabled()) {
+                log.debug("Claim: " + mappedClaim.getClaim().getClaimUri() +
+                        " is an identity store managed claim as per the ManagedInUserStore property.");
+            }
+            return true;
+        }
+
+        Set<String> excludedUserStores = mappedClaim.getClaim().getExcludedUserStores();
+        if (CollectionUtils.isEmpty(excludedUserStores)) {
+            return false;
+        }
+        return excludedUserStores.contains(userStoreDomain);
     }
 
     /**
@@ -17382,8 +17426,10 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
     private boolean containsIdentityClaims(List<ExpressionCondition> expressionConditions) {
 
         for (ExpressionCondition expressionCondition : expressionConditions) {
+            // For the identity store managed claims, claim URI will be in the attribute name, for others
+            // mapped attribute name will be present.
             if (expressionCondition.getAttributeName() != null &&
-                    expressionCondition.getAttributeName().contains(IDENTITY_CLAIM_URI)) {
+                    expressionCondition.getAttributeName().contains(DEFAULT_CARBON_DIALECT)) {
                 return true;
             }
         }
@@ -17400,8 +17446,10 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
 
         int identityClaimsCount = 0;
         for (ExpressionCondition expressionCondition : expressionConditions) {
+            // For the identity store managed claims, claim URI will be in the attribute name, for others
+            // mapped attribute name will be present.
             if (expressionCondition.getAttributeName() != null &&
-                    expressionCondition.getAttributeName().contains(IDENTITY_CLAIM_URI)) {
+                    expressionCondition.getAttributeName().contains(DEFAULT_CARBON_DIALECT)) {
                 identityClaimsCount += 1;
             }
         }


### PR DESCRIPTION
### Purpose
This pull request introduces enhancements to the way claims are managed and filtered in the user store, particularly focusing on supporting claims that are managed within specific user stores and those excluded from certain stores. The main changes involve extending the `Claim` class to track user store management properties, updating claim mapping logic to consider these new properties, and refining the methods that filter and count identity claims to use a more robust dialect-based check.

**Claim management enhancements:**

* Added `managedInUserStore` and `excludedUserStores` properties to the `Claim` class, along with their respective getter and setter methods, to allow tracking whether a claim is managed in the user store and which user stores exclude it. [[1]](diffhunk://#diff-58bb16b8bd59331c39523bf41e1c0bc8a9e6a0557f45464aef79f7ab58109a9cR98-R107) [[2]](diffhunk://#diff-58bb16b8bd59331c39523bf41e1c0bc8a9e6a0557f45464aef79f7ab58109a9cR205-R240)
* Imported `Set` in `Claim.java` to support the new property.

**Claim mapping and filtering improvements:**

* Updated the claim mapping logic in `AbstractUserStoreManager` to use both the new claim properties and the user store domain when mapping attributes to local identity claims. This includes passing the domain to the mapping method and using the correct mapped attribute for each domain. [[1]](diffhunk://#diff-72ed29bb5d0219833ab12a1c431a6ba2c33003d1230c16bf4b05e0302cb4da18L16780-R16781) [[2]](diffhunk://#diff-72ed29bb5d0219833ab12a1c431a6ba2c33003d1230c16bf4b05e0302cb4da18L16938-R16939) [[3]](diffhunk://#diff-72ed29bb5d0219833ab12a1c431a6ba2c33003d1230c16bf4b05e0302cb4da18L17058-R17059) [[4]](diffhunk://#diff-72ed29bb5d0219833ab12a1c431a6ba2c33003d1230c16bf4b05e0302cb4da18L17345-R17347) [[5]](diffhunk://#diff-72ed29bb5d0219833ab12a1c431a6ba2c33003d1230c16bf4b05e0302cb4da18L17357-R17370)
* Introduced the `isIdentityStoreManagedClaim` helper method to determine if a claim is managed in the identity store, factoring in both the `managedInUserStore` and `excludedUserStores` properties.

**Identity claim detection logic:**

* Refined the logic in methods that check for and count identity claims (`containsIdentityClaims`, `countIdentityClaims`) to use the dialect constant (`DEFAULT_CARBON_DIALECT`) instead of a hardcoded URI substring, making the checks more robust and maintainable. [[1]](diffhunk://#diff-72ed29bb5d0219833ab12a1c431a6ba2c33003d1230c16bf4b05e0302cb4da18R113) [[2]](diffhunk://#diff-72ed29bb5d0219833ab12a1c431a6ba2c33003d1230c16bf4b05e0302cb4da18L17289-R17295) [[3]](diffhunk://#diff-72ed29bb5d0219833ab12a1c431a6ba2c33003d1230c16bf4b05e0302cb4da18R17429-R17432) [[4]](diffhunk://#diff-72ed29bb5d0219833ab12a1c431a6ba2c33003d1230c16bf4b05e0302cb4da18R17449-R17452)

### Related Issues
- https://github.com/wso2/product-is/issues/26159