### PR TITLE
[4.9.x] Cache not found paths as -1 to reduce jdbc calls

### DIFF
--- a/core/org.wso2.carbon.registry.core/src/main/java/org/wso2/carbon/registry/core/jdbc/dao/JDBCPathCache.java
+++ b/core/org.wso2.carbon.registry.core/src/main/java/org/wso2/carbon/registry/core/jdbc/dao/JDBCPathCache.java
@@ -510,6 +510,10 @@ public class JDBCPathCache extends PathCache {
                         cache.put(key, e);
                         return pathId;
                     }
+                } else {
+                    //not found . set -1 in the cache as well for the path
+                    RegistryCacheEntry e = new RegistryCacheEntry(-1);
+                    cache.put(key, e);
                 }
 
             } catch (SQLException e) {


### PR DESCRIPTION
### Purpose 
To fix https://github.com/wso2/api-manager/issues/4581

### Approach
Cherry picked from https://github.com/wso2/carbon-kernel/pull/3605

This was previously fixed with https://github.com/wso2/carbon-kernel/pull/3606, but the commit had been removed during the 4.9.x branch creation

If the path was not found, keep the cached value as -1, so it doesn't have to check the file multiple times

### Testing

1. Create an API without a thumbnail
2. Call the following curl command to get the thumbnail. 
```
curl -kv https://localhost:9443/api/am/devportal/v3/apis/f8c90a40-51f1-4ea2-b0eb-4c457cc7370b/thumbnail -u admin:admin
```
3. Observe the correlation logs for `SELECT REG_PATH_ID FROM REG_PATH ...` queries before the fix and after the fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cache handling to store entries for unsuccessful path lookups, reducing redundant queries and enhancing performance when accessing non-existent paths repeatedly.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->