### PR TITLE
Fix Oracle Registry DB Connection Fails Due to Validation Query Misconfiguration

### DIFF
--- a/distribution/kernel/carbon-home/repository/resources/conf/infer.json
+++ b/distribution/kernel/carbon-home/repository/resources/conf/infer.json
@@ -264,37 +264,37 @@
     "mysql": {
       "database.$1.driver": "com.mysql.jdbc.Driver",
       "database.$1.url": "jdbc:mysql://$ref{database.$1.hostname}:$ref{database.$1.port}/$ref{database.$1.name}",
-      "database.$1.validationQuery": "SELECT 1"
+      "database.$1.pool_options.validationQuery": "SELECT 1"
     },
     "mariadb": {
       "database.$1.driver": "org.mariadb.jdbc.Driver",
       "database.$1.url": "jdbc:mariadb://$ref{database.$1.hostname}:$ref{database.$1.port}/$ref{database.$1.name}",
-      "database.$1.validationQuery": "SELECT 1"
+      "database.$1.pool_options.validationQuery": "SELECT 1"
     },
     "oracle": {
       "database.$1.driver": "oracle.jdbc.OracleDriver",
       "database.$1.url": "jdbc:oracle:thin:@$ref{database.$1.hostname}:$ref{database.$1.port}/$ref{database.$1.sid}",
-      "database.$1.validationQuery": "SELECT 1 FROM DUAL"
+      "database.$1.pool_options.validationQuery": "SELECT 1 FROM DUAL"
     },
     "mssql": {
       "database.$1.driver": "com.microsoft.sqlserver.jdbc.SQLServerDriver",
       "database.$1.url": "jdbc:sqlserver://$ref{database.$1.hostname}:$ref{database.$1.port};databaseName=$ref{database.$1.name};SendStringParametersAsUnicode=false",
-      "database.$1.validationQuery": "SELECT 1"
+      "database.$1.pool_options.validationQuery": "SELECT 1"
     },
     "db2": {
       "database.$1.driver": "com.ibm.db2.jcc.DB2Driver",
       "database.$1.url": "jdbc:db2://$ref{database.$1.hostname}:$ref{database.$1.port}/$ref{database.$1.name}:progressiveStreaming=2;",
-      "database.$1.validationQuery": "SELECT 1 FROM sysibm.sysdummy1"
+      "database.$1.pool_options.validationQuery": "SELECT 1 FROM sysibm.sysdummy1"
     },
     "postgre": {
       "database.$1.driver": "org.postgresql.Driver",
       "database.$1.url": "jdbc:postgresql://$ref{database.$1.hostname}:$ref{database.$1.port}/$ref{database.$1.name}",
-      "database.$1.validationQuery": "SELECT 1; COMMIT"
+      "database.$1.pool_options.validationQuery": "SELECT 1; COMMIT"
     },
     "h2": {
       "database.$1.driver": "org.h2.Driver",
       "database.$1.url": "jdbc:h2:async:./repository/database/WSO2CARBON_DB;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000",
-      "database.$1.validationQuery": "SELECT 1"
+      "database.$1.pool_options.validationQuery": "SELECT 1"
     }
   },
   "tenant_mgt.tenant_manager.type": {


### PR DESCRIPTION
## Related Issue
- https://github.com/wso2/product-is/issues/26198

## Purpose
This PR fixes the issue where Oracle-based external databases fail to validate connections when used as the local registry database in WSO2 Identity Server.

Previously, the validation query configuration in `<IS_HOME>/repository/resources/conf/default.json` and `<IS_HOME>/repository/resources/conf/infer.json` used an incorrect key `database.$1.validationQuery` instead of the correct `database.$1.pool_options.validationQuery`. As a result, the default `SELECT 1` query was applied for all databases, causing connection validation failures in Oracle (SELECT 1 is invalid in Oracle).

**Changes**
Updated the JSON configuration to use `database.$1.pool_options.validationQuery` for all database types.

## Manual Testing
https://github.com/user-attachments/assets/1ed09f02-6cd7-41e7-8bd7-6b5cb22dd1d9
