### PR TITLE
Pass userStoreManager for store identity claim config retrieval

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
@@ -16844,7 +16844,7 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
         getExpressionConditions(duplicateCondition, expressionConditions);
 
         // Check whether the request has IdentityClaims in filters.
-        mapAttributesToLocalIdentityClaims(expressionConditions, domain);
+        mapAttributesToLocalIdentityClaims(expressionConditions, domain, secondaryUserStoreManager);
         boolean identityClaimsExistsInInitialCondition = containsIdentityClaims(expressionConditions);
 
         if (identityClaimsExistsInInitialCondition) {
@@ -17002,7 +17002,7 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
         validation in the next iteration of flow when the domain name is not in query params.*/
         Condition duplicateCondition = getDuplicateCondition(condition);
         getExpressionConditions(duplicateCondition, expressionConditions);
-        mapAttributesToLocalIdentityClaims(expressionConditions, domain);
+        mapAttributesToLocalIdentityClaims(expressionConditions, domain, secondaryUserStoreManager);
 
         /* *****************************************************
          * Logic to Filter Users Based on Identity & Non Identity Claims
@@ -17122,7 +17122,7 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
         getExpressionConditions(duplicateCondition, expressionConditions);
 
         // Check whether the request has IdentityClaims in filters.
-        mapAttributesToLocalIdentityClaims(expressionConditions, domain);
+        mapAttributesToLocalIdentityClaims(expressionConditions, domain, secondaryUserStoreManager);
         boolean identityClaimsExistsInInitialCondition = countIdentityClaims(expressionConditions) > 0;
 
         if (identityClaimsExistsInInitialCondition) {
@@ -17410,7 +17410,8 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
      * @throws UserStoreException
      */
     private void mapAttributesToLocalIdentityClaims(List<ExpressionCondition> expressionConditions,
-                                                    String userStoreDomain) throws UserStoreException {
+                                                    String userStoreDomain, UserStoreManager userStoreManager)
+            throws UserStoreException {
 
         List<org.wso2.carbon.user.api.ClaimMapping> claimMapping;
         try {
@@ -17433,7 +17434,7 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
             }
 
             // Check if the claim is an identity store managed claim and map the attribute name to claim URI.
-            if (isIdentityStoreManagedClaim(mappedClaim.getClaim(), userStoreDomain, null)) {
+            if (isIdentityStoreManagedClaim(mappedClaim.getClaim(), userStoreDomain, userStoreManager)) {
                 expressionCondition.setAttributeName(mappedClaim.getClaim().getClaimUri());
                 if (log.isDebugEnabled()) {
                     log.debug("Obtained the ClaimURI " + mappedClaim.getClaim().getClaimUri() +


### PR DESCRIPTION
This pull request updates the way identity claims are mapped in user store filtering operations by passing the `UserStoreManager` instance to the `mapAttributesToLocalIdentityClaims` method. This change ensures that claim mapping logic can utilize the specific user store manager context, improving accuracy and flexibility in scenarios involving secondary user stores.

**Enhancements to identity claim mapping:**

* The `mapAttributesToLocalIdentityClaims` method in `AbstractUserStoreManager.java` now accepts a `UserStoreManager` parameter, allowing it to operate with the correct user store context.
* All invocations of `mapAttributesToLocalIdentityClaims` in methods like `getUserListWithID`, `getPaginatedUserListWithID`, and `getUsersCount` have been updated to pass the `secondaryUserStoreManager` argument. [[1]](diffhunk://#diff-72ed29bb5d0219833ab12a1c431a6ba2c33003d1230c16bf4b05e0302cb4da18L16847-R16847) [[2]](diffhunk://#diff-72ed29bb5d0219833ab12a1c431a6ba2c33003d1230c16bf4b05e0302cb4da18L17005-R17005) [[3]](diffhunk://#diff-72ed29bb5d0219833ab12a1c431a6ba2c33003d1230c16bf4b05e0302cb4da18L17125-R17125)
* The call to `isIdentityStoreManagedClaim` within `mapAttributesToLocalIdentityClaims` now uses the provided `userStoreManager` instead of `null`, ensuring accurate claim management based on the current user store.

### Related Issues
- https://github.com/wso2/product-is/issues/26159