### PR TITLE
[4.9.x] Prepare for next development version

### DIFF
--- a/core/org.wso2.carbon.logging/pom.xml
+++ b/core/org.wso2.carbon.logging/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon</groupId>
         <artifactId>carbon-kernel</artifactId>
-        <version>4.9.33-SNAPSHOT</version>
+        <version>4.9.34-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/org.wso2.carbon.ui/src/main/resources/web/docs/about.html
+++ b/core/org.wso2.carbon.ui/src/main/resources/web/docs/about.html
@@ -21,7 +21,7 @@
 <link href="../admin/css/documentation.css" rel="stylesheet" type="text/css" media="all"/>
 </head>
 <body>
-<h1>Version 4.9.33</h1>
+<h1>Version 4.9.34-SNAPSHOT</h1>
 <h2>About WSO2 Carbon </h2>
 <p>WSO2 Carbon is a component based Enterprise SOA platform. The
 design of

--- a/distribution/kernel/carbon.product
+++ b/distribution/kernel/carbon.product
@@ -2,7 +2,7 @@
 <?pde version="3.5"?>
 
 <product name="Carbon Product" uid="carbon.product.id" id="carbon.product" application="carbon.application"
-version="4.9.33" useFeatures="true" includeLaunchers="true">
+version="4.9.34.SNAPSHOT" useFeatures="true" includeLaunchers="true">
 
    <configIni use="default">
    </configIni>
@@ -14,7 +14,7 @@ version="4.9.33" useFeatures="true" includeLaunchers="true">
    </plugins>
 
    <features>
-      <feature id="org.wso2.carbon.core.runtime" version="4.9.33"/>
+      <feature id="org.wso2.carbon.core.runtime" version="4.9.34.SNAPSHOT"/>
    </features>
 
   <configurations>

--- a/distribution/kernel/src/assembly/filter.properties
+++ b/distribution/kernel/src/assembly/filter.properties
@@ -1,2 +1,2 @@
-carbon.version=4.9.33
+carbon.version=4.9.34-SNAPSHOT
 p2.repo.url=http://product-dist.wso2.com/p2/carbon/releases/wilkes/

--- a/distribution/product/modules/distribution/src/assembly/filter.properties
+++ b/distribution/product/modules/distribution/src/assembly/filter.properties
@@ -1,8 +1,8 @@
 product.name=WSO2 Carbon
-product.version=4.9.33
+product.version=4.9.34-SNAPSHOT
 product.key=Carbon
-carbon.product.version=4.9.33
-carbon.version=4.9.33
+carbon.product.version=4.9.34-SNAPSHOT
+carbon.version=4.9.34-SNAPSHOT
 default.server.role=CarbonServer
 hotdeployment=true
 hotupdate=true


### PR DESCRIPTION
## Purpose
This pull request updates the version of WSO2 Carbon from 4.9.33 to 4.9.34-SNAPSHOT throughout the codebase, ensuring consistency in versioning across multiple configuration and documentation files.

Version update across the codebase:

* Updated the parent version in `core/org.wso2.carbon.logging/pom.xml` to `4.9.34-SNAPSHOT` to reflect the new release.
* Changed the displayed version in the documentation file `core/org.wso2.carbon.ui/src/main/resources/web/docs/about.html` to `4.9.34-SNAPSHOT`.

Configuration and product files:

* Updated the product version and related feature version in `distribution/kernel/carbon.product` to `4.9.34.SNAPSHOT`, including the feature dependency version. [[1]](diffhunk://#diff-0adf2f05a62ab856e199901119b972cc833a6764a05b266c7ddf7aa281771f61L5-R5) [[2]](diffhunk://#diff-0adf2f05a62ab856e199901119b972cc833a6764a05b266c7ddf7aa281771f61L17-R17)
* Changed `carbon.version` in `distribution/kernel/src/assembly/filter.properties` to `4.9.34-SNAPSHOT`.
* Updated multiple version properties in `distribution/product/modules/distribution/src/assembly/filter.properties` to `4.9.34-SNAPSHOT`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated product version to 4.9.34-SNAPSHOT across distribution and configuration files.
  * Updated About page version display to reflect the new version information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->