### PR TITLE
[master] Perform a case-insensitive check for binary attributes

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/ReadOnlyLDAPUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/ReadOnlyLDAPUserStoreManager.java
@@ -4799,7 +4799,11 @@ public class ReadOnlyLDAPUserStoreManager extends AbstractUserStoreManager {
                 log.debug("LDAP binary attributes: " + Arrays.toString(ldapBinaryAttributes));
             }
 
-            return ArrayUtils.contains(ldapBinaryAttributes, attributeName);
+            String normalizedAttribute = StringUtils.trimToEmpty(attributeName);
+            return Arrays.stream(ldapBinaryAttributes)
+                    .filter(StringUtils::isNotBlank)
+                    .map(StringUtils::trimToEmpty)
+                    .anyMatch(attr -> StringUtils.equalsIgnoreCase(attr, normalizedAttribute));
         }
         return false;
     }


### PR DESCRIPTION
### Purpose
By default, `objectGuid` is a binary attribute, and Active Directory expects it to be handled as a binary value in the calls made from WSO2 IS.

However, `objectGuid` is set in string format at IS end, and it needs to be converted into byte code [1][2] before being sent to AD. When determining whether an attribute is configured as a `BinaryAttribute` under the user store configurations [3], the check is performed in a case-insensitive manner [4]. As a result, `objectGuid` (when configured as `objectGUID`) is skipped during the binary conversion process because `isBinaryUserAttribute` returns `false`.

Consequently, AD fails to retrieve the user record corresponding to the given objectGuid and sets returnedUserEntry to `""`. This results in an error during the profile update flow when the modified attributes are sent back to AD [5], as the entry is erroneous and contains the value `""`.

[1] https://github.com/wso2/carbon-kernel/blob/ebb81dbc8ed30d294d1a8ba39eae945e0a8c09b1/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/UniqueIDActiveDirectoryUserStoreManager.java#L814
[2] https://github.com/wso2/carbon-kernel/blob/ebb81dbc8ed30d294d1a8ba39eae945e0a8c09b1/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/UniqueIDReadWriteLDAPUserStoreManager.java#L1035
[3] https://github.com/wso2/carbon-kernel/blob/ebb81dbc8ed30d294d1a8ba39eae945e0a8c09b1/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/ReadOnlyLDAPUserStoreManager.java#L4790
[4] https://github.com/wso2/carbon-kernel/blob/ebb81dbc8ed30d294d1a8ba39eae945e0a8c09b1/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/ReadOnlyLDAPUserStoreManager.java#L4802
[5] https://github.com/wso2/carbon-kernel/blob/ebb81dbc8ed30d294d1a8ba39eae945e0a8c09b1/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/UniqueIDReadWriteLDAPUserStoreManager.java#L1115


### Related Issues
- https://github.com/wso2/product-is/issues/26447


