### PR TITLE
Bump Axis2 Version for the Issue Fixed for Multipart HTTP Requests

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -451,7 +451,7 @@
         <version.spring>3.1.0.RELEASE</version.spring>
 
         <!-- Apache Axis2 -->
-        <version.axis2>1.6.1-wso2v111</version.axis2>
+        <version.axis2>1.6.1-wso2v116</version.axis2>
         <imp.pkg.version.axis2>[1.6.1, 1.7.0)</imp.pkg.version.axis2>
         <version.addressing>${version.axis2}</version.addressing>
         <orbit.version.axis2>${version.axis2}</orbit.version.axis2>


### PR DESCRIPTION
### Description
Bump the Axis2 version to 116 for a fix done for the Multipart HTTP Requests.

- Related issue https://github.com/wso2/api-manager/issues/4488