### PR TITLE
[master] Reset pagination cookie for new search bases

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/UniqueIDReadOnlyLDAPUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/UniqueIDReadOnlyLDAPUserStoreManager.java
@@ -3294,8 +3294,9 @@ public class UniqueIDReadOnlyLDAPUserStoreManager extends ReadOnlyLDAPUserStoreM
                     pageSize));
         }
         try {
+            List<User> usersList = new ArrayList<>();
+            String userNameAttribute = realmConfig.getUserStoreProperty(LDAPConstants.USER_NAME_ATTRIBUTE);
             for (String searchBase : searchBaseArray) {
-                List<User> usersList = new ArrayList<>();
                 do {
                     List<User> tempUsersList = new ArrayList<>();
                     answer = ldapContext.search(escapeDNForSearch(searchBase), searchFilter, searchControls);
@@ -3353,19 +3354,21 @@ public class UniqueIDReadOnlyLDAPUserStoreManager extends ReadOnlyLDAPUserStoreM
                         }
                     }
                     cookie = parseControls(ldapContext.getResponseControls());
-                    String userNameAttribute = realmConfig.getUserStoreProperty(LDAPConstants.USER_NAME_ATTRIBUTE);
                     ldapContext.setRequestControls(new Control[]{new PagedResultsControl(pageSize, cookie,
                             Control.CRITICAL), new SortControl(userNameAttribute, Control.NONCRITICAL)});
                 } while ((cookie != null) && (cookie.length != 0));
-                if (CollectionUtils.isNotEmpty(usersList)) {
-                    // Here we show the remaining users in the final page if we have any.
-                    pageIndex++;
-                    if (isMemberShipPropertyFound) {
-                        users = membershipGroupFilterPostProcessing(isUsernameFiltering, isClaimFiltering,
-                                expressionConditions, usersList);
-                    } else {
-                        generatePaginatedUserList(pageIndex, offset, pageSize, usersList, users);
-                    }
+                // Reset paging cookie for new search base.
+                ldapContext.setRequestControls(new Control[]{new PagedResultsControl(pageSize, null,
+                        Control.CRITICAL), new SortControl(userNameAttribute, Control.NONCRITICAL)});
+            }
+            if (CollectionUtils.isNotEmpty(usersList)) {
+                // Here we show the remaining users in the final page if we have any.
+                pageIndex++;
+                if (isMemberShipPropertyFound) {
+                    users = membershipGroupFilterPostProcessing(isUsernameFiltering, isClaimFiltering,
+                            expressionConditions, usersList);
+                } else {
+                    generatePaginatedUserList(pageIndex, offset, pageSize, usersList, users);
                 }
             }
         } catch (PartialResultException e) {


### PR DESCRIPTION
### Purpose

`LDAP: error code 53 - Invalid cookie for this PagedSearch request.` error is throw with user retrieval with multiple user search bases in LDAP/AD. This happens because the pagination cookie from the previous search base [1] is incorrectly reused for the subsequent search base. As a result, the search fails when the LDAP context associated with the new search base attempts to use the old cookie [2].

[1] - https://github.com/wso2/carbon-kernel/blob/a286224351c7d2ab0875a91fe51eaf3b61a312d2/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/UniqueIDReadOnlyLDAPUserStoreManager.java#L3350-L3353

[2] - https://github.com/wso2/carbon-kernel/blob/a286224351c7d2ab0875a91fe51eaf3b61a312d2/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/UniqueIDReadOnlyLDAPUserStoreManager.java#L3296


This fix will reset the cookie to `null` for new user search bases and minor bug fix in `pageIndex` increment logic to cater multiple user search bases.

### Related Issues
- https://github.com/wso2/product-is/issues/26537

### Related PRs
- https://github.com/wso2/identity-apps/pull/9575