### PR TITLE
Introduce CustomTlsStrategy to disable Java's built-in endpoint identification algorithm

### DIFF
--- a/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/httpclient5/CustomTlsStrategy.java
+++ b/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/httpclient5/CustomTlsStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/httpclient5/CustomTlsStrategy.java
+++ b/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/httpclient5/CustomTlsStrategy.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.utils.httpclient5;
+
+import org.apache.hc.client5.http.ssl.DefaultClientTlsStrategy;
+import org.apache.hc.client5.http.ssl.HostnameVerificationPolicy;
+import org.apache.hc.core5.reactor.ssl.SSLBufferMode;
+
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLContext;
+
+/**
+ * Custom TLS strategy that disables Java's built-in hostname verification
+ * to allow custom hostname verifiers to be the sole verification mechanism.
+ * <p>
+ * This is critical for ensuring that when a custom hostname verifier is provided,
+ * Java's default endpoint identification algorithm does not interfere with the
+ * custom verification logic. This strategy uses {@link HostnameVerificationPolicy#CLIENT}
+ * which delegates all hostname verification to the provided custom verifier.
+ */
+public class CustomTlsStrategy extends DefaultClientTlsStrategy {
+
+    public CustomTlsStrategy(SSLContext sslContext, HostnameVerifier hostnameVerifier) {
+        // Use CLIENT policy which relies ONLY on the provided hostname verifier
+        // and disables Java's built-in endpoint identification algorithm.
+        super(sslContext, null, null, SSLBufferMode.STATIC, 
+              HostnameVerificationPolicy.CLIENT, hostnameVerifier);
+    }
+}

--- a/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/httpclient5/CustomTlsStrategy.java
+++ b/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/httpclient5/CustomTlsStrategy.java
@@ -24,6 +24,7 @@ import org.apache.hc.core5.reactor.ssl.SSLBufferMode;
 
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLContext;
+import java.util.Objects;
 
 /**
  * Custom TLS strategy that disables Java's built-in hostname verification
@@ -37,9 +38,13 @@ import javax.net.ssl.SSLContext;
 public class CustomTlsStrategy extends DefaultClientTlsStrategy {
 
     public CustomTlsStrategy(SSLContext sslContext, HostnameVerifier hostnameVerifier) {
-        // Use CLIENT policy which relies ONLY on the provided hostname verifier
-        // and disables Java's built-in endpoint identification algorithm.
-        super(sslContext, null, null, SSLBufferMode.STATIC, 
-              HostnameVerificationPolicy.CLIENT, hostnameVerifier);
+        super(
+            Objects.requireNonNull(sslContext, "SSLContext cannot be null"),
+            null,  // SupportedProtocols - null to use system default TLS protocols.
+            null,  // SupportedCipherSuites - null to use system default cipher suites from SSLContext.
+            SSLBufferMode.STATIC,
+            HostnameVerificationPolicy.CLIENT,
+            Objects.requireNonNull(hostnameVerifier, "HostnameVerifier cannot be null.")
+        );
     }
 }

--- a/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/httpclient5/HTTPClientUtils.java
+++ b/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/httpclient5/HTTPClientUtils.java
@@ -18,16 +18,20 @@
 
 package org.wso2.carbon.utils.httpclient5;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.apache.hc.client5.http.config.ConnectionConfig;
 import org.apache.hc.client5.http.config.RequestConfig;
 import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
 import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder;
 import org.apache.hc.client5.http.ssl.NoopHostnameVerifier;
 import org.apache.hc.core5.ssl.SSLContexts;
+import org.apache.hc.core5.ssl.SSLInitializationException;
 import org.apache.hc.core5.util.Timeout;
 import org.wso2.carbon.utils.Utils;
 
 import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLContext;
 
 import static org.wso2.carbon.CarbonConstants.HOST_NAME_VERIFIER;
 import static org.wso2.carbon.CarbonConstants.ALLOW_ALL;
@@ -38,6 +42,7 @@ import static org.wso2.carbon.CarbonConstants.DEFAULT_AND_LOCALHOST;
  */
 public class HTTPClientUtils {
 
+    private static final Log log = LogFactory.getLog(HTTPClientUtils.class);
     private static final int CONNECTION_TIMEOUT;
     private static final int SOCKET_TIMEOUT;
 
@@ -67,20 +72,23 @@ public class HTTPClientUtils {
         }
 
         if (hostnameVerifier != null) {
-            httpClientBuilder.setConnectionManager(
-                PoolingHttpClientConnectionManagerBuilder.create().useSystemProperties()
-                    .setTlsSocketStrategy(
-                        new CustomTlsStrategy(
-                                SSLContexts.createSystemDefault(),
-                                hostnameVerifier
+            try {
+                SSLContext sslContext = SSLContexts.createSystemDefault();
+                httpClientBuilder.setConnectionManager(
+                    PoolingHttpClientConnectionManagerBuilder.create().useSystemProperties()
+                        .setTlsSocketStrategy(
+                            new CustomTlsStrategy(sslContext, hostnameVerifier)
                         )
-                    )
-                    .setDefaultConnectionConfig(
-                        ConnectionConfig.custom().setConnectTimeout(Timeout.ofMilliseconds(CONNECTION_TIMEOUT))
-                            .build()
-                    )
-                    .build()
-            );
+                        .setDefaultConnectionConfig(
+                            ConnectionConfig.custom().setConnectTimeout(Timeout.ofMilliseconds(CONNECTION_TIMEOUT))
+                                .build()
+                        )
+                        .build()
+                );
+            } catch (SSLInitializationException e) {
+                log.error("Failed to create system default SSL context. Continuing without custom hostname verifier."
+                        , e);
+            }
         }
 
         RequestConfig.Builder config = RequestConfig.custom()

--- a/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/httpclient5/HTTPClientUtils.java
+++ b/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/httpclient5/HTTPClientUtils.java
@@ -22,9 +22,8 @@ import org.apache.hc.client5.http.config.ConnectionConfig;
 import org.apache.hc.client5.http.config.RequestConfig;
 import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
 import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder;
-import org.apache.hc.client5.http.ssl.ClientTlsStrategyBuilder;
 import org.apache.hc.client5.http.ssl.NoopHostnameVerifier;
-import org.apache.hc.client5.http.ssl.TlsSocketStrategy;
+import org.apache.hc.core5.ssl.SSLContexts;
 import org.apache.hc.core5.util.Timeout;
 import org.wso2.carbon.utils.Utils;
 
@@ -71,9 +70,10 @@ public class HTTPClientUtils {
             httpClientBuilder.setConnectionManager(
                 PoolingHttpClientConnectionManagerBuilder.create().useSystemProperties()
                     .setTlsSocketStrategy(
-                        (TlsSocketStrategy) ClientTlsStrategyBuilder.create()
-                            .setHostnameVerifier(hostnameVerifier)
-                            .build()
+                        new CustomTlsStrategy(
+                                SSLContexts.createSystemDefault(),
+                                hostnameVerifier
+                        )
                     )
                     .setDefaultConnectionConfig(
                         ConnectionConfig.custom().setConnectTimeout(Timeout.ofMilliseconds(CONNECTION_TIMEOUT))

--- a/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/httpclient5/HTTPClientUtils.java
+++ b/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/httpclient5/HTTPClientUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2025-2026, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -42,7 +42,7 @@ import static org.wso2.carbon.CarbonConstants.DEFAULT_AND_LOCALHOST;
  */
 public class HTTPClientUtils {
 
-    private static final Log log = LogFactory.getLog(HTTPClientUtils.class);
+    private static final Log LOG = LogFactory.getLog(HTTPClientUtils.class);
     private static final int CONNECTION_TIMEOUT;
     private static final int SOCKET_TIMEOUT;
 
@@ -86,7 +86,7 @@ public class HTTPClientUtils {
                         .build()
                 );
             } catch (SSLInitializationException e) {
-                log.error("Failed to create system default SSL context. Continuing without custom hostname verifier."
+                LOG.error("Failed to create system default SSL context. Continuing without custom hostname verifier."
                         , e);
             }
         }

--- a/core/org.wso2.carbon.utils/src/test/java/org/wso2/carbon/utils/httpclient5/CustomTlsStrategyTest.java
+++ b/core/org.wso2.carbon.utils/src/test/java/org/wso2/carbon/utils/httpclient5/CustomTlsStrategyTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.utils.httpclient5;
+
+import org.apache.hc.client5.http.ssl.NoopHostnameVerifier;
+import org.apache.hc.core5.ssl.SSLContexts;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import org.wso2.carbon.BaseTest;
+
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLContext;
+
+/**
+ * Unit tests for CustomTlsStrategy class.
+ * Verifies that the TLS strategy is properly instantiated with valid parameters
+ * and rejects invalid configurations.
+ */
+public class CustomTlsStrategyTest extends BaseTest {
+
+    @Test
+    public void testCustomTlsStrategyWithValidParameters() {
+
+        SSLContext sslContext = SSLContexts.createDefault();
+        HostnameVerifier hostnameVerifier = LocalhostSANsTrustedHostnameVerifier.getInstance();
+        CustomTlsStrategy customTlsStrategy = new CustomTlsStrategy(sslContext, hostnameVerifier);
+        Assert.assertNotNull(customTlsStrategy, "CustomTlsStrategy should be created successfully");
+    }
+
+    @Test(expectedExceptions = NullPointerException.class,
+            expectedExceptionsMessageRegExp = ".*SSLContext cannot be null.*")
+    public void testCustomTlsStrategyWithNullSSLContext() {
+
+        SSLContext sslContext = null;
+        HostnameVerifier hostnameVerifier = NoopHostnameVerifier.INSTANCE;
+        new CustomTlsStrategy(sslContext, hostnameVerifier);
+    }
+
+    @Test(expectedExceptions = NullPointerException.class,
+            expectedExceptionsMessageRegExp = ".*HostnameVerifier cannot be null.*")
+    public void testCustomTlsStrategyWithNullHostnameVerifier() {
+
+        SSLContext sslContext = SSLContexts.createDefault();
+        HostnameVerifier hostnameVerifier = null;
+        new CustomTlsStrategy(sslContext, hostnameVerifier);
+    }
+}

--- a/core/org.wso2.carbon.utils/src/test/java/org/wso2/carbon/utils/httpclient5/HTTPClientUtilsTest.java
+++ b/core/org.wso2.carbon.utils/src/test/java/org/wso2/carbon/utils/httpclient5/HTTPClientUtilsTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.utils.httpclient5;
+
+import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import org.wso2.carbon.BaseTest;
+
+import java.lang.reflect.Field;
+
+import static org.wso2.carbon.CarbonConstants.ALLOW_ALL;
+import static org.wso2.carbon.CarbonConstants.DEFAULT_AND_LOCALHOST;
+import static org.wso2.carbon.CarbonConstants.HOST_NAME_VERIFIER;
+
+/**
+ * Unit tests for HTTPClientUtils class with Apache HttpClient 5.
+ */
+public class HTTPClientUtilsTest extends BaseTest {
+
+    public static final String DUMMY_PROPERTY = "dummy";
+
+    @AfterMethod
+    public void tearDown() {
+
+        System.clearProperty(HOST_NAME_VERIFIER);
+    }
+
+    @DataProvider(name = "hostnameVerifierDataProvider")
+    public Object[][] hostnameVerifierDataProvider() {
+
+        return new Object[][]{
+                {DEFAULT_AND_LOCALHOST, true},
+                {ALLOW_ALL, true},
+                {DUMMY_PROPERTY, false}
+        };
+    }
+
+    @Test(dataProvider = "hostnameVerifierDataProvider")
+    public void testCreateClientWithCustomHostnameVerifier(String hostnameVerifierType,
+                                                           boolean shouldHaveConnectionManager)
+            throws NoSuchFieldException, IllegalAccessException {
+
+        System.setProperty(HOST_NAME_VERIFIER, hostnameVerifierType);
+        HttpClientBuilder httpClientBuilder = HTTPClientUtils.createClientWithCustomHostnameVerifier();
+
+        Assert.assertNotNull(httpClientBuilder, "HttpClientBuilder should not be null");
+
+        // Use reflection to check if connection manager is set.
+        Class<HttpClientBuilder> httpClientBuilderClass = HttpClientBuilder.class;
+        Field connManagerField = httpClientBuilderClass.getDeclaredField("connManager");
+        connManagerField.setAccessible(true);
+
+        PoolingHttpClientConnectionManager connManager =
+                (PoolingHttpClientConnectionManager) connManagerField.get(httpClientBuilder);
+
+        if (shouldHaveConnectionManager) {
+            Assert.assertNotNull(connManager);
+        } else {
+            Assert.assertNull(connManager);
+        }
+    }
+
+    /**
+     * Test error handling when SSL context creation fails.
+     * This test verifies that:
+     * 1. The HttpClientBuilder is still created successfully.
+     * 2. The client continues without custom TLS strategy.
+     */
+    @Test
+    public void testCreateClientWithSSLInitializationFailure() throws NoSuchFieldException, IllegalAccessException {
+
+        System.setProperty(HOST_NAME_VERIFIER, DEFAULT_AND_LOCALHOST);
+        HttpClientBuilder httpClientBuilder = HTTPClientUtils.createClientWithCustomHostnameVerifier();
+
+        Assert.assertNotNull(httpClientBuilder,
+                "HttpClientBuilder should be created even if SSL context initialization encounters issues");
+
+        // Verify that the builder has basic configuration (request config should always be set).
+        Field defaultRequestConfigField = HttpClientBuilder.class.getDeclaredField("defaultRequestConfig");
+        defaultRequestConfigField.setAccessible(true);
+        Object requestConfig = defaultRequestConfigField.get(httpClientBuilder);
+
+        Assert.assertNotNull(requestConfig,
+                "HttpClientBuilder should have request config set even if SSL initialization fails");
+    }
+
+    /**
+     * Test that no connection manager is set when hostname verifier property is not configured.
+     */
+    @Test
+    public void testNoConnectionManagerWithoutHostnameVerifierProperty()
+            throws NoSuchFieldException, IllegalAccessException {
+
+        System.clearProperty(HOST_NAME_VERIFIER);
+        HttpClientBuilder httpClientBuilder = HTTPClientUtils.createClientWithCustomHostnameVerifier();
+
+        Field connManagerField = HttpClientBuilder.class.getDeclaredField("connManager");
+        connManagerField.setAccessible(true);
+        PoolingHttpClientConnectionManager connManager =
+                (PoolingHttpClientConnectionManager) connManagerField.get(httpClientBuilder);
+
+        Assert.assertNull(connManager,
+                "Connection manager should not be set when hostname verifier property is not configured");
+    }
+}


### PR DESCRIPTION
## Description

Resolves: https://github.com/wso2/product-is/issues/12577

Introduce `CustomTlsStrategy` class to properly disable Java's built-in hostname verification for Apache HttpClient 5, ensuring only the custom hostname verifier is used.

## Problem

After migrating to Apache HttpClient 5 in version 7.2.0, the system property `-Dhttpclient.hostnameVerifier="DefaultAndLocalhost"` is not properly honored. When the server hostname is changed (e.g., from `localhost` to `example.com`), internal API calls that use `localhost` fail with SSL hostname verification errors.

**Root Cause:**  
Apache HttpClient 5's architecture requires hostname verification to be configured through the connection manager's TLS strategy. By default, **Java's built-in endpoint identification algorithm** runs in addition to any custom hostname verifier, causing verification to fail even when the custom verifier would allow the connection.

## Solution

Created `CustomTlsStrategy` class that extends `DefaultClientTlsStrategy` with `HostnameVerificationPolicy.CLIENT`. This policy:
- Disables Java's built-in endpoint identification algorithm (`setEndpointIdentificationAlgorithm(null)`)
- Relies solely on the provided custom hostname verifier (`LocalhostSANsTrustedHostnameVerifier`)


| Policy | Java's Endpoint Identification | Custom HostnameVerifier | Use Case |
|--------|-------------------------------|-------------------------|----------|
| `BUILTIN` | ✅ Enabled | ❌ Not used | Standard HTTPS with proper certificates |
| `CLIENT` | ❌ Disabled | ✅ Used exclusively | Custom hostname logic (e.g., localhost SANs) |
| `BOTH` | ✅ Enabled | ✅ Both must pass | Defense-in-depth verification |

**Default behavior:** When `hostnameVerifier` is set → defaults to `BOTH`

**Before (In 7.1):**

```
[2026-01-18 17:27:55,901] [8fb66ff1-f0a3-4c14-ac4b-307b74103132] ERROR {org.wso2.carbon.identity.application.authentication.endpoint.util.AuthenticationEndpointUtil} - Sending GET request to URL : https://fake.example.com:9444/api/identity/auth/v1.1/data/AuthRequestKey/2b45d8ee-86c8-4ca3-b386-f48251fccf0f, failed. javax.net.ssl.SSLPeerUnverifiedException: Certificate for <fake.example.com> doesn't match any of the subject alternative names: [is.dev.wso2.com]
	at org.apache.http.conn.ssl.SSLConnectionSocketFactory.verifyHostname(SSLConnectionSocketFactory.java:507)
```

**After (In 7.2 after the fix working with the correct behaviour as before):**

```
[2026-01-18 17:27:27,954] [5b3c4704-8bcc-4f91-b5a6-d8be466f3476] ERROR {org.wso2.carbon.identity.application.authentication.endpoint.util.AuthenticationEndpointUtil} - Sending GET request to URL : https://fake.example.com:9443/api/identity/auth/v1.1/data/AuthRequestKey/2ed70d2d-2486-411c-a6ec-00a63f248947, failed. javax.net.ssl.SSLPeerUnverifiedException: Certificate for <fake.example.com> doesn't match any of the subject alternative names: [is.dev.wso2.com]
	at org.apache.hc.client5.http.ssl.DefaultHostnameVerifier.matchDNSName(DefaultHostnameVerifier.java:171)
	at org.apache.hc.client5.http.ssl.DefaultHostnameVerifier.verify(DefaultHostnameVerifier.java:129)
	at org.wso2.carbon.utils.httpclient5.LocalhostSANsTrustedHostnameVerifier.verify(LocalhostSANsTrustedHostnameVerifier.java:100)
```