### PR TITLE
Support for HSM-backed Keystores for Signing and Encryption

### DIFF
--- a/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/RegistryResources.java
+++ b/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/RegistryResources.java
@@ -145,6 +145,12 @@ public final class RegistryResources {
         public static final String SERVER_PRIVATE_KEY_PASSWORD = "Security.KeyStore.KeyPassword";
         public static final String SERVER_PRIMARY_KEYSTORE_TYPE = "Security.KeyStore.Type";
 
+        //HSM key store
+        public static final String SERVER_HSM_KEYSTORE_ENABLED = "Security.HSMKeyStore.Enabled";
+        public static final String SERVER_HSM_KEYSTORE_PROVIDER_CONFIG_FILE = "Security.HSMKeyStore.ProviderConfiguration";
+        public static final String SERVER_HSM_KEYSTORE_PASSWORD = "Security.HSMKeyStore.Password";
+        public static final String SERVER_HSM_KEYSTORE_KEY_ALIAS = "Security.HSMKeyStore.KeyAlias";
+
         public static final String DEFAULT_SECURITY_CERTIFICATE_ALIAS = "wso2carbon";
 
         //Registry store

--- a/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/util/KeyStoreManager.java
+++ b/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/util/KeyStoreManager.java
@@ -603,9 +603,7 @@ public class KeyStoreManager {
             KeyStoreException, CertificateException, IOException, NoSuchAlgorithmException, CarbonException {
 
         if (tenantId == MultitenantConstants.SUPER_TENANT_ID) {
-            if (log.isDebugEnabled()) {
-                log.debug("Loading HSM key store.");
-            }
+            log.debug("Loading HSM key store.");
             Provider pkcs11 = Security.getProvider(SUN_PKCS11);
             pkcs11 = pkcs11.configure(this.getServerConfigService()
                     .getFirstProperty(RegistryResources.SecurityManagement.SERVER_HSM_KEYSTORE_PROVIDER_CONFIG_FILE));
@@ -616,7 +614,7 @@ public class KeyStoreManager {
             log.info("HSM keystore loaded successfully.");
             return ks;
         }
-        throw new CarbonException(String.format(PERMISSION_DENIED_ERROR, "primary key store", "primary key store"));
+        throw new CarbonException(String.format(PERMISSION_DENIED_ERROR, "HSM key store", "HSM key store"));
     }
 
     /**

--- a/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/util/KeyStoreManager.java
+++ b/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/util/KeyStoreManager.java
@@ -554,6 +554,7 @@ public class KeyStoreManager {
 
                 ServerConfigurationService config = this.getServerConfigService();
                 if (isHSMEnabled()) {
+                    log.info("HSM keystore is enabled. Loading HSM keystore.");
                     primaryKeyStore = getHSMKeyStore();
                 } else {
                     String file =
@@ -611,6 +612,7 @@ public class KeyStoreManager {
         KeyStore ks = KeyStore.getInstance(PKCS11, pkcs11);
         ks.load(null, this.getServerConfigService()
                 .getFirstProperty(RegistryResources.SecurityManagement.SERVER_HSM_KEYSTORE_PASSWORD).toCharArray());
+        log.info("HSM keystore loaded successfully.");
         return ks;
     }
 

--- a/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/util/KeyStoreManager.java
+++ b/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/util/KeyStoreManager.java
@@ -51,7 +51,9 @@ import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.NoSuchProviderException;
 import java.security.PrivateKey;
+import java.security.Provider;
 import java.security.PublicKey;
+import java.security.Security;
 import java.security.UnrecoverableKeyException;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
@@ -90,6 +92,9 @@ public class KeyStoreManager {
     private static final String KEY_STORE_NAME_NULL_ERROR = "Key store name is null or empty.";
     private static final String PERMISSION_DENIED_ERROR = "Permission denied for accessing %s. The %s is " +
             "available only for the super tenant.";
+
+    private static final String SUN_PKCS11 = "SunPKCS11";
+    private static final String PKCS11 = "PKCS11";
 
     /**
      * Private Constructor of the KeyStoreManager
@@ -548,23 +553,65 @@ public class KeyStoreManager {
             if (primaryKeyStore == null) {
 
                 ServerConfigurationService config = this.getServerConfigService();
-                String file =
-                        new File(config
-                                .getFirstProperty(RegistryResources.SecurityManagement.SERVER_PRIMARY_KEYSTORE_FILE))
-                                .getAbsolutePath();
-                KeyStore store = KeystoreUtils.getKeystoreInstance(config
-                                .getFirstProperty(RegistryResources.SecurityManagement.SERVER_PRIMARY_KEYSTORE_TYPE));
-                String password = config
-                        .getFirstProperty(RegistryResources.SecurityManagement.SERVER_PRIMARY_KEYSTORE_PASSWORD);
-                try (FileInputStream in = new FileInputStream(file)) {
-                    store.load(in, password.toCharArray());
-                    primaryKeyStore = store;
+                if (isHSMEnabled()) {
+                    primaryKeyStore = getHSMKeyStore();
+                } else {
+                    String file =
+                            new File(config
+                                    .getFirstProperty(RegistryResources.SecurityManagement.SERVER_PRIMARY_KEYSTORE_FILE))
+                                    .getAbsolutePath();
+                    KeyStore store = KeystoreUtils.getKeystoreInstance(config
+                            .getFirstProperty(RegistryResources.SecurityManagement.SERVER_PRIMARY_KEYSTORE_TYPE));
+                    String password = config
+                            .getFirstProperty(RegistryResources.SecurityManagement.SERVER_PRIMARY_KEYSTORE_PASSWORD);
+                    try (FileInputStream in = new FileInputStream(file)) {
+                        store.load(in, password.toCharArray());
+                        primaryKeyStore = store;
+                    }
                 }
             }
             return primaryKeyStore;
         } else {
             throw new CarbonException(String.format(PERMISSION_DENIED_ERROR, "primary key store", "primary key store"));
         }
+    }
+
+    /**
+     * Check whether HSM based keystore is enabled or not.
+     * @return true if HSM based keystore is enabled, false otherwise.
+     */
+    private boolean isHSMEnabled() {
+
+        return Boolean.parseBoolean(this.getServerConfigService()
+                .getFirstProperty(RegistryResources.SecurityManagement.SERVER_HSM_KEYSTORE_ENABLED));
+    }
+
+    /**
+     * Load the HSM key store
+     *
+     * @return HSM key store object
+     * @throws KeyStoreException        if KeyStoreSpi implementation for the specified type is not available from the
+     *                                  specified Provider object.
+     * @throws CertificateException     if any of the certificates in the keystore could not be loaded.
+     * @throws IOException              if there is an I/O or format problem with the keystore data, if a password is required but
+     *                                  not given, or if the given password was incorrect.
+     * @throws NoSuchAlgorithmException if the algorithm used to check the integrity of the keystore cannot be found.
+     *
+     */
+    public KeyStore getHSMKeyStore() throws
+            KeyStoreException, CertificateException, IOException, NoSuchAlgorithmException {
+
+        if (log.isDebugEnabled()) {
+            log.debug("Loading HSM key store.");
+        }
+        Provider pkcs11 = Security.getProvider(SUN_PKCS11);
+        pkcs11 = pkcs11.configure(this.getServerConfigService()
+                .getFirstProperty(RegistryResources.SecurityManagement.SERVER_HSM_KEYSTORE_PROVIDER_CONFIG_FILE));
+        Security.addProvider(pkcs11);
+        KeyStore ks = KeyStore.getInstance(PKCS11, pkcs11);
+        ks.load(null, this.getServerConfigService()
+                .getFirstProperty(RegistryResources.SecurityManagement.SERVER_HSM_KEYSTORE_PASSWORD).toCharArray());
+        return ks;
     }
 
     /**
@@ -764,11 +811,19 @@ public class KeyStoreManager {
         }
         if (tenantId == MultitenantConstants.SUPER_TENANT_ID) {
             ServerConfigurationService config = this.getServerConfigService();
-            String password = config
-                    .getFirstProperty(RegistryResources.SecurityManagement.SERVER_PRIMARY_KEYSTORE_PASSWORD);
-            String alias = config
-                    .getFirstProperty(RegistryResources.SecurityManagement.SERVER_PRIMARY_KEYSTORE_KEY_ALIAS);
-            return (PrivateKey) primaryKeyStore.getKey(alias, password.toCharArray());
+            if (isHSMEnabled()) {
+                String alias = config
+                        .getFirstProperty(RegistryResources.SecurityManagement.SERVER_HSM_KEYSTORE_KEY_ALIAS);
+                String password = config
+                        .getFirstProperty(RegistryResources.SecurityManagement.SERVER_HSM_KEYSTORE_PASSWORD);
+                return (PrivateKey) primaryKeyStore.getKey(alias, password.toCharArray());
+            } else {
+                String password = config
+                        .getFirstProperty(RegistryResources.SecurityManagement.SERVER_PRIMARY_KEYSTORE_PASSWORD);
+                String alias = config
+                        .getFirstProperty(RegistryResources.SecurityManagement.SERVER_PRIMARY_KEYSTORE_KEY_ALIAS);
+                return (PrivateKey) primaryKeyStore.getKey(alias, password.toCharArray());
+            }
         }
         throw new CarbonException(String.format(PERMISSION_DENIED_ERROR, "primary key store", "primary key store"));
     }

--- a/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/util/KeyStoreManager.java
+++ b/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/util/KeyStoreManager.java
@@ -602,18 +602,21 @@ public class KeyStoreManager {
     public KeyStore getHSMKeyStore() throws
             KeyStoreException, CertificateException, IOException, NoSuchAlgorithmException {
 
-        if (log.isDebugEnabled()) {
-            log.debug("Loading HSM key store.");
+        if (tenantId == MultitenantConstants.SUPER_TENANT_ID) {
+            if (log.isDebugEnabled()) {
+                log.debug("Loading HSM key store.");
+            }
+            Provider pkcs11 = Security.getProvider(SUN_PKCS11);
+            pkcs11 = pkcs11.configure(this.getServerConfigService()
+                    .getFirstProperty(RegistryResources.SecurityManagement.SERVER_HSM_KEYSTORE_PROVIDER_CONFIG_FILE));
+            Security.addProvider(pkcs11);
+            KeyStore ks = KeyStore.getInstance(PKCS11, pkcs11);
+            ks.load(null, this.getServerConfigService()
+                    .getFirstProperty(RegistryResources.SecurityManagement.SERVER_HSM_KEYSTORE_PASSWORD).toCharArray());
+            log.info("HSM keystore loaded successfully.");
+            return ks;
         }
-        Provider pkcs11 = Security.getProvider(SUN_PKCS11);
-        pkcs11 = pkcs11.configure(this.getServerConfigService()
-                .getFirstProperty(RegistryResources.SecurityManagement.SERVER_HSM_KEYSTORE_PROVIDER_CONFIG_FILE));
-        Security.addProvider(pkcs11);
-        KeyStore ks = KeyStore.getInstance(PKCS11, pkcs11);
-        ks.load(null, this.getServerConfigService()
-                .getFirstProperty(RegistryResources.SecurityManagement.SERVER_HSM_KEYSTORE_PASSWORD).toCharArray());
-        log.info("HSM keystore loaded successfully.");
-        return ks;
+        return null;
     }
 
     /**
@@ -924,7 +927,9 @@ public class KeyStoreManager {
             String alias = isHSMEnabled() ?  config
                     .getFirstProperty(RegistryResources.SecurityManagement.SERVER_HSM_KEYSTORE_KEY_ALIAS) :
                     config.getFirstProperty(RegistryResources.SecurityManagement.SERVER_PRIMARY_KEYSTORE_KEY_ALIAS);
-            log.debug("Loading primary key store public certificate with alias: " + alias);
+            if (log.isDebugEnabled()) {
+                log.debug("Loading primary key store public certificate with alias: " + alias);
+            }
             return (X509Certificate) getPrimaryKeyStore().getCertificate(alias);
         }
         throw new CarbonException(String.format(PERMISSION_DENIED_ERROR, "primary key store", "primary key store"));

--- a/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/util/KeyStoreManager.java
+++ b/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/util/KeyStoreManager.java
@@ -921,8 +921,10 @@ public class KeyStoreManager {
         }
         if (tenantId == MultitenantConstants.SUPER_TENANT_ID) {
             ServerConfigurationService config = this.getServerConfigService();
-            String alias = config
-                    .getFirstProperty(RegistryResources.SecurityManagement.SERVER_PRIMARY_KEYSTORE_KEY_ALIAS);
+            String alias = isHSMEnabled() ?  config
+                    .getFirstProperty(RegistryResources.SecurityManagement.SERVER_HSM_KEYSTORE_KEY_ALIAS) :
+                    config.getFirstProperty(RegistryResources.SecurityManagement.SERVER_PRIMARY_KEYSTORE_KEY_ALIAS);
+            log.debug("Loading primary key store public certificate with alias: " + alias);
             return (X509Certificate) getPrimaryKeyStore().getCertificate(alias);
         }
         throw new CarbonException(String.format(PERMISSION_DENIED_ERROR, "primary key store", "primary key store"));

--- a/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/util/KeyStoreManager.java
+++ b/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/util/KeyStoreManager.java
@@ -600,7 +600,7 @@ public class KeyStoreManager {
      *
      */
     public KeyStore getHSMKeyStore() throws
-            KeyStoreException, CertificateException, IOException, NoSuchAlgorithmException {
+            KeyStoreException, CertificateException, IOException, NoSuchAlgorithmException, CarbonException {
 
         if (tenantId == MultitenantConstants.SUPER_TENANT_ID) {
             if (log.isDebugEnabled()) {
@@ -616,7 +616,7 @@ public class KeyStoreManager {
             log.info("HSM keystore loaded successfully.");
             return ks;
         }
-        return null;
+        throw new CarbonException(String.format(PERMISSION_DENIED_ERROR, "primary key store", "primary key store"));
     }
 
     /**

--- a/distribution/kernel/carbon-home/repository/resources/conf/templates/repository/conf/carbon.xml.j2
+++ b/distribution/kernel/carbon-home/repository/resources/conf/templates/repository/conf/carbon.xml.j2
@@ -535,6 +535,16 @@
             <!-- Keystore type (JKS/PKCS12 etc.)-->
             <Type>{{keystore.tenant.type}}</Type>
         </TenantKeyStore>
+        <!-- KeyStore configurations for HSM.-->
+        <HSMKeyStore>
+            <Enabled>{{keystore.hsm.enabled}}</Enabled>
+            <!-- Provider Configuration file location-->
+            <ProviderConfiguration>${carbon.home}/repository/resources/security/{{keystore.hsm.provider_configuration}}</ProviderConfiguration>
+            <!-- Keystore password-->
+            <Password>{{keystore.hsm.pin}}</Password>
+            <!-- Private Key alias-->
+            <KeyAlias>{{keystore.hsm.alias}}</KeyAlias>
+        </HSMKeyStore>
 
         <!--
             The KeyStore which is used for encrypting/decrypting internal data.


### PR DESCRIPTION
## Purpose
This pr adds support to configure and load a HSM keystore via the PKCS11 API.

### deployment.toml configuration
```
[keystore.hsm]
enabled = true
pin = "hsm_pin"
alias = "hsm_key_alias"
provider_configuration = "pkcs11.cfg"
```

### Related Issue
https://github.com/wso2/product-is/issues/26706