### PR TITLE
Enforce mandatory JDK 21 requirement in wso2server.sh

### DIFF
--- a/distribution/kernel/carbon-home/bin/wso2server.sh
+++ b/distribution/kernel/carbon-home/bin/wso2server.sh
@@ -213,9 +213,11 @@ fi
 # ---------- Handle the SSL Issue with proper JDK version --------------------
 java_version=$("$JAVACMD" -version 2>&1 | awk -F '"' '/version/ {print $2}')
 java_version_formatted=$(echo "$java_version" | awk -F. '{printf("%02d%02d",$1,$2);}')
-if [ $java_version_formatted -lt 1100 ] || [ $java_version_formatted -gt 2100 ]; then
-   echo " Starting WSO2 Carbon (in unsupported JDK)"
-   echo " [ERROR] CARBON is supported only between JDK 11 and JDK 21"
+if [ "$java_version_formatted" -lt 2100 ]; then
+   echo " [ERROR] WSO2 Identity Server requires JDK 21 or higher."
+   echo " [ERROR] Current Java version detected: $java_version"
+   echo " [ERROR] Please set JAVA_HOME to a JDK 21 or higher installation and try again."
+   exit 1
 fi
 
 CARBON_XBOOTCLASSPATH=""


### PR DESCRIPTION
## Purpose
This PR updates the wso2server.sh startup script to strictly enforce the use of JDK 21. Previously, the script allowed a range between JDK 11 and JDK 21, but current requirements for the WSO2 Identity Server now mandate version 21 specifically to ensure compatibility and stability.

## Testing
### Before


https://github.com/user-attachments/assets/e6b77855-d9a9-443f-accf-8ba7d1aa73bf

### After

https://github.com/user-attachments/assets/4230df29-e61e-48dc-b130-230171364115