### PR TITLE
Fix multi attribute total result incorrect issue

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
@@ -16949,8 +16949,12 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
          * If there are only non identity claims, filter users from the user store.
          */
         if (identityClaimFilterCount == 0) {
-            paginatedUserResponse = new PaginatedUserResponse(getFilteredUsers(duplicateCondition, profileName, limit,
-                    offset, sortBy, sortOrder, secondaryUserStoreManager));
+            List<User> filteredUsers = getFilteredUsers(duplicateCondition, profileName, limit,
+                    offset, sortBy, sortOrder, secondaryUserStoreManager);
+            paginatedUserResponse = new PaginatedUserResponse(filteredUsers);
+            if (filteredUsers != null) {
+                paginatedUserResponse.setTotalResults(filteredUsers.size());
+            }
         }
 
         /*
@@ -16978,15 +16982,21 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
                  * Both identity & non identity claim filters can be applied for the user store.
                  */
                 updateCondition(duplicateCondition, domain);
-                paginatedUserResponse = new PaginatedUserResponse(getFilteredUsers(duplicateCondition, profileName,
-                        limit, offset, sortBy, sortOrder, secondaryUserStoreManager));
+                List<User> filteredUsers = getFilteredUsers(duplicateCondition, profileName,
+                        limit, offset, sortBy, sortOrder, secondaryUserStoreManager);
+                paginatedUserResponse = new PaginatedUserResponse(filteredUsers);
+                if (filteredUsers != null) {
+                    paginatedUserResponse.setTotalResults(filteredUsers.size());
+                }
             } else {
                 if (!nonIdentityClaimExist) {
                     /*
                      * Case 2.2: Only Identity claims exist and stored in the identity store.
                      */
+                    List<User> filteredUsers = getUserListByUsernames(identityClaimFilteredUserNames);
                     paginatedUserResponse =
-                            new PaginatedUserResponse(getUserListByUsernames(identityClaimFilteredUserNames));
+                            new PaginatedUserResponse(filteredUsers);
+                    paginatedUserResponse.setTotalResults(filteredUsers.size());
                 } else {
                     /*
                      * Case 2.3: Identity claims stored in identity store and non identity claims stored in user store.


### PR DESCRIPTION
## Purpose
$subject

This pull request updates the logic for constructing `PaginatedUserResponse` objects in the `getPaginatedUserListWithID` method of `AbstractUserStoreManager.java`. The main improvement is ensuring that the `totalResults` field is set consistently based on the size of the filtered user list, which helps make pagination and response metadata more accurate.

**User response construction improvements:**

* Updated the creation of `PaginatedUserResponse` to explicitly set the `totalResults` field to the size of the filtered user list when only non-identity claims are present.
* Applied the same logic for cases where both identity and non-identity claim filters are used, ensuring `totalResults` reflects the actual number of users returned.
* For scenarios with only identity claims, refactored to set `totalResults` using the size of the filtered user list obtained from `getUserListByUsernames`.


### Related Issues
- https://github.com/wso2/product-is/issues/26159