### PR TITLE
[APIM][4.9.x] Handle userstore failures gracefully without affecting other userstores

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/CircuitBreakerOpenException.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/CircuitBreakerOpenException.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.user.core;
+
+/**
+ * The exception to throw when the Circuit Breaker triggers for user stores.
+ */
+public class CircuitBreakerOpenException extends UserStoreException {
+
+    public CircuitBreakerOpenException(String message, Throwable cause) {
+
+        super(message, cause);
+    }
+
+    public CircuitBreakerOpenException(String message, String errorCode, Throwable cause) {
+
+        super(message, errorCode, cause);
+    }
+
+    public CircuitBreakerOpenException(String message, String errorCode) {
+
+        super(message, errorCode);
+    }
+
+    public CircuitBreakerOpenException(String message) {
+
+        super(message);
+    }
+
+    public CircuitBreakerOpenException(Throwable cause) {
+
+        super(cause);
+    }
+}

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/UserCoreConstants.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/UserCoreConstants.java
@@ -121,6 +121,10 @@ public class UserCoreConstants {
     public static final String USER_LOCKED = "true";
     public static final String USER_UNLOCKED = "false";
 
+    // Server level config introduced for backward compatibility with the CircuitBreaker.
+    public static final String PROP_ENABLE_CIRCUIT_BREAKER_FOR_USERSTORE =
+            "UserStore.enableCircuitBreakerForUserStores";
+
     public static final class RealmConfig {
         public static final String LOCAL_NAME_USER_MANAGER = "UserManager";
         public static final String LOCAL_NAME_REALM = "Realm";
@@ -239,6 +243,9 @@ public class UserCoreConstants {
         public static final String LEADING_OR_TRAILING_SPACE_ALLOWED_IN_USERNAME =
                 "LeadingOrTrailingSpaceAllowedInUserName";
         public static final String PROPERTY_USER_ID_ENABLED = "UserIDEnabled";
+
+        public static final String CIRCUIT_STATE_OPEN = "open";
+        public static final String CIRCUIT_STATE_CLOSE = "close";
     }
 
     public static final class ClaimTypeURIs {

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/UserStoreConfigConstants.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/UserStoreConfigConstants.java
@@ -173,7 +173,16 @@ public class UserStoreConfigConstants {
     public static final String CONNECTION_RETRY_DELAY_DESCRIPTION = "Specifies waiting time in milliseconds"
             + " inorder to establish the connection after couple of failure attempts.";
     public static final int DEFAULT_CONNECTION_RETRY_DELAY_IN_MILLISECONDS = 120000;
+    public static final String MIN_CONNECTION_RETRY_DELAY_IN_MILLISECONDS =
+            "UserStore.minConnectionRetryDelayInMilliSeconds";
     public static final String OBJECT_GUID = "objectGuid";
+
+    public static final String CONNECTION_RETRY_COUNT = "ConnectionRetryCount";
+    public static final int DEFAULT_CONNECTION_RETRY_COUNT = 2;
+    public static final String MAX_CONNECTION_RETRY_COUNT = "UserStore.maxConnectionRetryCount";
+    public static final String CONNECTION_RETRY_COUNT_DISPLAY_NAME = "Connection Retry Count";
+    public static final String CONNECTION_RETRY_COUNT_DESCRIPTION = "Specifies connection retry times"
+            + " inorder to re-establish the connection on failure";
 
     // Property for specify case insensitivity for User stores.
     public static final String CASE_INSENSITIVE_USERNAME = "CaseInsensitiveUsername";

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
@@ -11017,6 +11017,11 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
                         }
                     }
 
+                    if (authenticationResult.getAuthenticationStatus()
+                            == AuthenticationResult.AuthenticationStatus.SUCCESS) {
+                        authenticated = true;
+                    }
+
                     if (authenticated) {
                         // Set domain in thread local variable for subsequent operations
                         UserCoreUtil.setDomainInThreadLocal(

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
@@ -27,6 +27,7 @@ import org.wso2.carbon.CarbonConstants;
 import org.wso2.carbon.base.ServerConfiguration;
 import org.wso2.carbon.context.CarbonContext;
 import org.wso2.carbon.user.api.RealmConfiguration;
+import org.wso2.carbon.user.core.CircuitBreakerOpenException;
 import org.wso2.carbon.user.core.NotImplementedException;
 import org.wso2.carbon.user.core.PaginatedUserStoreManager;
 import org.wso2.carbon.user.core.Permission;
@@ -1696,12 +1697,22 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
                         credentialArgument = credential;
                     }
 
-                    if (!listener.doPreAuthenticate(userName, credentialArgument, abstractUserStoreManager)) {
-                        handleOnAuthenticateFailure(ErrorMessages.ERROR_CODE_ERROR_WHILE_PRE_AUTHENTICATION.getCode(),
-                                String.format(ErrorMessages.ERROR_CODE_ERROR_WHILE_PRE_AUTHENTICATION.getMessage(),
-                                        UserCoreErrorConstants.PRE_LISTENER_TASKS_FAILED_MESSAGE), userName,
-                                credentialArgument);
-                        return false;
+                    try {
+                        if (!listener.doPreAuthenticate(userName, credentialArgument, abstractUserStoreManager)) {
+                            handleOnAuthenticateFailure(ErrorMessages.ERROR_CODE_ERROR_WHILE_PRE_AUTHENTICATION.getCode(),
+                                    String.format(ErrorMessages.ERROR_CODE_ERROR_WHILE_PRE_AUTHENTICATION.getMessage(),
+                                            UserCoreErrorConstants.PRE_LISTENER_TASKS_FAILED_MESSAGE), userName,
+                                    credentialArgument);
+                            return false;
+                        }
+                        // Added for compatibility with old pre-listeners.
+                    } catch (CircuitBreakerOpenException circuitBreakerOpenEx) {
+                        if (log.isDebugEnabled()) {
+                            log.debug("Circuit Breaker is in open state for " + userStore.getDomainName()
+                                    + " domain. Hence ignore the userstore and proceed", circuitBreakerOpenEx);
+                        }
+                        log.error("Error occurred while obtaining user store connection for: "
+                                + userStore.getDomainName());
                     }
                 }
             } catch (UserStoreException ex) {
@@ -1738,17 +1749,25 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
             // We are here due to two reason. Either there is no secondary UserStoreManager or no
             // domain name provided with user name.
             try {
-                // Let's authenticate with the primary UserStoreManager.
-                if (abstractUserStoreManager.isUniqueUserIdEnabled()) {
-                    String userNameProperty = abstractUserStoreManager.getUsernameProperty();
-                    AuthenticationResult authenticationResult = abstractUserStoreManager
-                            .doAuthenticateWithID(userNameProperty, userName, credential, null);
-                    if (authenticationResult.getAuthenticationStatus()
-                            == AuthenticationResult.AuthenticationStatus.SUCCESS) {
-                        authenticated = true;
+                // Validate whether circuit breaker is enabled and open.
+                if (isCircuitBreakerEnabledAndOpen()) {
+                    if (log.isDebugEnabled()) {
+                        log.debug("Avoiding searching the " + abstractUserStoreManager.getMyDomainName()
+                                + " domain as Circuit Breaker is in open state");
                     }
                 } else {
-                    authenticated = abstractUserStoreManager.doAuthenticate(userName, credentialObj);
+                    // Let's authenticate with the primary UserStoreManager.
+                    if (abstractUserStoreManager.isUniqueUserIdEnabled()) {
+                        String userNameProperty = abstractUserStoreManager.getUsernameProperty();
+                        AuthenticationResult authenticationResult = abstractUserStoreManager
+                                .doAuthenticateWithID(userNameProperty, userName, credential, null);
+                        if (authenticationResult.getAuthenticationStatus()
+                                == AuthenticationResult.AuthenticationStatus.SUCCESS) {
+                            authenticated = true;
+                        }
+                    } else {
+                        authenticated = abstractUserStoreManager.doAuthenticate(userName, credentialObj);
+                    }
                 }
             } catch (Exception e) {
                 handleOnAuthenticateFailure(ErrorMessages.ERROR_CODE_ERROR_WHILE_AUTHENTICATION.getCode(),
@@ -1763,9 +1782,7 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
                     throw (UserStoreClientException) e;
                 }
                 log.error("Error occurred while authenticating user: " + userName, e);
-                authenticated = false;
             }
-
         } finally {
             credentialObj.clear();
         }
@@ -1807,10 +1824,20 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
                 }
             }
         } catch (UserStoreException ex) {
-            handleOnAuthenticateFailure(ErrorMessages.ERROR_CODE_ERROR_WHILE_POST_AUTHENTICATION.getCode(),
-                    String.format(ErrorMessages.ERROR_CODE_ERROR_WHILE_POST_AUTHENTICATION.getMessage(),
-                            ex.getMessage()), userName, credential);
-            throw ex;
+            // Added for compatibility with old pre-listeners.
+            if (ex instanceof CircuitBreakerOpenException) {
+                if (log.isDebugEnabled()) {
+                    log.debug("Circuit Breaker is in open state for " + userStore.getDomainName()
+                            + " domain. Hence ignore the userstore and proceed", ex);
+                }
+                log.error("Error occurred while obtaining user store connection for: "
+                        + userStore.getDomainName());
+            } else {
+                handleOnAuthenticateFailure(ErrorMessages.ERROR_CODE_ERROR_WHILE_POST_AUTHENTICATION.getCode(),
+                        String.format(ErrorMessages.ERROR_CODE_ERROR_WHILE_POST_AUTHENTICATION.getMessage(),
+                                ex.getMessage()), userName, credential);
+                throw ex;
+            }
         }
 
         if (log.isDebugEnabled()) {
@@ -3041,11 +3068,27 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
                 // Get the user list and return with domain appended.
                 try {
                     AbstractUserStoreManager userStoreManager = (AbstractUserStoreManager) userManager;
+
+                    // Validate whether circuit breaker is enabled and open.
+                    if (userStoreManager.isCircuitBreakerEnabledAndOpen()) {
+                        if (log.isDebugEnabled()) {
+                            log.debug("Circuit Breaker is in open state for:  " + extractedDomain);
+                        }
+                        return Collections.emptyList();
+                    }
                     String[] userArray = userStoreManager.getUserListFromProperties(property, claimValue, profileName);
                     if (log.isDebugEnabled()) {
                         log.debug("List of filtered users for: " + extractedDomain + " : " + Arrays.asList(userArray));
                     }
                     return Arrays.asList(UserCoreUtil.addDomainToNames(userArray, extractedDomain));
+                } catch (CircuitBreakerOpenException ex) {
+                    if (log.isDebugEnabled()) {
+                        log.debug("Circuit Breaker is in open state for " + extractedDomain
+                                + " domain. Hence ignore the userstore and proceed", ex);
+                    }
+                    log.error("Error occurred while obtaining user store connection.");
+                    return Collections.emptyList();
+
                 } catch (UserStoreException ex) {
                     handleGetUserListFailure(ErrorMessages.ERROR_CODE_ERROR_WHILE_GETTING_USER_LIST.getCode(),
                             String.format(ErrorMessages.ERROR_CODE_ERROR_WHILE_GETTING_USER_LIST.getMessage(),
@@ -3265,12 +3308,29 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
                 // Get the user list and return with domain appended.
                 try {
                     AbstractUserStoreManager userStoreManager = (AbstractUserStoreManager) userManager;
+
+                    // Validate whether circuit breaker is enabled and open.
+                    if (userStoreManager.isCircuitBreakerEnabledAndOpen()) {
+                        if (log.isDebugEnabled()) {
+                            log.debug("Avoiding user listing as the Circuit Breaker is in open state for domain: "
+                                    + extractedDomain);
+                        }
+                        return Collections.emptyList();
+                    }
                     List<String> userIDs = userStoreManager
                             .doGetUserListFromPropertiesWithID(property, claimValue, profileName);
                     if (log.isDebugEnabled()) {
                         log.debug("List of filtered users for: " + extractedDomain + " : " + Arrays.asList(userIDs));
                     }
                     return userStoreManager.getUsersFromIDs(userIDs, null, extractedDomain, profileName);
+
+                } catch (CircuitBreakerOpenException ex) {
+                    if (log.isDebugEnabled()) {
+                        log.debug("Circuit Breaker is in open state for " + extractedDomain
+                                + " domain. Hence ignore the userstore and proceed", ex);
+                    }
+                    log.error("Error occurred while obtaining user store connection.");
+                    return Collections.emptyList();
 
                 } catch (UserStoreException ex) {
                     handleGetUserListFailureWithID(ErrorMessages.ERROR_CODE_ERROR_WHILE_GETTING_USER_LIST.getCode(),
@@ -6417,15 +6477,24 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
 
         // #################### Domain Name Free Zone Starts Here ################################
 
-        if (userStore.isSystemStore()) {
-            return systemUserRoleManager.isExistingSystemUser(userStore.getDomainFreeName());
-        }
-
-        if (!isUniqueUserIdEnabledInUserStore(userStore)) {
-            return doCheckExistingUser(userStore.getDomainFreeName());
+        /* Validate whether circuit breaker is enabled and open for compatibility with old pre-listeners. */
+        if (((AbstractUserStoreManager) userStore.getUserStoreManager()).isCircuitBreakerEnabledAndOpen()) {
+            if (log.isDebugEnabled()) {
+                log.debug("Avoiding user listing as the Circuit Breaker is in open state for domain: "
+                        + userStore.getDomainName());
+            }
         } else {
-            return getUserIDFromUserName(userName) != null;
+            if (userStore.isSystemStore()) {
+                return systemUserRoleManager.isExistingSystemUser(userStore.getDomainFreeName());
+            }
+
+            if (!isUniqueUserIdEnabledInUserStore(userStore)) {
+                return doCheckExistingUser(userStore.getDomainFreeName());
+            } else {
+                return getUserIDFromUserName(userName) != null;
+            }
         }
+        return false;
     }
 
     /**
@@ -6481,8 +6550,57 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
             handlePostGetUserList(null, null, new ArrayList<>(Arrays.asList(userList)), true);
             return userList;
         }
-
         try {
+            // Validate whether circuit breaker is enabled and open.
+            if (this.isCircuitBreakerEnabledAndOpen()) {
+                if (log.isDebugEnabled()) {
+                    log.debug("Circuit Breaker is in open state for " + this.getMyDomainName()
+                            + " domain. Hence ignore the userstore and proceed");
+                }
+                return new String[0];
+            }
+            // Check whether we have a secondary UserStoreManager setup.
+            if (index > 0) {
+                // Using the short-circuit. User name comes with the domain name.
+                String domain = filter.substring(0, index);
+                UserStoreManager secManager = this;
+                if (!StringUtils.equalsIgnoreCase(getMyDomainName(), domain)) {
+                    secManager = getSecondaryUserStoreManager(domain);
+                }
+
+                if (secManager != null) {
+                    // We have a secondary UserStoreManager registered for this domain.
+                    filter = filter.substring(index + 1);
+                    if (secManager instanceof AbstractUserStoreManager) {
+                        if (!((AbstractUserStoreManager) secManager).isUniqueUserIdEnabled()) {
+                            userList = ((AbstractUserStoreManager) secManager).doListUsers(filter, maxItemLimit);
+                        } else {
+                            userList = secManager.listUsers(filter, maxItemLimit);
+                            for (int i = 0; i < userList.length; i++) {
+                                userList[i] = UserCoreUtil.addDomainToName(userList[i], domain);
+                            }
+                        }
+                        handlePostGetUserList(null, null, new ArrayList<>(Arrays.asList(userList)), true);
+                        return userList;
+                    } else {
+                        userList = secManager.listUsers(filter, maxItemLimit);
+                        handlePostGetUserList(null, null, new ArrayList<>(Arrays.asList(userList)), true);
+                        return userList;
+                    }
+                }
+            } else if (index == 0) {
+                if (!isUniqueUserIdEnabled()) {
+                    userList = doListUsers(filter.substring(1), maxItemLimit);
+                } else {
+                    userList = doListUsersWithID(filter.substring(1), maxItemLimit)
+                            .stream()
+                            .map(User::getDomainQualifiedUsername)
+                            .toArray(String[]::new);
+                }
+                handlePostGetUserList(null, null, new ArrayList<>(Arrays.asList(userList)), true);
+                return userList;
+            }
+
             if (!isUniqueUserIdEnabled()) {
                 userList = doListUsers(filter, maxItemLimit);
             } else {
@@ -6491,6 +6609,14 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
                         .map(User::getUsername)
                         .toArray(String[]::new);
             }
+        } catch (CircuitBreakerOpenException ex) {
+            if (log.isDebugEnabled()) {
+                log.debug("Circuit Breaker is in open state for " + this.getMyDomainName()
+                        + " domain. Hence ignore " + "the userstore and proceed", ex);
+            }
+            log.error("Error occurred while obtaining user store connection.");
+            return new String[0];
+
         } catch (UserStoreException ex) {
             handleGetUserListFailure(ErrorMessages.ERROR_CODE_ERROR_WHILE_GETTING_USER_LIST.getCode(),
                     String.format(ErrorMessages.ERROR_CODE_ERROR_WHILE_GETTING_USER_LIST.getMessage(), ex.getMessage()),
@@ -10867,30 +10993,35 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
                 }
             } else {
                 // Domain is not provided. Try to authenticate with the current user store manager.
-                if (abstractUserStoreManager.isUniqueUserIdEnabled()) {
-                    authenticationResult = abstractUserStoreManager.doAuthenticateWithID(loginIdentifiers, credential);
-                } else {
-                    String userName = getUsernameByClaims(loginIdentifiers);
-                    String userID = userUniqueIDManger.getUniqueId(userName, abstractUserStoreManager);
-                    boolean status = abstractUserStoreManager.doAuthenticate(userName, credential);
-                    if (status) {
-                        User user = getUser(userID, userName);
-                        authenticationResult.setAuthenticationStatus(AuthenticationResult.AuthenticationStatus.SUCCESS);
-                        authenticationResult.setAuthenticatedUser(user);
-                    } else {
-                        authenticationResult.setAuthenticationStatus(AuthenticationResult.AuthenticationStatus.FAIL);
-                        authenticationResult.setFailureReason(new FailureReason("Authentication failed."));
+                // Validate whether circuit breaker is enabled and open.
+                if (abstractUserStoreManager.isCircuitBreakerEnabledAndOpen()) {
+                    if (log.isDebugEnabled()) {
+                        log.debug("Avoiding searching the " + abstractUserStoreManager.getMyDomainName()
+                                + " domain as Circuit Breaker is in open state");
                     }
-                }
+                    authenticated = false;
+                } else {
+                    if (abstractUserStoreManager.isUniqueUserIdEnabled()) {
+                        authenticationResult = abstractUserStoreManager.doAuthenticateWithID(loginIdentifiers, credential);
+                    } else {
+                        String userName = getUsernameByClaims(loginIdentifiers);
+                        String userID = userUniqueIDManger.getUniqueId(userName, abstractUserStoreManager);
+                        boolean status = abstractUserStoreManager.doAuthenticate(userName, credential);
+                        if (status) {
+                            User user = getUser(userID, userName);
+                            authenticationResult.setAuthenticationStatus(AuthenticationResult.AuthenticationStatus.SUCCESS);
+                            authenticationResult.setAuthenticatedUser(user);
+                        } else {
+                            authenticationResult.setAuthenticationStatus(AuthenticationResult.AuthenticationStatus.FAIL);
+                            authenticationResult.setFailureReason(new FailureReason("Authentication failed."));
+                        }
+                    }
 
-                if (authenticationResult.getAuthenticationStatus()
-                        == AuthenticationResult.AuthenticationStatus.SUCCESS) {
-                    authenticated = true;
-                }
-                if (authenticated) {
-                    // Set domain in thread local variable for subsequent operations
-                    UserCoreUtil
-                            .setDomainInThreadLocal(UserCoreUtil.getDomainName(abstractUserStoreManager.realmConfig));
+                    if (authenticated) {
+                        // Set domain in thread local variable for subsequent operations
+                        UserCoreUtil.setDomainInThreadLocal(
+                                UserCoreUtil.getDomainName(abstractUserStoreManager.realmConfig));
+                    }
                 }
             }
         } finally {
@@ -11311,46 +11442,56 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
                         .getAttributeName(abstractUserStoreManager.getMyDomainName(), preferredUserNameClaim);
                 // Let's authenticate with the primary UserStoreManager.
 
-                if (abstractUserStoreManager.isUniqueUserIdEnabled()) {
-                    authenticationResult = abstractUserStoreManager
-                            .doAuthenticateWithID(preferredUserNameProperty, preferredUserNameValue, credentialObj,
-                                    profileName);
+                // Validate whether circuit breaker is enabled and open.
+                if (abstractUserStoreManager.isCircuitBreakerEnabledAndOpen()) {
+                    if (log.isDebugEnabled()) {
+                        log.debug("Avoiding searching the " + abstractUserStoreManager.getMyDomainName()
+                                + " domain as Circuit Breaker is in open state");
+                    }
+                    authenticated = false;
                 } else {
-                    List<String> users = new ArrayList<>();
-                    if (preferredUserNameProperty.equals(getUserNameMappedAttribute())) {
-                        users.add(UserCoreUtil.addDomainToName(preferredUserNameValue,
-                                abstractUserStoreManager.getMyDomainName()));
+                    if (abstractUserStoreManager.isUniqueUserIdEnabled()) {
+                        authenticationResult = abstractUserStoreManager
+                                .doAuthenticateWithID(preferredUserNameProperty, preferredUserNameValue, credentialObj,
+                                        profileName);
                     } else {
-                        users = doGetUserList(preferredUserNameClaim, preferredUserNameValue, profileName,
-                                abstractUserStoreManager.getMyDomainName(), abstractUserStoreManager);
-                    }
-                    if (users.size() != 1) {
-                        String message = "Users count matching to claim: " + preferredUserNameClaim + " and value: "
-                                + preferredUserNameValue + " is: " + users.size();
-                        authenticationResult.setAuthenticationStatus(AuthenticationResult.AuthenticationStatus.FAIL);
-                        authenticationResult.setFailureReason(new FailureReason(message));
-                        if (log.isDebugEnabled()) {
-                            log.debug(message);
-                        }
-                    } else {
-                        boolean status = abstractUserStoreManager.doAuthenticate(UserCoreUtil.removeDomainFromName(
-                                users.get(0)), credentialObj);
-                        authenticationResult = new AuthenticationResult(status ?
-                                AuthenticationResult.AuthenticationStatus.SUCCESS :
-                                AuthenticationResult.AuthenticationStatus.FAIL);
-                        if (status) {
-                            String userID = userUniqueIDManger.getUniqueId(users.get(0), this);
-                            User user = userUniqueIDManger.getUser(userID, this);
-                            user.setTenantDomain(getTenantDomain(tenantId));
-                            authenticationResult.setAuthenticatedUser(user);
+                        List<String> users = new ArrayList<>();
+                        if (preferredUserNameProperty.equals(getUserNameMappedAttribute())) {
+                            users.add(UserCoreUtil.addDomainToName(preferredUserNameValue,
+                                    abstractUserStoreManager.getMyDomainName()));
                         } else {
-                            authenticationResult.setFailureReason(new FailureReason("Invalid credentials."));
+                            users = doGetUserList(preferredUserNameClaim, preferredUserNameValue, profileName,
+                                    abstractUserStoreManager.getMyDomainName(), abstractUserStoreManager);
+                        }
+                        if (users.size() != 1) {
+                            String message = "Users count matching to claim: " + preferredUserNameClaim + " and value: "
+                                    + preferredUserNameValue + " is: " + users.size();
+                            authenticationResult.setAuthenticationStatus(AuthenticationResult.AuthenticationStatus.FAIL);
+                            authenticationResult.setFailureReason(new FailureReason(message));
+                            if (log.isDebugEnabled()) {
+                                log.debug(message);
+                            }
+                        } else {
+                            boolean status = abstractUserStoreManager.doAuthenticate(UserCoreUtil.removeDomainFromName(
+                                    users.get(0)), credentialObj);
+                            authenticationResult = new AuthenticationResult(status ?
+                                    AuthenticationResult.AuthenticationStatus.SUCCESS :
+                                    AuthenticationResult.AuthenticationStatus.FAIL);
+                            if (status) {
+                                String userID = userUniqueIDManger.getUniqueId(users.get(0), this);
+                                User user = userUniqueIDManger.
+                                        getUser(userID, this);
+                                user.setTenantDomain(getTenantDomain(tenantId));
+                                authenticationResult.setAuthenticatedUser(user);
+                            } else {
+                                authenticationResult.setFailureReason(new FailureReason("Invalid credentials."));
+                            }
                         }
                     }
-                }
-                if (authenticationResult.getAuthenticationStatus()
-                        == AuthenticationResult.AuthenticationStatus.SUCCESS) {
-                    authenticated = true;
+                    if (authenticationResult.getAuthenticationStatus()
+                            == AuthenticationResult.AuthenticationStatus.SUCCESS) {
+                        authenticated = true;
+                    }
                 }
             } catch (Exception e) {
                 handleOnAuthenticateFailureWithID(ErrorMessages.ERROR_CODE_ERROR_WHILE_AUTHENTICATION.getCode(),
@@ -12764,22 +12905,29 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
         }
         userName = userStore.getDomainFreeName();
         String userID = getFromUserIDCache(userName, userStore);
-        if (StringUtils.isEmpty(userID)) {
-            if (isUniqueUserIdEnabledInUserStore(userStore)) {
-                userID = doGetUserIDFromUserNameWithID(userName);
-                addToUserIDCache(userID, userName, userStore);
-                addToUserNameCache(userID, userName, userStore);
-                return userID;
+        if (((AbstractUserStoreManager) userStore.getUserStoreManager()).isCircuitBreakerEnabledAndOpen()) {
+            if (log.isDebugEnabled()) {
+                log.debug("Avoiding user listing as the Circuit Breaker is in open state for domain: "
+                        + userStore.getDomainName());
             }
-
-            Map<String, String> claims = doGetUserClaimValues(userName,
-                    new String[]{UserCoreClaimConstants.USER_ID_CLAIM_URI},
-                    userStore.getDomainName(), null);
-            if (claims != null && claims.size() == 1) {
-                userID = claims.get(UserCoreClaimConstants.USER_ID_CLAIM_URI);
-                addToUserIDCache(userID, userName, userStore);
-                addToUserNameCache(userID, userName, userStore);
-                return userID;
+            return null;
+        } else {
+            if (StringUtils.isEmpty(userID)) {
+                if (isUniqueUserIdEnabledInUserStore(userStore)) {
+                    userID = doGetUserIDFromUserNameWithID(userName);
+                    addToUserIDCache(userID, userName, userStore);
+                    addToUserNameCache(userID, userName, userStore);
+                    return userID;
+                }
+                Map<String, String> claims = doGetUserClaimValues(userName,
+                        new String[]{UserCoreClaimConstants.USER_ID_CLAIM_URI},
+                        userStore.getDomainName(), null);
+                if (claims != null && claims.size() == 1) {
+                    userID = claims.get(UserCoreClaimConstants.USER_ID_CLAIM_URI);
+                    addToUserIDCache(userID, userName, userStore);
+                    addToUserNameCache(userID, userName, userStore);
+                    return userID;
+                }
             }
         }
         return userID;
@@ -18003,5 +18151,11 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
             return Integer.parseInt(pwValidityTimeoutStr);
         }
         return DEFAULT_PASSWORD_VALIDITY_PERIOD_VALUE;
+    }
+
+    // Default assigned as false.
+    protected boolean isCircuitBreakerEnabledAndOpen() throws UserStoreException {
+
+        return false;
     }
 }

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/JDBCUserStoreConstants.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/JDBCUserStoreConstants.java
@@ -172,6 +172,19 @@ public class JDBCUserStoreConstants {
                 "The default auto-commit state of connections created by this pool",
                 new Property[] { CONNECTION.getProperty(), BOOLEAN.getProperty(), FALSE.getProperty() });
 
+        // Added for circuit breaker implementation.
+        setAdvancedProperty(UserStoreConfigConstants.CONNECTION_RETRY_COUNT, UserStoreConfigConstants
+                        .CONNECTION_RETRY_COUNT_DISPLAY_NAME, String.valueOf(UserStoreConfigConstants
+                        .DEFAULT_CONNECTION_RETRY_COUNT), UserStoreConfigConstants.CONNECTION_RETRY_COUNT_DESCRIPTION,
+                new Property[] { CONNECTION.getProperty(), NUMBER.getProperty(), FALSE.getProperty() });
+
+        // Added for circuit breaker implementation.
+        setAdvancedProperty(UserStoreConfigConstants.CONNECTION_RETRY_DELAY, UserStoreConfigConstants.
+                CONNECTION_RETRY_DELAY_DISPLAY_NAME, String.valueOf(UserStoreConfigConstants
+                .DEFAULT_CONNECTION_RETRY_DELAY_IN_MILLISECONDS), UserStoreConfigConstants
+                .CONNECTION_RETRY_DELAY_DESCRIPTION, new Property[] { CONNECTION.getProperty(), NUMBER.getProperty(),
+                FALSE.getProperty() });
+
         setAdvancedProperty(JDBCRealmConstants.DEFAULT_READ_ONLY, "Default Read Only", "",
                 "The default read-only state of connections created by this pool",
                 new Property[] { CONNECTION.getProperty(), BOOLEAN.getProperty(), FALSE.getProperty() });

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/JDBCUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/JDBCUserStoreManager.java
@@ -25,10 +25,12 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.CarbonConstants;
+import org.wso2.carbon.base.ServerConfiguration;
 import org.wso2.carbon.context.CarbonContext;
 import org.wso2.carbon.user.api.Properties;
 import org.wso2.carbon.user.api.Property;
 import org.wso2.carbon.user.api.RealmConfiguration;
+import org.wso2.carbon.user.core.CircuitBreakerOpenException;
 import org.wso2.carbon.user.core.NotImplementedException;
 import org.wso2.carbon.user.core.UserCoreConstants;
 import org.wso2.carbon.user.core.UserRealm;
@@ -85,10 +87,22 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.regex.Matcher;
 import java.util.stream.Collectors;
 import javax.sql.DataSource;
 
+import static org.wso2.carbon.user.core.UserCoreConstants.PROP_ENABLE_CIRCUIT_BREAKER_FOR_USERSTORE;
+import static org.wso2.carbon.user.core.UserCoreConstants.RealmConfig.CIRCUIT_STATE_OPEN;
+import static org.wso2.carbon.user.core.UserCoreConstants.RealmConfig.CIRCUIT_STATE_CLOSE;
+import static org.wso2.carbon.user.core.UserStoreConfigConstants.CONNECTION_RETRY_COUNT;
+import static org.wso2.carbon.user.core.UserStoreConfigConstants.CONNECTION_RETRY_DELAY;
+import static org.wso2.carbon.user.core.UserStoreConfigConstants.DEFAULT_CONNECTION_RETRY_COUNT;
+import static org.wso2.carbon.user.core.UserStoreConfigConstants.DEFAULT_CONNECTION_RETRY_DELAY_IN_MILLISECONDS;
+import static org.wso2.carbon.user.core.UserStoreConfigConstants.MAX_CONNECTION_RETRY_COUNT;
+import static org.wso2.carbon.user.core.UserStoreConfigConstants.MIN_CONNECTION_RETRY_DELAY_IN_MILLISECONDS;
 import static org.wso2.carbon.user.core.constants.UserCoreDBConstants.CASE_INSENSITIVE_SQL_STATEMENT_PARAMETER_PLACEHOLDER;
 import static org.wso2.carbon.user.core.constants.UserCoreDBConstants.SQL_STATEMENT_PARAMETER_PLACEHOLDER;
 import static org.wso2.carbon.user.core.constants.UserCoreErrorConstants.ErrorMessages.ERROR_CODE_DUPLICATE_WHILE_ADDING_A_USER;
@@ -122,6 +136,17 @@ public class JDBCUserStoreManager extends AbstractUserStoreManager {
     private static final String POSTGRESQL = "postgresql";
     public static final String PRIMARY_USER_STORE_DOMAIN = "PRIMARY";
     private static final int MAX_ITEM_LIMIT_UNLIMITED = -1;
+
+    // Params added to implement Circuit Breaker.
+    private int connectionRetryCount;
+    private String jdbcConnectionCircuitBreakerState;
+    private long thresholdTimeoutInMilliseconds;
+    private long thresholdStartTime;
+
+    // Added to implement ReadWriteLock concept.
+    private final ReadWriteLock readWriteLock = new ReentrantReadWriteLock();
+    private final Lock writeLock = readWriteLock.writeLock();
+    private final Lock readLock = readWriteLock.readLock();
 
     public JDBCUserStoreManager() {
 
@@ -201,7 +226,27 @@ public class JDBCUserStoreManager extends AbstractUserStoreManager {
             readGroupsEnabled = true;
         }
 
-		/* Initialize user roles cache as implemented in AbstractUserStoreManager */
+        /* Set waiting time to re-establish connection after the specified retry count on failure attempts
+          if specified otherwise set default time.
+         */
+        String userStoreConnectionRetryDelayProperty = realmConfig.getUserStoreProperty(CONNECTION_RETRY_DELAY);
+        long userStoreConnectionRetryDelay = StringUtils.isNotEmpty(userStoreConnectionRetryDelayProperty) ?
+                Long.parseLong(userStoreConnectionRetryDelayProperty) : DEFAULT_CONNECTION_RETRY_DELAY_IN_MILLISECONDS;
+        long validatedConnectionRetryDelay = getValidatedThresholdTimeoutInMilliseconds(userStoreConnectionRetryDelay);
+        setThresholdTimeoutInMilliseconds(validatedConnectionRetryDelay);
+
+        // Set retry count for failure attempts.
+        String userStoreConnectionRetryCountProperty = realmConfig.getUserStoreProperty(CONNECTION_RETRY_COUNT);
+        int userStoreConnectionRetryCount = StringUtils.isNotEmpty(userStoreConnectionRetryCountProperty) ?
+                Integer.parseInt(userStoreConnectionRetryCountProperty) : DEFAULT_CONNECTION_RETRY_COUNT;
+        int validatedConnectionRetryCount = getValidatedConnectionRetryCount(userStoreConnectionRetryCount);
+        setConnectionRetryCount(validatedConnectionRetryCount);
+
+        // Used for Circuit breaker: By-default set to close state.
+        setCircuitBreakerState(CIRCUIT_STATE_CLOSE);
+        setThresholdStartTime(0);
+
+        /* Initialize user roles cache as implemented in AbstractUserStoreManager */
         initUserRolesCache();
     }
 
@@ -1316,7 +1361,7 @@ public class JDBCUserStoreManager extends AbstractUserStoreManager {
      * @throws SQLException
      * @throws UserStoreException
      */
-    protected Connection getDBConnection() throws SQLException, UserStoreException {
+    private Connection getConnection() throws SQLException, UserStoreException {
         Connection dbConnection = getJDBCDataSource().getConnection();
         dbConnection.setAutoCommit(false);
         if (dbConnection.getTransactionIsolation() != Connection.TRANSACTION_READ_COMMITTED) {
@@ -4827,5 +4872,314 @@ public class JDBCUserStoreManager extends AbstractUserStoreManager {
     private boolean isH2DB(Connection dbConnection) throws Exception {
 
         return H2.equalsIgnoreCase(DatabaseCreator.getDatabaseType(dbConnection));
+    }
+
+    /**
+     * Retrieves a database connection with support for the Circuit Breaker pattern.
+     *
+     * @return DB Connection.
+     * @throws UserStoreException if unknown occurred while getting database connection.
+     * @throws SQLException if error occurred while retrieving database connection.
+     */
+    protected Connection getDBConnection() throws UserStoreException, SQLException {
+
+        Connection dbConnection = null;
+
+        /* Validate whether circuit breaker is enabled for userstores.*/
+        if (Boolean.parseBoolean(ServerConfiguration.getInstance()
+                .getFirstProperty(PROP_ENABLE_CIRCUIT_BREAKER_FOR_USERSTORE))) {
+            switch (getCircuitBreakerState()) {
+            case CIRCUIT_STATE_OPEN:
+                dbConnection = getConnectionOnCircuitBreakerOpen();
+                log.info("Successfully recovered DB connection for domain: " + getMyDomainName());
+                break;
+            case CIRCUIT_STATE_CLOSE:
+                dbConnection = getConnectionOnCircuitBreakerClose();
+                break;
+            default:
+                throw new UserStoreException("Unknown JDBC connection circuit breaker state.");
+            }
+            return dbConnection;
+        }
+        return getConnection();
+    }
+
+    /**
+     * Attempts and returns the DB Connection when the circuit Breaker is in open state.
+     * @return returns the DB connection.
+     *
+     * @throws CircuitBreakerOpenException An error occurred while attempting to retrieve the DB connection.
+     */
+    private Connection getConnectionOnCircuitBreakerOpen() throws UserStoreException {
+
+        long circuitOpenDuration = System.currentTimeMillis() - getThresholdStartTime();
+        if (log.isDebugEnabled()) {
+            log.debug("Trying to obtain JDBC connection for domain: " + getMyDomainName()
+                    + " when circuit breaker state is " + getCircuitBreakerState()
+                    + " and circuit breaker open duration: " + circuitOpenDuration + "ms.");
+        }
+
+        if (circuitOpenDuration > getThresholdTimeoutInMilliseconds()) {
+            try {
+                Connection dbConnection = getConnection();
+                setCircuitBreakerState(CIRCUIT_STATE_CLOSE);
+                setThresholdStartTime(0);
+                return dbConnection;
+            } catch (Exception e) {
+                log.warn("Error occurred while trying to obtaining connection for domain: " + getMyDomainName()
+                        + ". Circuit Breaker state for domain: " + getMyDomainName() + " is set to "
+                        + getCircuitBreakerState());
+                setThresholdStartTime(System.currentTimeMillis());
+
+                throw new CircuitBreakerOpenException("Error occurred while obtaining connection.", e);
+            }
+        } else {
+            throw new CircuitBreakerOpenException(
+                    "JDBC Connection circuit breaker is in open state for " + circuitOpenDuration
+                            + "ms and has not exceeded the threshold timeout: " + getThresholdTimeoutInMilliseconds()
+                            + "ms, hence avoid establishing the connection for domain " + getMyDomainName());
+        }
+    }
+
+    /**
+     * Attempts and returns the DB Connection when the circuit Breaker is in closed state.
+     * @return returns the DB connection.
+     *
+     * @throws CircuitBreakerOpenException An error occurred while attempting to retrieve the DB connection.
+     */
+    private Connection getConnectionOnCircuitBreakerClose() throws UserStoreException {
+
+        if (log.isDebugEnabled()) {
+            log.debug("Connection circuit breaker state: " + getCircuitBreakerState()
+                    + ", so trying to obtain the connection for domain " + getMyDomainName());
+        }
+        int retryCounter = 1;
+        while (true) {
+            try {
+                return getConnection();
+            } catch (Exception e) {
+                log.warn("Error occurred while obtaining JDBC connection for domain " + getMyDomainName()
+                        + ". Hence, retry attempt to recover DB connection: " + retryCounter);
+
+                if (retryCounter >= getConnectionRetryCount()) {
+                    log.error("Retry count exceeds above the maximum count: " + getConnectionRetryCount()
+                            + " and failed for domain " + getMyDomainName());
+                    setCircuitBreakerState(CIRCUIT_STATE_OPEN);
+                    setThresholdStartTime(System.currentTimeMillis());
+                    throw new CircuitBreakerOpenException("Error occurred while obtaining connection for domain: "
+                            + getMyDomainName() + " and circuit breaker state set to: " + getCircuitBreakerState(), e);
+                }
+                retryCounter++;
+            }
+        }
+    }
+
+    /**
+     * Sets threadsafe JDBC ConnectionCircuitBreakerState.
+     *
+     * @param jdbcConnectionCircuitBreakerState JDBC ConnectionCircuitBreakerState.
+     */
+    public void setCircuitBreakerState(String jdbcConnectionCircuitBreakerState) {
+
+        writeLock.lock();
+        try {
+            this.jdbcConnectionCircuitBreakerState = jdbcConnectionCircuitBreakerState;
+        } finally {
+            writeLock.unlock();
+        }
+    }
+
+    /**
+     * Sets threadsafe thresholdTimeoutInMilliseconds.
+     *
+     * @param thresholdTimeoutInMilliseconds threshold Timeout in Milliseconds.
+     */
+    public void setThresholdTimeoutInMilliseconds(long thresholdTimeoutInMilliseconds) {
+
+        writeLock.lock();
+        try {
+            this.thresholdTimeoutInMilliseconds = thresholdTimeoutInMilliseconds;
+        } finally {
+            writeLock.unlock();
+        }
+    }
+
+    /**
+     * Sets threadsafe thresholdStartTime.
+     *
+     * @param thresholdStartTime Threshold Start Time.
+     */
+    public void setThresholdStartTime(long thresholdStartTime) {
+
+        writeLock.lock();
+        try {
+            this.thresholdStartTime = thresholdStartTime;
+        } finally {
+            writeLock.unlock();
+        }
+    }
+
+    /**
+     * Sets threadsafe connectionRetryCount.
+     *
+     * @param connectionRetryCount Connection Retry Count.
+     */
+    public void setConnectionRetryCount(int connectionRetryCount) {
+
+        writeLock.lock();
+        try {
+            this.connectionRetryCount = connectionRetryCount;
+        } finally {
+            writeLock.unlock();
+        }
+    }
+
+    /**
+     * Returns threadsafe connectionRetryCount.
+     *
+     * @return returns connectionRetryCount.
+     */
+    public int getConnectionRetryCount() {
+
+        return connectionRetryCount;
+    }
+
+    /**
+     * Returns threadsafe thresholdStartTime.
+     *
+     * @return returns thresholdStartTime.
+     */
+    public long getThresholdStartTime() {
+
+        readLock.lock();
+        try	{
+            return thresholdStartTime;
+        } finally {
+            readLock.unlock();
+        }
+    }
+
+    /**
+     * Returns threadsafe JDBC ConnectionCircuitBreakerState.
+     *
+     * @return returns jdbcConnectionCircuitBreakerState.
+     */
+    public String getCircuitBreakerState() {
+
+        readLock.lock();
+        try	{
+            return jdbcConnectionCircuitBreakerState;
+        } finally {
+            readLock.unlock();
+        }
+    }
+
+    /**
+     * Returns threadsafe thresholdTimeoutInMilliseconds.
+     *
+     * @return returns thresholdTimeoutInMilliseconds.
+     */
+    public long getThresholdTimeoutInMilliseconds() {
+
+        readLock.lock();
+        try	{
+            return thresholdTimeoutInMilliseconds;
+        } finally {
+            readLock.unlock();
+        }
+    }
+
+    /**
+     * Return the validated retry waiting time with minimum retry waiting time.
+     *
+     * @param retryWaitingTime Retry waiting time.
+     * @return Allowed Retry waiting time in milliseconds.
+     *
+     * @throws UserStoreException An error occurred while parsing the property value.
+     */
+    protected long getValidatedThresholdTimeoutInMilliseconds(long retryWaitingTime) throws UserStoreException {
+
+        try {
+            String minRetryWaitingTimeProperty = ServerConfiguration.getInstance()
+                    .getFirstProperty(MIN_CONNECTION_RETRY_DELAY_IN_MILLISECONDS);
+            if (StringUtils.isEmpty(minRetryWaitingTimeProperty)) {
+                if (log.isDebugEnabled()) {
+                    log.debug("Minimum retry delay in milliseconds is not configured. Hence, returning the given " +
+                            "retry delay in milliseconds: " + retryWaitingTime);
+                }
+                return retryWaitingTime;
+            }
+
+            long minRetryWaitingTime = Long.parseLong(minRetryWaitingTimeProperty);
+            if (minRetryWaitingTime > retryWaitingTime) {
+                if (log.isDebugEnabled()) {
+                    log.debug("Connection retry delay in milliseconds configured is less than the allowed minimum "
+                            + "waiting time. Hence, returning the min allowed connection retry delay in milliseconds: "
+                            + minRetryWaitingTime);
+                }
+                return minRetryWaitingTime;
+            }
+            return retryWaitingTime;
+        } catch (NumberFormatException e) {
+            throw new UserStoreException("Error occurred while parsing ConnectionRetryDelay property value");
+        }
+    }
+
+    /**
+     * Return the validated retry count with maximum retry count.
+     *
+     * @param connectionRetryCount Retry connection count.
+     * @return Allowed Retry connection count.
+     *
+     * @throws UserStoreException An error occurred while parsing the property value.
+     */
+    protected int getValidatedConnectionRetryCount(int connectionRetryCount) throws UserStoreException {
+
+        try {
+            String maxConnectionRetryCountProperty = ServerConfiguration.getInstance()
+                    .getFirstProperty(MAX_CONNECTION_RETRY_COUNT);
+            if (StringUtils.isEmpty(maxConnectionRetryCountProperty)) {
+                if (log.isDebugEnabled()) {
+                    log.debug("Max Connection retry count is not configured. Hence, returning the given "
+                            + "retry count: " + connectionRetryCount);
+                }
+                return connectionRetryCount;
+            }
+
+            int maxConnectionRetryCount = Integer.parseInt(maxConnectionRetryCountProperty);
+            if (connectionRetryCount > maxConnectionRetryCount) {
+                if (log.isDebugEnabled()) {
+                    log.debug("Connection retry count configured exceeds the allowed maximum retry count. "
+                            + "Hence, returning the max allowed connection retry count: " + maxConnectionRetryCount);
+                }
+                return maxConnectionRetryCount;
+            }
+            return connectionRetryCount;
+        } catch (NumberFormatException e) {
+            throw new UserStoreException("Error occurred while parsing ConnectionRetryCount property value.");
+        }
+    }
+
+    /**
+     * Verify Circuit Breaker state for user store.
+     *
+     * @return true if CircuitBreaker Open, false otherwise.
+     */
+    public boolean isCircuitBreakerEnabledAndOpen() throws UserStoreException {
+
+        if (Boolean.parseBoolean(ServerConfiguration.getInstance()
+                .getFirstProperty(PROP_ENABLE_CIRCUIT_BREAKER_FOR_USERSTORE))) {
+
+            long circuitOpenDuration = System.currentTimeMillis() - getThresholdStartTime();
+            if (CIRCUIT_STATE_OPEN.equals(getCircuitBreakerState()) && circuitOpenDuration
+                    <= getThresholdTimeoutInMilliseconds()) {
+
+                log.warn("JDBC connection circuit breaker is in open state for " + circuitOpenDuration
+                        + "ms and has not exceeded the threshold timeout: " + getThresholdTimeoutInMilliseconds()
+                        + "ms, hence avoid establishing the " + getMyDomainName() + " domain JDBC connection.");
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/ActiveDirectoryUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/ActiveDirectoryUserStoreManager.java
@@ -982,6 +982,10 @@ public class ActiveDirectoryUserStoreManager extends ReadWriteLDAPUserStoreManag
         setAdvancedProperty(UserStoreConfigConstants.STARTTLS_ENABLED,
                 UserStoreConfigConstants.STARTTLS_ENABLED_DISPLAY_NAME, "false",
                 UserStoreConfigConstants.STARTTLS_ENABLED_DESCRIPTION);
+        setAdvancedProperty(UserStoreConfigConstants.CONNECTION_RETRY_COUNT,
+                UserStoreConfigConstants.CONNECTION_RETRY_COUNT_DISPLAY_NAME,
+                String.valueOf(UserStoreConfigConstants.DEFAULT_CONNECTION_RETRY_COUNT),
+                UserStoreConfigConstants.CONNECTION_RETRY_COUNT_DESCRIPTION);
         setAdvancedProperty(UserStoreConfigConstants.CONNECTION_RETRY_DELAY,
                 UserStoreConfigConstants.CONNECTION_RETRY_DELAY_DISPLAY_NAME,
                 String.valueOf(UserStoreConfigConstants.DEFAULT_CONNECTION_RETRY_DELAY_IN_MILLISECONDS),

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/LDAPConnectionContext.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/LDAPConnectionContext.java
@@ -21,8 +21,9 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.CarbonConstants;
+import org.wso2.carbon.base.ServerConfiguration;
 import org.wso2.carbon.user.api.RealmConfiguration;
-import org.wso2.carbon.user.core.UserCoreConstants;
+import org.wso2.carbon.user.core.CircuitBreakerOpenException;
 import org.wso2.carbon.user.core.UserStoreConfigConstants;
 import org.wso2.carbon.user.core.UserStoreException;
 import org.wso2.carbon.user.core.dto.CorrelationLogDTO;
@@ -40,6 +41,9 @@ import java.util.Hashtable;
 import java.util.List;
 import java.util.SortedMap;
 import java.util.TreeMap;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 import javax.naming.AuthenticationException;
 import javax.naming.Context;
 import javax.naming.NamingEnumeration;
@@ -51,6 +55,17 @@ import javax.naming.directory.InitialDirContext;
 import javax.naming.ldap.Control;
 import javax.naming.ldap.InitialLdapContext;
 import javax.naming.ldap.LdapContext;
+
+import static org.wso2.carbon.user.core.UserCoreConstants.PROP_ENABLE_CIRCUIT_BREAKER_FOR_USERSTORE;
+import static org.wso2.carbon.user.core.UserCoreConstants.RealmConfig.CIRCUIT_STATE_CLOSE;
+import static org.wso2.carbon.user.core.UserCoreConstants.RealmConfig.CIRCUIT_STATE_OPEN;
+import static org.wso2.carbon.user.core.UserCoreConstants.RealmConfig.PROPERTY_READ_ONLY;
+import static org.wso2.carbon.user.core.UserStoreConfigConstants.CONNECTION_RETRY_COUNT;
+import static org.wso2.carbon.user.core.UserStoreConfigConstants.CONNECTION_RETRY_DELAY;
+import static org.wso2.carbon.user.core.UserStoreConfigConstants.DEFAULT_CONNECTION_RETRY_COUNT;
+import static org.wso2.carbon.user.core.UserStoreConfigConstants.DEFAULT_CONNECTION_RETRY_DELAY_IN_MILLISECONDS;
+import static org.wso2.carbon.user.core.UserStoreConfigConstants.MAX_CONNECTION_RETRY_COUNT;
+import static org.wso2.carbon.user.core.UserStoreConfigConstants.MIN_CONNECTION_RETRY_DELAY_IN_MILLISECONDS;
 
 public class LDAPConnectionContext {
 
@@ -80,11 +95,18 @@ public class LDAPConnectionContext {
     private static final String CORRELATION_LOG_SEPARATOR = "|";
     public static final String CIRCUIT_STATE_OPEN = "open";
     public static final String CIRCUIT_STATE_CLOSE = "close";
+    private static final String CORRELATION_LOG_SYSTEM_PROPERTY = "enableCorrelationLogs";
 
+    private int connectionRetryCount;
     private String ldapConnectionCircuitBreakerState;
     private long thresholdTimeoutInMilliseconds;
     private long thresholdStartTime;
     private boolean startTLSEnabled;
+
+    //added to implement readWriteLock
+    private final ReadWriteLock readWriteLock = new ReentrantReadWriteLock();
+    private final Lock writeLock = readWriteLock.writeLock();
+    private final Lock readLock = readWriteLock.readLock();
 
     static {
         String initialContextFactoryClassSystemProperty = System.getProperty(Context.INITIAL_CONTEXT_FACTORY);
@@ -109,7 +131,7 @@ public class LDAPConnectionContext {
                 populateDCMap();
             }
             //need to keep track of if the user store config is read only
-            String readOnlyString = realmConfig.getUserStoreProperty(UserCoreConstants.RealmConfig.PROPERTY_READ_ONLY);
+            String readOnlyString = realmConfig.getUserStoreProperty(PROPERTY_READ_ONLY);
             if (readOnlyString != null) {
                 readOnly = Boolean.parseBoolean(readOnlyString);
             }
@@ -231,82 +253,120 @@ public class LDAPConnectionContext {
         startTLSEnabled = Boolean.parseBoolean(realmConfig.getUserStoreProperty(
                 UserStoreConfigConstants.STARTTLS_ENABLED));
 
-        // Set waiting time to re-establish LDAP connection after couple of failure attempts if specified otherwise
-        // set default time.
-        String retryWaitingTime = realmConfig.getUserStoreProperty(UserStoreConfigConstants.CONNECTION_RETRY_DELAY);
-        if (StringUtils.isNotEmpty(retryWaitingTime)) {
-            thresholdTimeoutInMilliseconds = getThresholdTimeoutInMilliseconds(retryWaitingTime);
-        } else {
-            thresholdTimeoutInMilliseconds = UserStoreConfigConstants.DEFAULT_CONNECTION_RETRY_DELAY_IN_MILLISECONDS;
-        }
-        // By-default set to close state.
-        ldapConnectionCircuitBreakerState = CIRCUIT_STATE_CLOSE;
-        thresholdStartTime = 0;
+        /* Set waiting time to re-establish connection after the specified retry count on failure attempts
+          if specified otherwise set default time.
+         */
+        String userStoreConnectionRetryDelayProperty = realmConfig.getUserStoreProperty(CONNECTION_RETRY_DELAY);
+        long userStoreConnectionRetryDelay = StringUtils.isNotEmpty(userStoreConnectionRetryDelayProperty) ?
+                Long.parseLong(userStoreConnectionRetryDelayProperty) : DEFAULT_CONNECTION_RETRY_DELAY_IN_MILLISECONDS;
+        long validatedConnectionRetryDelay = getValidatedThresholdTimeoutInMilliseconds(userStoreConnectionRetryDelay);
+        setThresholdTimeoutInMilliseconds(validatedConnectionRetryDelay);
+
+        // Set retry count for failure attempts.
+        String userStoreConnectionRetryCountProperty = realmConfig.getUserStoreProperty(CONNECTION_RETRY_COUNT);
+        int userStoreConnectionRetryCount = StringUtils.isNotEmpty(userStoreConnectionRetryCountProperty) ?
+                Integer.parseInt(userStoreConnectionRetryCountProperty) : DEFAULT_CONNECTION_RETRY_COUNT;
+        int validatedConnectionRetryCount = getValidatedConnectionRetryCount(userStoreConnectionRetryCount);
+        setConnectionRetryCount(validatedConnectionRetryCount);
+
+        // Used for Circuit breaker: By-default set to close state.
+        setCircuitBreakerState(CIRCUIT_STATE_CLOSE);
+        setThresholdStartTime(0);
     }
 
     public DirContext getContext() throws UserStoreException {
 
         DirContext context = null;
-
-        // Implemented basic circuit breaker logic to reduce the resource consumption.
-        switch (ldapConnectionCircuitBreakerState) {
-        case CIRCUIT_STATE_OPEN:
-            long circuitOpenDuration = System.currentTimeMillis() - thresholdStartTime;
-            if (circuitOpenDuration >= thresholdTimeoutInMilliseconds) {
-                try {
-                    if (log.isDebugEnabled()) {
-                        log.debug("Trying to obtain LDAP connection, connection URL: " + environment
-                                .get(Context.PROVIDER_URL) + " when circuit breaker state: "
-                                + ldapConnectionCircuitBreakerState + " and circuit breaker open duration: "
-                                + circuitOpenDuration + "ms.");
-                    }
-                    context = getDirContext();
-                    ldapConnectionCircuitBreakerState = CIRCUIT_STATE_CLOSE;
-                    thresholdStartTime = 0;
+        // Validate whether circuit breaker is enabled for userstores.
+        if (Boolean.parseBoolean(ServerConfiguration.getInstance()
+                .getFirstProperty(PROP_ENABLE_CIRCUIT_BREAKER_FOR_USERSTORE))) {
+            // Implemented basic circuit breaker logic to reduce the resource consumption.
+            switch (getCircuitBreakerState()) {
+            case CIRCUIT_STATE_OPEN:
+                context = getConnectionOnCircuitBreakerOpen();
+                log.info("Successfully recovered LDAP connection for connection URL: " + environment
+                        .get(Context.PROVIDER_URL));
                     break;
-                } catch (UserStoreException e) {
-                    log.error("Error occurred while obtaining LDAP connection. Connection URL: " + environment
-                            .get(Context.PROVIDER_URL), e);
-                    thresholdStartTime = System.currentTimeMillis();
-                    if (log.isDebugEnabled()) {
-                        log.debug("LDAP connection circuit breaker state set to: " + ldapConnectionCircuitBreakerState);
-                    }
-                    throw new UserStoreException("Error occurred while obtaining LDAP connection.", e);
-                }
-            } else {
-                throw new UserStoreException(
-                        "LDAP connection circuit breaker is in open state for " + circuitOpenDuration
-                                + "ms and has not reach the threshold timeout: " + thresholdTimeoutInMilliseconds
-                                + "ms, hence avoid establishing the LDAP connection.");
-            }
-        case CIRCUIT_STATE_CLOSE:
-            try {
-                if (log.isDebugEnabled()) {
-                    log.debug("LDAP connection circuit breaker state: " + ldapConnectionCircuitBreakerState
-                            + ", so trying to obtain the LDAP connection, connection URL: "
-                            + environment.get(Context.PROVIDER_URL));
-                }
-                context = getDirContext();
+            case CIRCUIT_STATE_CLOSE:
+                context = getConnectionOnCircuitBreakerClose();
                 break;
-            } catch (UserStoreException e) {
-                log.error("Error occurred while obtaining LDAP connection. Connection URL: "
-                        + environment.get(Context.PROVIDER_URL), e);
-                log.error("Trying again to get connection.");
-                try {
-                    context = getDirContext();
-                    break;
-                } catch (Exception e1) {
-                    log.error("Error occurred while obtaining connection for the second time.", e1);
-                    ldapConnectionCircuitBreakerState = CIRCUIT_STATE_OPEN;
-                    thresholdStartTime = System.currentTimeMillis();
-                    throw new UserStoreException("Error occurred while obtaining LDAP connection, LDAP connection "
-                            + "circuit breaker state set to: " + ldapConnectionCircuitBreakerState, e1);
-                }
+            default:
+                throw new UserStoreException("Unknown LDAP connection circuit breaker state.");
             }
-        default:
-            throw new UserStoreException("Unknown LDAP connection circuit breaker state.");
+            return context;
         }
-        return context;
+        return getDirContext();
+    }
+
+    /**
+     * Attempts and returns the LDAP Connection when the circuit Breaker is in open state.
+     * @return returns the DB connection.
+     *
+     * @throws CircuitBreakerOpenException An error occurred while attempting to retrieve the LDAP connection.
+     */
+    private DirContext getConnectionOnCircuitBreakerOpen() throws UserStoreException {
+
+        long circuitOpenDuration = System.currentTimeMillis() - getThresholdStartTime();
+        if (log.isDebugEnabled()) {
+            log.debug("Trying to obtain LDAP connection, connection URL: " + environment
+                    .get(Context.PROVIDER_URL) + " when circuit breaker state: "
+                    + getCircuitBreakerState() + " and circuit breaker open duration: "
+                    + circuitOpenDuration + "ms.");
+        }
+        if (circuitOpenDuration > getThresholdTimeoutInMilliseconds()) {
+            try {
+                DirContext context = getDirContext();
+                setCircuitBreakerState(CIRCUIT_STATE_CLOSE);
+                setThresholdStartTime(0);
+                return context;
+            } catch (UserStoreException e) {
+                log.warn("Error occurred while obtaining LDAP connection. Connection URL: " + environment
+                        .get(Context.PROVIDER_URL) + ". LDAP connection circuit breaker state set to: "
+                        + getCircuitBreakerState());
+                setThresholdStartTime(System.currentTimeMillis());
+                throw new CircuitBreakerOpenException("Error occurred while obtaining LDAP connection.", e);
+            }
+        } else {
+            throw new CircuitBreakerOpenException(
+                    "LDAP connection circuit breaker is in open state for " + circuitOpenDuration
+                            + "ms and has not exceeded the threshold timeout: " + getThresholdTimeoutInMilliseconds()
+                            + "ms, hence avoid establishing the LDAP connection.");
+        }
+    }
+
+    /**
+     * Attempts and returns the LDAP Connection when the circuit Breaker is in closed state.
+     * @return returns the LDAP connection.
+     *
+     * @throws CircuitBreakerOpenException An error occurred while attempting to retrieve the LDAP connection.
+     */
+    private DirContext getConnectionOnCircuitBreakerClose() throws UserStoreException {
+
+        if (log.isDebugEnabled()) {
+            log.debug("LDAP connection circuit breaker state: " + getCircuitBreakerState()
+                    + ", so trying to obtain the LDAP connection, connection URL: "
+                    + environment.get(Context.PROVIDER_URL));
+        }
+        int retryCounter = 1;
+        while (true) {
+            try {
+                return getDirContext();
+            } catch (UserStoreException e) {
+                log.warn("Error occurred while obtaining LDAP connection. Connection URL: "
+                        + environment.get(Context.PROVIDER_URL) + ". Hence, retry attempt to recover " +
+                        "LDAP connection: " + retryCounter);
+
+                if (retryCounter >= getConnectionRetryCount()) {
+                    log.error("Retry count exceeds above the maximum count: " + getConnectionRetryCount() +
+                            " and failed for LDAP connection: " + environment.get(Context.PROVIDER_URL));
+                    setCircuitBreakerState(CIRCUIT_STATE_OPEN);
+                    setThresholdStartTime(System.currentTimeMillis());
+                    throw new CircuitBreakerOpenException("Error occurred while obtaining LDAP connection, "
+                            + "LDAP connection circuit breaker state set to: " + getCircuitBreakerState(), e);
+                }
+                retryCounter++;
+            }
+        }
     }
 
     private DirContext getDirContext() throws UserStoreException {
@@ -479,7 +539,7 @@ public class LDAPConnectionContext {
         switch (ldapConnectionCircuitBreakerState) {
         case CIRCUIT_STATE_OPEN:
             long circuitOpenDuration = System.currentTimeMillis() - thresholdStartTime;
-            if (circuitOpenDuration >= thresholdTimeoutInMilliseconds) {
+            if (circuitOpenDuration > thresholdTimeoutInMilliseconds) {
                 try {
                     if (log.isDebugEnabled()) {
                         log.debug("Trying to obtain LDAP connection, connection URL: " + environment
@@ -503,7 +563,7 @@ public class LDAPConnectionContext {
             } else {
                 throw new UserStoreException(
                         "LDAP connection circuit breaker is in open state for " + circuitOpenDuration
-                                + "ms and has not reach the threshold timeout: " + thresholdTimeoutInMilliseconds
+                                + "ms and has not exceed the threshold timeout: " + thresholdTimeoutInMilliseconds
                                 + "ms, hence avoid establishing the LDAP connection.");
             }
         case CIRCUIT_STATE_CLOSE:
@@ -845,19 +905,191 @@ public class LDAPConnectionContext {
     }
 
     /**
-     * Convert retry waiting time string to long.
+     * Sets threadsafe LDAP ConnectionCircuitBreakerState.
      *
-     * @param retryWaitingTime Retry waiting time as a string.
-     * @return Retry waiting time in milliseconds.
-     * @throws UserStoreException
+     * @param ldapConnectionCircuitBreakerState LDAP ConnectionCircuitBreakerState.
      */
-    private long getThresholdTimeoutInMilliseconds(String retryWaitingTime) throws UserStoreException {
+    public void setCircuitBreakerState(String ldapConnectionCircuitBreakerState) {
+
+        writeLock.lock();
+        try {
+            this.ldapConnectionCircuitBreakerState = ldapConnectionCircuitBreakerState;
+        } finally {
+            writeLock.unlock();
+        }
+    }
+
+    /**
+     * Sets threadsafe thresholdTimeoutInMilliseconds.
+     *
+     * @param thresholdTimeoutInMilliseconds threshold Timeout in Milliseconds.
+     */
+    public void setThresholdTimeoutInMilliseconds(long thresholdTimeoutInMilliseconds) {
+
+        writeLock.lock();
+        try {
+            this.thresholdTimeoutInMilliseconds = thresholdTimeoutInMilliseconds;
+        } finally {
+            writeLock.unlock();
+        }
+    }
+    /**
+     * Sets threadsafe thresholdStartTime.
+     *
+     * @param thresholdStartTime Threshold Start Time.
+     */
+    public void setThresholdStartTime(long thresholdStartTime) {
+
+        writeLock.lock();
+        try {
+            this.thresholdStartTime = thresholdStartTime;
+        } finally {
+            writeLock.unlock();
+        }
+    }
+
+    /**
+     * Sets threadsafe connectionRetryCount.
+     *
+     * @param connectionRetryCount Connection Retry Count.
+     */
+    public void setConnectionRetryCount(int connectionRetryCount) {
+
+        writeLock.lock();
+        try {
+            this.connectionRetryCount = connectionRetryCount;
+        } finally {
+            writeLock.unlock();
+        }
+    }
+
+    /**
+     * Returns threadsafe connectionRetryCount.
+     *
+     * @return returns connectionRetryCount.
+     */
+    public int getConnectionRetryCount() {
+
+        readLock.lock();
+        try	{
+            return connectionRetryCount;
+        } finally {
+            readLock.unlock();
+        }
+    }
+
+    /**
+     * Return the validated retry count with maximum retry count.
+     *
+     * @param connectionRetryCount Retry connection count.
+     * @return Allowed Retry connection count.
+     *
+     * @throws UserStoreException An error occurred while parsing the property value.
+     */
+    protected int getValidatedConnectionRetryCount(int connectionRetryCount) throws UserStoreException {
 
         try {
-            return Long.parseLong(retryWaitingTime);
+            String maxConnectionRetryCountProperty = ServerConfiguration.getInstance()
+                    .getFirstProperty(MAX_CONNECTION_RETRY_COUNT);
+            if (StringUtils.isEmpty(maxConnectionRetryCountProperty)) {
+                if (log.isDebugEnabled()) {
+                    log.debug("Max Connection retry count is not configured. Hence, returning the given "
+                            + "retry count: " + connectionRetryCount);
+                }
+                return connectionRetryCount;
+            }
+
+            int maxConnectionRetryCount = Integer.parseInt(maxConnectionRetryCountProperty);
+            if (connectionRetryCount > maxConnectionRetryCount) {
+                if (log.isDebugEnabled()) {
+                    log.debug("Connection retry count configured exceeds the allowed maximum retry count. "
+                            + "Hence, returning the max allowed connection retry count: " + maxConnectionRetryCount);
+                }
+                return maxConnectionRetryCount;
+            }
+            return connectionRetryCount;
         } catch (NumberFormatException e) {
-            throw new UserStoreException("Error occurred while parsing ConnectionRetryDelay property value. value: "
-                    + UserStoreConfigConstants.CONNECTION_RETRY_DELAY);
+            throw new UserStoreException("Error occurred while parsing ConnectionRetryCount property value.");
+        }
+    }
+
+    /**
+     * Returns threadsafe thresholdStartTime.
+     *
+     * @return returns thresholdStartTime.
+     */
+    public long getThresholdStartTime() {
+
+        readLock.lock();
+        try	{
+            return thresholdStartTime;
+        } finally {
+            readLock.unlock();
+        }
+    }
+
+    /**
+     * Returns threadsafe LDAP ConnectionCircuitBreakerState.
+     *
+     * @return returns ldapConnectionCircuitBreakerState.
+     */
+    public String getCircuitBreakerState() {
+
+        readLock.lock();
+        try	{
+            return ldapConnectionCircuitBreakerState;
+        } finally {
+            readLock.unlock();
+        }
+    }
+
+    /**
+     * Returns threadsafe thresholdTimeoutInMilliseconds.
+     *
+     * @return returns thresholdTimeoutInMilliseconds.
+     */
+    public long getThresholdTimeoutInMilliseconds() {
+
+        readLock.lock();
+        try	{
+            return thresholdTimeoutInMilliseconds;
+        } finally {
+            readLock.unlock();
+        }
+    }
+
+    /**
+     * Return the validated retry waiting time with minimum retry waiting time.
+     *
+     * @param retryWaitingTime Retry waiting time.
+     * @return Allowed Retry waiting time in milliseconds.
+     *
+     * @throws UserStoreException An error occurred while parsing the property value.
+     */
+    protected long getValidatedThresholdTimeoutInMilliseconds(long retryWaitingTime) throws UserStoreException {
+
+        try {
+            String minRetryWaitingTimeProperty = ServerConfiguration.getInstance()
+                    .getFirstProperty(MIN_CONNECTION_RETRY_DELAY_IN_MILLISECONDS);
+            if (StringUtils.isEmpty(minRetryWaitingTimeProperty)) {
+                if (log.isDebugEnabled()) {
+                    log.debug(
+                            "Minimum retry delay in milliseconds is not configured. Hence, returning the given " + "retry delay in milliseconds: " + retryWaitingTime);
+                }
+                return retryWaitingTime;
+            }
+
+            long minRetryWaitingTime = Long.parseLong(minRetryWaitingTimeProperty);
+            if (minRetryWaitingTime > retryWaitingTime) {
+                if (log.isDebugEnabled()) {
+                    log.debug(
+                            "Connection retry delay in milliseconds configured is less than the allowed minimum " + "waiting time. Hence, returning the min allowed connection retry delay in milliseconds: " + minRetryWaitingTime);
+                }
+                return minRetryWaitingTime;
+            }
+            return retryWaitingTime;
+        } catch (NumberFormatException e) {
+            throw new UserStoreException("Error occurred while parsing ConnectionRetryDelay property value.");
         }
     }
 }

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/ReadOnlyLDAPUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/ReadOnlyLDAPUserStoreManager.java
@@ -25,6 +25,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.CarbonConstants;
 import org.wso2.carbon.base.MultitenantConstants;
+import org.wso2.carbon.base.ServerConfiguration;
 import org.wso2.carbon.caching.impl.CachingConstants;
 import org.wso2.carbon.context.CarbonContext;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
@@ -105,6 +106,8 @@ import javax.naming.ldap.Rdn;
 import javax.naming.ldap.SortControl;
 import javax.sql.DataSource;
 
+import static org.wso2.carbon.user.core.UserCoreConstants.PROP_ENABLE_CIRCUIT_BREAKER_FOR_USERSTORE;
+import static org.wso2.carbon.user.core.UserCoreConstants.RealmConfig.CIRCUIT_STATE_OPEN;
 import static org.wso2.carbon.user.core.UserStoreConfigConstants.GROUP_CREATED_DATE_ATTRIBUTE;
 import static org.wso2.carbon.user.core.UserStoreConfigConstants.GROUP_ID_ATTRIBUTE;
 import static org.wso2.carbon.user.core.UserStoreConfigConstants.GROUP_LAST_MODIFIED_DATE_ATTRIBUTE;
@@ -4505,10 +4508,15 @@ public class ReadOnlyLDAPUserStoreManager extends AbstractUserStoreManager {
         setAdvancedProperty(UserStoreConfigConstants.STARTTLS_ENABLED,
                 UserStoreConfigConstants.STARTTLS_ENABLED_DISPLAY_NAME, "false",
                 UserStoreConfigConstants.STARTTLS_ENABLED_DESCRIPTION);
+        /* Added to implement Circuit Breaker. */
         setAdvancedProperty(UserStoreConfigConstants.CONNECTION_RETRY_DELAY,
                 UserStoreConfigConstants.CONNECTION_RETRY_DELAY_DISPLAY_NAME,
                 String.valueOf(UserStoreConfigConstants.DEFAULT_CONNECTION_RETRY_DELAY_IN_MILLISECONDS),
                 UserStoreConfigConstants.CONNECTION_RETRY_DELAY_DESCRIPTION);
+        setAdvancedProperty(UserStoreConfigConstants.CONNECTION_RETRY_COUNT,
+                UserStoreConfigConstants.CONNECTION_RETRY_COUNT_DISPLAY_NAME,
+                String.valueOf(UserStoreConfigConstants.DEFAULT_CONNECTION_RETRY_COUNT),
+                UserStoreConfigConstants.CONNECTION_RETRY_COUNT_DESCRIPTION);
         setAdvancedProperty(UserStoreConfigConstants.SSLCertificateValidationEnabled, "Enable SSL certificate" +
                 " validation", "true", UserStoreConfigConstants.SSLCertificateValidationEnabledDescription);
         setAdvancedProperty(UserStoreConfigConstants.immutableAttributes,
@@ -4836,5 +4844,29 @@ public class ReadOnlyLDAPUserStoreManager extends AbstractUserStoreManager {
         OffsetDateTime offsetDateTime = OffsetDateTime.parse(date, dateTimeFormatter);
         Instant instant = offsetDateTime.toInstant();
         return instant.toString();
+    }
+
+    /**
+     * Verify Circuit Breaker state for user store.
+     *
+     * @return true if CircuitBreaker Open, false otherwise.
+     */
+    public boolean isCircuitBreakerEnabledAndOpen() throws UserStoreException {
+
+        if (Boolean.parseBoolean(ServerConfiguration.getInstance()
+                .getFirstProperty(PROP_ENABLE_CIRCUIT_BREAKER_FOR_USERSTORE))) {
+
+            long circuitOpenDuration = System.currentTimeMillis() - this.connectionSource.getThresholdStartTime();
+            if (CIRCUIT_STATE_OPEN.equals(this.connectionSource.getCircuitBreakerState())
+                    && circuitOpenDuration <=  this.connectionSource.getThresholdTimeoutInMilliseconds()) {
+                log.warn("LDAP connection circuit breaker is in open state for " + circuitOpenDuration
+                        + "ms and has not reach the threshold timeout: "
+                        + this.connectionSource.getThresholdTimeoutInMilliseconds() + "ms. " +
+                        "Hence avoid establishing the LDAP connection for domain: " + this.getMyDomainName());
+
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/ReadWriteLDAPUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/ReadWriteLDAPUserStoreManager.java
@@ -480,6 +480,11 @@ public class ReadWriteLDAPUserStoreManager extends ReadOnlyLDAPUserStoreManager 
         setAdvancedProperty(UserStoreConfigConstants.STARTTLS_ENABLED,
                 UserStoreConfigConstants.STARTTLS_ENABLED_DISPLAY_NAME, "false",
                 UserStoreConfigConstants.STARTTLS_ENABLED_DESCRIPTION);
+        // Added for Circuit Breaker implementation.
+        setAdvancedProperty(UserStoreConfigConstants.CONNECTION_RETRY_COUNT,
+                UserStoreConfigConstants.CONNECTION_RETRY_COUNT_DISPLAY_NAME,
+                String.valueOf(UserStoreConfigConstants.DEFAULT_CONNECTION_RETRY_COUNT),
+                UserStoreConfigConstants.CONNECTION_RETRY_COUNT_DESCRIPTION);
         setAdvancedProperty(UserStoreConfigConstants.CONNECTION_RETRY_DELAY,
                 UserStoreConfigConstants.CONNECTION_RETRY_DELAY_DISPLAY_NAME,
                 String.valueOf(UserStoreConfigConstants.DEFAULT_CONNECTION_RETRY_DELAY_IN_MILLISECONDS),

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/UniqueIDActiveDirectoryUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/UniqueIDActiveDirectoryUserStoreManager.java
@@ -1062,6 +1062,11 @@ public class UniqueIDActiveDirectoryUserStoreManager extends UniqueIDReadWriteLD
         setAdvancedProperty(UserStoreConfigConstants.STARTTLS_ENABLED,
                 UserStoreConfigConstants.STARTTLS_ENABLED_DISPLAY_NAME, "false",
                 UserStoreConfigConstants.STARTTLS_ENABLED_DESCRIPTION);
+        /* Added for circuit breaker implementation. */
+        setAdvancedProperty(UserStoreConfigConstants.CONNECTION_RETRY_COUNT,
+                UserStoreConfigConstants.CONNECTION_RETRY_COUNT_DISPLAY_NAME,
+                String.valueOf(UserStoreConfigConstants.DEFAULT_CONNECTION_RETRY_COUNT),
+                UserStoreConfigConstants.CONNECTION_RETRY_COUNT_DESCRIPTION);
         setAdvancedProperty(UserStoreConfigConstants.CONNECTION_RETRY_DELAY,
                 UserStoreConfigConstants.CONNECTION_RETRY_DELAY_DISPLAY_NAME,
                 String.valueOf(UserStoreConfigConstants.DEFAULT_CONNECTION_RETRY_DELAY_IN_MILLISECONDS),

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/UniqueIDReadOnlyLDAPUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/UniqueIDReadOnlyLDAPUserStoreManager.java
@@ -2649,6 +2649,11 @@ public class UniqueIDReadOnlyLDAPUserStoreManager extends ReadOnlyLDAPUserStoreM
         setAdvancedProperty(UserStoreConfigConstants.STARTTLS_ENABLED,
                 UserStoreConfigConstants.STARTTLS_ENABLED_DISPLAY_NAME, "false",
                 UserStoreConfigConstants.STARTTLS_ENABLED_DESCRIPTION);
+        /* Added for circuit breaker implementation. */
+        setAdvancedProperty(UserStoreConfigConstants.CONNECTION_RETRY_COUNT,
+                UserStoreConfigConstants.CONNECTION_RETRY_COUNT_DISPLAY_NAME,
+                String.valueOf(UserStoreConfigConstants.DEFAULT_CONNECTION_RETRY_COUNT),
+                UserStoreConfigConstants.CONNECTION_RETRY_COUNT_DESCRIPTION);
         setAdvancedProperty(UserStoreConfigConstants.CONNECTION_RETRY_DELAY,
                 UserStoreConfigConstants.CONNECTION_RETRY_DELAY_DISPLAY_NAME,
                 String.valueOf(UserStoreConfigConstants.DEFAULT_CONNECTION_RETRY_DELAY_IN_MILLISECONDS),

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/UniqueIDReadWriteLDAPUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/UniqueIDReadWriteLDAPUserStoreManager.java
@@ -74,6 +74,8 @@ import javax.naming.directory.SearchControls;
 import javax.naming.directory.SearchResult;
 import javax.sql.DataSource;
 
+import static org.wso2.carbon.user.core.UserStoreConfigConstants.DEFAULT_CONNECTION_RETRY_COUNT;
+
 /**
  * This class is capable of get connected to an external or internal LDAP based user store in
  * read/write mode. Create, Update, Delete users and groups are supported.
@@ -2309,6 +2311,11 @@ public class UniqueIDReadWriteLDAPUserStoreManager extends UniqueIDReadOnlyLDAPU
         setAdvancedProperty(UserStoreConfigConstants.STARTTLS_ENABLED,
                 UserStoreConfigConstants.STARTTLS_ENABLED_DISPLAY_NAME, "false",
                 UserStoreConfigConstants.STARTTLS_ENABLED_DESCRIPTION);
+        /* Added for Circuit Breaker Implementation.*/
+        setAdvancedProperty(UserStoreConfigConstants.CONNECTION_RETRY_COUNT,
+                UserStoreConfigConstants.CONNECTION_RETRY_COUNT_DISPLAY_NAME,
+                String.valueOf(DEFAULT_CONNECTION_RETRY_COUNT),
+                UserStoreConfigConstants.CONNECTION_RETRY_COUNT_DESCRIPTION);
         setAdvancedProperty(UserStoreConfigConstants.CONNECTION_RETRY_DELAY,
                 UserStoreConfigConstants.CONNECTION_RETRY_DELAY_DISPLAY_NAME,
                 String.valueOf(UserStoreConfigConstants.DEFAULT_CONNECTION_RETRY_DELAY_IN_MILLISECONDS),

--- a/distribution/kernel/carbon-home/repository/resources/conf/default.json
+++ b/distribution/kernel/carbon-home/repository/resources/conf/default.json
@@ -223,6 +223,9 @@
   "signature_util.enable_sha256_algo" : false,
   "clustering.agent": "org.wso2.carbon.hazelcast.HazelcastClusteringAgent",
   "remote_logging.config_sync.period": "15",
-  "admin_console.resolve_absolute_urls.enable": false
-
+  "admin_console.resolve_absolute_urls.enable": false,
+  "jdbc_user_store.enable_optimized_jdbc_search": false,
+  "user_store_commons.enable_circuit_breaker_for_user_stores": true,
+  "user_store_commons.max_connection_retry_count": "5",
+  "user_store_commons.min_connection_retry_delay_in_milli_seconds": "60000"
 }

--- a/distribution/kernel/carbon-home/repository/resources/conf/templates/repository/conf/carbon.xml.j2
+++ b/distribution/kernel/carbon-home/repository/resources/conf/templates/repository/conf/carbon.xml.j2
@@ -874,5 +874,10 @@
         {% endif %}
         {% endfor %}
     </DeniedAdminServices>
-
+    <!-- Enable/Disable circuit breaker for userstores to ensure backward compatibility -->
+    <UserStore>
+        <enableCircuitBreakerForUserStores>{{user_store_commons.enable_circuit_breaker_for_user_stores}}</enableCircuitBreakerForUserStores>
+        <maxConnectionRetryCount>{{user_store_commons.max_connection_retry_count}}</maxConnectionRetryCount>
+        <minConnectionRetryDelayInMilliSeconds>{{user_store_commons.min_connection_retry_delay_in_milli_seconds}}</minConnectionRetryDelayInMilliSeconds>
+    </UserStore>
 </Server>


### PR DESCRIPTION
### Description

- From this PR, handles the account remains unlock after exceeding the logging attempts issue when the secondary userstore fails

### Tested flows

### Tested flows

- [x] User successful login without secondary user store
- [x] User account lock when no secondary user store is configured
- [x] Successful login when LDAP secondary user store is configured
- [x] Successful user account lock when LDAP secondary user store is configured  
- [x] Successful user login when LDAP secondary user store is failing
- [x] Successful account lock when LDAP secondary user store is failing 
- [x] Successful login when mysql JDBC user store is configured as secondary user store
- [x] Sucessful account locking when secondary JDBC user store is configured
- [x] Successful user login when JDBC secondary user store is failing
- [x] Successful account lock when JDBC secondary user store is failing 
- [x] Backward compatibility test with below config
```
[user_store_commons]
enable_circuit_breaker_for_user_stores=false
```
