### PR TITLE
Add microsecond truncation option for recordedAt timestamps with config.

### DIFF
--- a/core/org.wso2.carbon.base/src/main/java/org/wso2/carbon/base/ServerConfiguration.java
+++ b/core/org.wso2.carbon.base/src/main/java/org/wso2/carbon/base/ServerConfiguration.java
@@ -81,6 +81,10 @@ public class ServerConfiguration implements ServerConfigurationService {
 	 * Constant to be used to disable admin services.
 	 */
 	public static final String AXIS2_CONFIG_DISABLE_ADMIN_SERVICES = "Axis2Config.DisableAdminServices";
+    /**
+     * Constant to be used for properties storing whether to truncate log timestamps to microseconds.
+     */
+    public static final String LOG_MGT_TRUNCATE_TO_MICROSECONDS = "LogMgt.TruncateToMicroseconds";
 	/**
 	 * Constant to be used for properties storing the http port of the servlet
 	 * transport.

--- a/core/org.wso2.carbon.base/src/main/java/org/wso2/carbon/base/ServerConfiguration.java
+++ b/core/org.wso2.carbon.base/src/main/java/org/wso2/carbon/base/ServerConfiguration.java
@@ -84,7 +84,7 @@ public class ServerConfiguration implements ServerConfigurationService {
     /**
      * Constant to be used for properties storing whether to truncate log timestamps to microseconds.
      */
-    public static final String LOG_MGT_TRUNCATE_TO_MICROSECONDS = "LogMgt.TruncateToMicroseconds";
+    public static final String LOG_MGT_TRUNCATE_TO_MICROSECONDS = "LogMgt.AuditLog.TruncateToMicroseconds";
 	/**
 	 * Constant to be used for properties storing the http port of the servlet
 	 * transport.

--- a/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/AuditLog.java
+++ b/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/AuditLog.java
@@ -22,6 +22,7 @@ import org.apache.commons.lang.StringUtils;
 import org.slf4j.MDC;
 
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
@@ -176,8 +177,21 @@ public class AuditLog {
             if (this.id == null) {
                 id = UUID.randomUUID().toString();
             }
+            Instant recordedAtInstant;
             if (this.recordedAt == null) {
-                recordedAt = Instant.now().toString();
+                recordedAtInstant = Instant.now();
+            } else {
+                try {
+                    recordedAtInstant = Instant.parse(this.recordedAt);
+                } catch (java.time.format.DateTimeParseException e){
+                    recordedAtInstant = Instant.now();
+                }
+            }
+            // Truncate to microseconds if enabled.
+            if (CarbonUtils.isMicrosecondTruncateEnabled()) {
+                recordedAt = recordedAtInstant.truncatedTo(ChronoUnit.MICROS).toString();
+            } else {
+                recordedAt = recordedAtInstant.toString();
             }
             if (this.impersonatorId == null) {
                 impersonatorId = MDC.get(IMPERSONATOR_ID);

--- a/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/AuditLog.java
+++ b/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/AuditLog.java
@@ -22,6 +22,7 @@ import org.apache.commons.lang.StringUtils;
 import org.slf4j.MDC;
 
 import java.time.Instant;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.ChronoUnit;
 import java.util.HashMap;
 import java.util.Map;
@@ -183,7 +184,7 @@ public class AuditLog {
             } else {
                 try {
                     recordedAtInstant = Instant.parse(this.recordedAt);
-                } catch (java.time.format.DateTimeParseException e){
+                } catch (DateTimeParseException e){
                     recordedAtInstant = Instant.now();
                 }
             }

--- a/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/CarbonUtils.java
+++ b/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/CarbonUtils.java
@@ -134,14 +134,10 @@ public class CarbonUtils {
      */
     public static boolean isMicrosecondTruncateEnabled() {
 
-        boolean truncateToMicroseconds = false;
         String truncateToMicrosecondsProp =
                 ServerConfiguration.getInstance()
                         .getFirstProperty(ServerConfiguration.LOG_MGT_TRUNCATE_TO_MICROSECONDS);
-        if (truncateToMicrosecondsProp != null) {
-            truncateToMicroseconds = Boolean.parseBoolean(truncateToMicrosecondsProp);
-        }
-        return truncateToMicroseconds;
+        return Boolean.parseBoolean(truncateToMicrosecondsProp);
     }
 
     /**

--- a/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/CarbonUtils.java
+++ b/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/CarbonUtils.java
@@ -101,7 +101,6 @@ public class CarbonUtils {
     private static final String TRANSPORT_MANAGER =
             "org.wso2.carbon.tomcat.ext.transport.ServletTransportManager";
 	private static final String TRUE = "true";
-    public static final String LOG_MGT_TRUNCATE_TO_MICROSECONDS = "LogMgt.TruncateToMicroseconds";
 	private static Log log = LogFactory.getLog(CarbonUtils.class);
 	private static Log diagnosticLog = LogFactory.getLog("diagnostics");
     private static final int ENTITY_EXPANSION_LIMIT = 0;
@@ -137,7 +136,8 @@ public class CarbonUtils {
 
         boolean truncateToMicroseconds = false;
         String truncateToMicrosecondsProp =
-                ServerConfiguration.getInstance().getFirstProperty(LOG_MGT_TRUNCATE_TO_MICROSECONDS);
+                ServerConfiguration.getInstance()
+                        .getFirstProperty(ServerConfiguration.LOG_MGT_TRUNCATE_TO_MICROSECONDS);
         if (truncateToMicrosecondsProp != null) {
             truncateToMicroseconds = Boolean.parseBoolean(truncateToMicrosecondsProp);
         }

--- a/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/CarbonUtils.java
+++ b/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/CarbonUtils.java
@@ -101,6 +101,7 @@ public class CarbonUtils {
     private static final String TRANSPORT_MANAGER =
             "org.wso2.carbon.tomcat.ext.transport.ServletTransportManager";
 	private static final String TRUE = "true";
+    public static final String LOG_MGT_TRUNCATE_TO_MICROSECONDS = "LogMgt.TruncateToMicroseconds";
 	private static Log log = LogFactory.getLog(CarbonUtils.class);
 	private static Log diagnosticLog = LogFactory.getLog("diagnostics");
     private static final int ENTITY_EXPANSION_LIMIT = 0;
@@ -125,6 +126,22 @@ public class CarbonUtils {
             enableAdminConsole = Boolean.valueOf(enableAdminConsoleProp);
         }
         return enableAdminConsole;
+    }
+
+    /**
+     * Check if microsecond truncate is enabled in log management configuration.
+     *
+     * @return true if microsecond truncate is enabled, false otherwise
+     */
+    public static boolean isMicrosecondTruncateEnabled() {
+
+        boolean truncateToMicroseconds = false;
+        String truncateToMicrosecondsProp =
+                ServerConfiguration.getInstance().getFirstProperty(LOG_MGT_TRUNCATE_TO_MICROSECONDS);
+        if (truncateToMicrosecondsProp != null) {
+            truncateToMicroseconds = Boolean.parseBoolean(truncateToMicrosecondsProp);
+        }
+        return truncateToMicroseconds;
     }
 
     /**

--- a/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/DiagnosticLog.java
+++ b/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/DiagnosticLog.java
@@ -21,6 +21,7 @@ package org.wso2.carbon.utils;
 import org.slf4j.MDC;
 
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
@@ -55,6 +56,9 @@ public class DiagnosticLog {
                          Map<String, Object> input, Map<String, Object> configurations) {
 
         this.logId = logId;
+        if (CarbonUtils.isMicrosecondTruncateEnabled()) {
+            recordedAt = recordedAt.truncatedTo(ChronoUnit.MICROS);
+        }
         this.recordedAt = recordedAt;
         this.requestId = requestId;
         this.flowId = flowId;
@@ -308,6 +312,9 @@ public class DiagnosticLog {
             }
             logId = UUID.randomUUID().toString();
             recordedAt = Instant.now();
+            if (CarbonUtils.isMicrosecondTruncateEnabled()) {
+                recordedAt = recordedAt.truncatedTo(ChronoUnit.MICROS);
+            }
             requestId = MDC.get(CORRELATION_ID_MDC);
             flowId = MDC.get(FLOW_ID_MDC);
             if (this.logDetailLevel == null) {

--- a/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/DiagnosticLog.java
+++ b/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/DiagnosticLog.java
@@ -21,7 +21,6 @@ package org.wso2.carbon.utils;
 import org.slf4j.MDC;
 
 import java.time.Instant;
-import java.time.temporal.ChronoUnit;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
@@ -56,9 +55,6 @@ public class DiagnosticLog {
                          Map<String, Object> input, Map<String, Object> configurations) {
 
         this.logId = logId;
-        if (CarbonUtils.isMicrosecondTruncateEnabled()) {
-            recordedAt = recordedAt.truncatedTo(ChronoUnit.MICROS);
-        }
         this.recordedAt = recordedAt;
         this.requestId = requestId;
         this.flowId = flowId;
@@ -312,9 +308,6 @@ public class DiagnosticLog {
             }
             logId = UUID.randomUUID().toString();
             recordedAt = Instant.now();
-            if (CarbonUtils.isMicrosecondTruncateEnabled()) {
-                recordedAt = recordedAt.truncatedTo(ChronoUnit.MICROS);
-            }
             requestId = MDC.get(CORRELATION_ID_MDC);
             flowId = MDC.get(FLOW_ID_MDC);
             if (this.logDetailLevel == null) {

--- a/distribution/kernel/carbon-home/repository/conf/carbon.xml
+++ b/distribution/kernel/carbon-home/repository/conf/carbon.xml
@@ -742,6 +742,9 @@
             <Period>15</Period>
         </ConfigSync>
     </RemoteLogging>
+    <LogMgt>
+        <TruncateToMicroseconds>false</TruncateToMicroseconds>
+    </LogMgt>
 
     <!-- Configure default management ui path for server -->
     <DefaultManagementUIPath>carbon</DefaultManagementUIPath>

--- a/distribution/kernel/carbon-home/repository/conf/carbon.xml
+++ b/distribution/kernel/carbon-home/repository/conf/carbon.xml
@@ -743,7 +743,9 @@
         </ConfigSync>
     </RemoteLogging>
     <LogMgt>
-        <TruncateToMicroseconds>false</TruncateToMicroseconds>
+        <AuditLog>
+            <TruncateToMicroseconds>false</TruncateToMicroseconds>
+        </AuditLog>
     </LogMgt>
 
     <!-- Configure default management ui path for server -->

--- a/distribution/kernel/carbon-home/repository/resources/conf/templates/repository/conf/carbon.xml.j2
+++ b/distribution/kernel/carbon-home/repository/resources/conf/templates/repository/conf/carbon.xml.j2
@@ -892,6 +892,12 @@
         <EnableEncryption>{{remote_logging.encrypt_secrets}}</EnableEncryption>
     </RemoteLogging>
 
+    {% if log_mgt.truncate_to_microseconds is defined %}
+    <LogMgt>
+        <TruncateToMicroseconds>{{log_mgt.truncate_to_microseconds}}</TruncateToMicroseconds>
+    </LogMgt>
+    {% endif %}
+
     {% if default_management_ui.path is defined %}
     <!-- Configure default management ui path for server -->
     <DefaultManagementUIPath>{{default_management_ui.path}}</DefaultManagementUIPath>

--- a/distribution/kernel/carbon-home/repository/resources/conf/templates/repository/conf/carbon.xml.j2
+++ b/distribution/kernel/carbon-home/repository/resources/conf/templates/repository/conf/carbon.xml.j2
@@ -892,9 +892,11 @@
         <EnableEncryption>{{remote_logging.encrypt_secrets}}</EnableEncryption>
     </RemoteLogging>
 
-    {% if log_mgt.truncate_to_microseconds is defined %}
+    {% if log_mgt.audit_log.truncate_to_microseconds is defined %}
     <LogMgt>
-        <TruncateToMicroseconds>{{log_mgt.truncate_to_microseconds}}</TruncateToMicroseconds>
+        <AuditLog>
+            <TruncateToMicroseconds>{{log_mgt.audit_log.truncate_to_microseconds}}</TruncateToMicroseconds>
+        </AuditLog>
     </LogMgt>
     {% endif %}
 


### PR DESCRIPTION
## Purpose
- With the java 21 support it will generate the timestamps in nano second precision. To keep the previous behaviour we need to forcefully convert the timestamp to micro seconds. 
- Now the recordedAt property will be forced to convert to micro seconds by checking the config (`log_mgt.audit_log.truncate_to_microseconds`). 
- By default there will be no change as this is disabled. Only if we enabled by adding below to deployment.toml recordedAt property will forced to convert to micro second precision.

```bash
[log_mgt]
audit_log.truncate_to_microseconds = true
```

Test runner: https://github.com/Malith-19/product-is/actions/runs/21199868228


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Added LogMgt.TruncateToMicroseconds configuration option to enable microsecond truncation of logging timestamps in audit and diagnostic logs (disabled by default)

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->