### PR TITLE
Add EdDSA key support

### DIFF
--- a/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/util/KeyStoreManager.java
+++ b/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/util/KeyStoreManager.java
@@ -834,7 +834,13 @@ public class KeyStoreManager {
             ServerConfigurationService config = this.getServerConfigService();
             String password = config
                     .getFirstProperty(RegistryResources.SecurityManagement.SERVER_PRIMARY_KEYSTORE_PASSWORD);
-            return (PrivateKey) getPrimaryKeyStore().getKey(alias, password.toCharArray());
+            KeyStore primaryKeyStore;
+            try {
+                primaryKeyStore = getPrimaryKeyStore();
+            } catch (Exception e) {
+                throw new CarbonException("Error getting primary key store.", e);
+            }
+            return (PrivateKey) primaryKeyStore.getKey(alias, password.toCharArray());
         }
         throw new CarbonException("Permission denied for accessing primary key store. The primary key store is " +
                 "available only for the super tenant.");

--- a/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/util/KeyStoreManager.java
+++ b/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/util/KeyStoreManager.java
@@ -851,7 +851,7 @@ public class KeyStoreManager {
             ServerConfigurationService config = this.getServerConfigService();
             String alias = config
                     .getFirstProperty(RegistryResources.SecurityManagement.SERVER_PRIMARY_KEYSTORE_KEY_ALIAS);
-            return primaryKeyStore.getCertificate(alias).getPublicKey();
+            return getPrimaryKeyStore().getCertificate(alias).getPublicKey();
         }
         throw new CarbonException(String.format(PERMISSION_DENIED_ERROR, "primary key store", "primary key store"));
     }
@@ -866,7 +866,11 @@ public class KeyStoreManager {
      */
     public PublicKey getDefaultPublicKey(String alias) throws CarbonException, KeyStoreException {
         if (tenantId == MultitenantConstants.SUPER_TENANT_ID) {
-            return primaryKeyStore.getCertificate(alias).getPublicKey();
+            try {
+                return getPrimaryKeyStore().getCertificate(alias).getPublicKey();
+            } catch (Exception e) {
+                throw new CarbonException("Error getting primary key store.", e);
+            }
         }
         throw new CarbonException("Permission denied for accessing primary key store. The primary key store is " +
                 "available only for the super tenant.");

--- a/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/util/KeyStoreManager.java
+++ b/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/util/KeyStoreManager.java
@@ -834,7 +834,7 @@ public class KeyStoreManager {
             ServerConfigurationService config = this.getServerConfigService();
             String password = config
                     .getFirstProperty(RegistryResources.SecurityManagement.SERVER_PRIMARY_KEYSTORE_PASSWORD);
-            return (PrivateKey) primaryKeyStore.getKey(alias, password.toCharArray());
+            return (PrivateKey) getPrimaryKeyStore().getKey(alias, password.toCharArray());
         }
         throw new CarbonException("Permission denied for accessing primary key store. The primary key store is " +
                 "available only for the super tenant.");

--- a/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/util/KeyStoreManager.java
+++ b/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/util/KeyStoreManager.java
@@ -821,6 +821,26 @@ public class KeyStoreManager {
     }
 
     /**
+     * Get the default private key, only allowed for tenant -1234
+     *
+     * @return Private key
+     * @throws CarbonException, UnrecoverableKeyException, KeyStoreException, NoSuchAlgorithmException
+     *         Exceptions while retrieving private key
+     */
+    public PrivateKey getDefaultPrivateKey(String alias) throws CarbonException,
+            UnrecoverableKeyException, KeyStoreException, NoSuchAlgorithmException {
+
+        if (tenantId == MultitenantConstants.SUPER_TENANT_ID) {
+            ServerConfigurationService config = this.getServerConfigService();
+            String password = config
+                    .getFirstProperty(RegistryResources.SecurityManagement.SERVER_PRIMARY_KEYSTORE_PASSWORD);
+            return (PrivateKey) primaryKeyStore.getKey(alias, password.toCharArray());
+        }
+        throw new CarbonException("Permission denied for accessing primary key store. The primary key store is " +
+                "available only for the super tenant.");
+    }
+
+    /**
      * Get default pub. key
      *
      * @return Public Key
@@ -831,7 +851,7 @@ public class KeyStoreManager {
             ServerConfigurationService config = this.getServerConfigService();
             String alias = config
                     .getFirstProperty(RegistryResources.SecurityManagement.SERVER_PRIMARY_KEYSTORE_KEY_ALIAS);
-            return (PublicKey) primaryKeyStore.getCertificate(alias).getPublicKey();
+            return primaryKeyStore.getCertificate(alias).getPublicKey();
         }
         throw new CarbonException(String.format(PERMISSION_DENIED_ERROR, "primary key store", "primary key store"));
     }

--- a/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/util/KeyStoreManager.java
+++ b/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/util/KeyStoreManager.java
@@ -834,13 +834,11 @@ public class KeyStoreManager {
             ServerConfigurationService config = this.getServerConfigService();
             String password = config
                     .getFirstProperty(RegistryResources.SecurityManagement.SERVER_PRIMARY_KEYSTORE_PASSWORD);
-            KeyStore primaryKeyStore;
             try {
-                primaryKeyStore = getPrimaryKeyStore();
+                return (PrivateKey) getPrimaryKeyStore().getKey(alias, password.toCharArray());
             } catch (Exception e) {
                 throw new CarbonException("Error getting primary key store.", e);
             }
-            return (PrivateKey) primaryKeyStore.getKey(alias, password.toCharArray());
         }
         throw new CarbonException("Permission denied for accessing primary key store. The primary key store is " +
                 "available only for the super tenant.");

--- a/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/util/KeyStoreManager.java
+++ b/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/util/KeyStoreManager.java
@@ -865,6 +865,7 @@ public class KeyStoreManager {
      * @throws KeyStoreException Exception while retrieving public key from keystore
      */
     public PublicKey getDefaultPublicKey(String alias) throws CarbonException, KeyStoreException {
+
         if (tenantId == MultitenantConstants.SUPER_TENANT_ID) {
             try {
                 return getPrimaryKeyStore().getCertificate(alias).getPublicKey();

--- a/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/util/KeyStoreManager.java
+++ b/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/util/KeyStoreManager.java
@@ -857,6 +857,22 @@ public class KeyStoreManager {
     }
 
     /**
+     * Get the public key by alias, only allowed for tenant -1234
+     *
+     * @param alias The alias of the public key to retrieve
+     * @return Public Key
+     * @throws CarbonException Exception Carbon Exception for tenants other than tenant -1234
+     * @throws KeyStoreException Exception while retrieving public key from keystore
+     */
+    public PublicKey getDefaultPublicKey(String alias) throws CarbonException, KeyStoreException {
+        if (tenantId == MultitenantConstants.SUPER_TENANT_ID) {
+            return primaryKeyStore.getCertificate(alias).getPublicKey();
+        }
+        throw new CarbonException("Permission denied for accessing primary key store. The primary key store is " +
+                "available only for the super tenant.");
+    }
+
+    /**
      * Get the private key password
      *
      * @return private key password

--- a/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/util/KeyStoreUtil.java
+++ b/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/util/KeyStoreUtil.java
@@ -40,6 +40,8 @@ import java.util.Iterator;
 
 import javax.xml.namespace.QName;
 
+import static org.wso2.carbon.utils.multitenancy.MultitenantConstants.TENANT_EC_KEY_SUFFIX;
+
 public class KeyStoreUtil {
 
     /**
@@ -51,9 +53,9 @@ public class KeyStoreUtil {
     public static String getPrivateKeyAlias(KeyStore store) throws KeyStoreException {
         String alias = null;
         Enumeration<String> enums = store.aliases();
-        while(enums.hasMoreElements()){
+        while (enums.hasMoreElements()) {
             String name = enums.nextElement();
-            if(store.isKeyEntry(name)){
+            if (store.isKeyEntry(name) && !name.endsWith(TENANT_EC_KEY_SUFFIX)) {
                 alias = name;
                 break;
             }
@@ -253,5 +255,40 @@ public class KeyStoreUtil {
         if (!Arrays.asList(keyStoreProperties).contains(propertyName)) {
             throw new CarbonException("Requested key store configuration is invalid.");
         }
+    }
+
+    /**
+     * Get tenant EC Key Alias
+     *
+     * @return Tenant EC Key Alias
+     * @throws CarbonException Exception Carbon Exception for tenants other than tenant -1234
+     */
+    public static String getTenantECKeyAlias(String tenantDomain) throws CarbonException {
+
+        if (StringUtils.isBlank(tenantDomain)) {
+            throw new CarbonException("Tenant domain must not be empty.");
+        } else {
+            return tenantDomain +  TENANT_EC_KEY_SUFFIX;
+        }
+    }
+
+
+    /**
+     * Get the primary key alias, only allowed for tenant -1234
+     *
+     * @param keyStore Primary Key Store
+     * @return Primary Key Alias
+     * @throws KeyStoreException Exception for invalid primary key alias
+     */
+    public static String getPrimaryKeyAlias(KeyStore keyStore) throws KeyStoreException {
+
+        ServerConfigurationService config = CarbonCoreDataHolder.getInstance().getServerConfigurationService();
+        String alias = StringUtils.trim(config.getFirstProperty(RegistryResources.SecurityManagement
+                .SERVER_PRIMARY_KEYSTORE_KEY_ALIAS));
+        if (StringUtils.isBlank(alias) || !keyStore.isKeyEntry(alias)) {
+            throw new IllegalStateException("Configured primary keystore key alias is invalid " +
+                    "or does not exist as a key entry");
+        }
+        return alias;
     }
 }

--- a/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/util/KeyStoreUtil.java
+++ b/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/util/KeyStoreUtil.java
@@ -43,6 +43,7 @@ import javax.xml.namespace.QName;
 public class KeyStoreUtil {
 
     private static final String TENANT_EDDSA_KEY_SUFFIX = "_ed";
+
     /**
      * KeyStore name will be here.
      * 
@@ -269,25 +270,5 @@ public class KeyStoreUtil {
         } else {
             return tenantDomain +  TENANT_EDDSA_KEY_SUFFIX;
         }
-    }
-
-
-    /**
-     * Get the primary key alias, only allowed for tenant -1234
-     *
-     * @param keyStore Primary Key Store
-     * @return Primary Key Alias
-     * @throws KeyStoreException Exception for invalid primary key alias
-     */
-    public static String getPrimaryKeyAlias(KeyStore keyStore) throws KeyStoreException {
-
-        ServerConfigurationService config = CarbonCoreDataHolder.getInstance().getServerConfigurationService();
-        String alias = StringUtils.trim(config.getFirstProperty(RegistryResources.SecurityManagement
-                .SERVER_PRIMARY_KEYSTORE_KEY_ALIAS));
-        if (StringUtils.isBlank(alias) || !keyStore.isKeyEntry(alias)) {
-            throw new IllegalStateException("Configured primary keystore key alias is invalid " +
-                    "or does not exist as a key entry");
-        }
-        return alias;
     }
 }

--- a/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/util/KeyStoreUtil.java
+++ b/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/util/KeyStoreUtil.java
@@ -41,6 +41,7 @@ import java.util.Iterator;
 import javax.xml.namespace.QName;
 
 import static org.wso2.carbon.utils.multitenancy.MultitenantConstants.TENANT_EC_KEY_SUFFIX;
+import static org.wso2.carbon.utils.multitenancy.MultitenantConstants.TENANT_ED_KEY_SUFFIX;
 
 public class KeyStoreUtil {
 
@@ -55,7 +56,7 @@ public class KeyStoreUtil {
         Enumeration<String> enums = store.aliases();
         while (enums.hasMoreElements()) {
             String name = enums.nextElement();
-            if (store.isKeyEntry(name) && !name.endsWith(TENANT_EC_KEY_SUFFIX)) {
+            if (store.isKeyEntry(name) && !name.endsWith(TENANT_EC_KEY_SUFFIX) && !name.endsWith(TENANT_ED_KEY_SUFFIX)) {
                 alias = name;
                 break;
             }
@@ -269,6 +270,21 @@ public class KeyStoreUtil {
             throw new CarbonException("Tenant domain must not be empty.");
         } else {
             return tenantDomain +  TENANT_EC_KEY_SUFFIX;
+        }
+    }
+
+    /**
+     * Get tenant EdDSA Key Alias
+     *
+     * @return Tenant EdDSA Key Alias
+     * @throws CarbonException Exception Carbon Exception for tenants other than tenant -1234
+     */
+    public static String getTenantEdKeyAlias(String tenantDomain) throws CarbonException {
+
+        if (StringUtils.isBlank(tenantDomain)) {
+            throw new CarbonException("Tenant domain must not be empty.");
+        } else {
+            return tenantDomain +  TENANT_ED_KEY_SUFFIX;
         }
     }
 

--- a/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/util/KeyStoreUtil.java
+++ b/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/util/KeyStoreUtil.java
@@ -40,10 +40,9 @@ import java.util.Iterator;
 
 import javax.xml.namespace.QName;
 
-import static org.wso2.carbon.utils.multitenancy.MultitenantConstants.TENANT_ED_KEY_SUFFIX;
-
 public class KeyStoreUtil {
 
+    private static final String TENANT_EDDSA_KEY_SUFFIX = "_ed";
     /**
      * KeyStore name will be here.
      * 
@@ -55,7 +54,7 @@ public class KeyStoreUtil {
         Enumeration<String> enums = store.aliases();
         while (enums.hasMoreElements()) {
             String name = enums.nextElement();
-            if (store.isKeyEntry(name) && !name.endsWith(TENANT_ED_KEY_SUFFIX)) {
+            if (store.isKeyEntry(name) && !name.endsWith(TENANT_EDDSA_KEY_SUFFIX)) {
                 alias = name;
                 break;
             }
@@ -268,7 +267,7 @@ public class KeyStoreUtil {
         if (StringUtils.isBlank(tenantDomain)) {
             throw new CarbonException("Tenant domain must not be empty.");
         } else {
-            return tenantDomain +  TENANT_ED_KEY_SUFFIX;
+            return tenantDomain +  TENANT_EDDSA_KEY_SUFFIX;
         }
     }
 

--- a/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/util/KeyStoreUtil.java
+++ b/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/util/KeyStoreUtil.java
@@ -40,7 +40,6 @@ import java.util.Iterator;
 
 import javax.xml.namespace.QName;
 
-import static org.wso2.carbon.utils.multitenancy.MultitenantConstants.TENANT_EC_KEY_SUFFIX;
 import static org.wso2.carbon.utils.multitenancy.MultitenantConstants.TENANT_ED_KEY_SUFFIX;
 
 public class KeyStoreUtil {
@@ -56,7 +55,7 @@ public class KeyStoreUtil {
         Enumeration<String> enums = store.aliases();
         while (enums.hasMoreElements()) {
             String name = enums.nextElement();
-            if (store.isKeyEntry(name) && !name.endsWith(TENANT_EC_KEY_SUFFIX) && !name.endsWith(TENANT_ED_KEY_SUFFIX)) {
+            if (store.isKeyEntry(name) && !name.endsWith(TENANT_ED_KEY_SUFFIX)) {
                 alias = name;
                 break;
             }
@@ -255,21 +254,6 @@ public class KeyStoreUtil {
 
         if (!Arrays.asList(keyStoreProperties).contains(propertyName)) {
             throw new CarbonException("Requested key store configuration is invalid.");
-        }
-    }
-
-    /**
-     * Get tenant EC Key Alias
-     *
-     * @return Tenant EC Key Alias
-     * @throws CarbonException Exception Carbon Exception for tenants other than tenant -1234
-     */
-    public static String getTenantECKeyAlias(String tenantDomain) throws CarbonException {
-
-        if (StringUtils.isBlank(tenantDomain)) {
-            throw new CarbonException("Tenant domain must not be empty.");
-        } else {
-            return tenantDomain +  TENANT_EC_KEY_SUFFIX;
         }
     }
 

--- a/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/multitenancy/MultitenantConstants.java
+++ b/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/multitenancy/MultitenantConstants.java
@@ -37,6 +37,8 @@ public class MultitenantConstants {
     public static final String TENANT_DOMAIN_HEADER_NAMESPACE = "http://cloud.wso2.com/";
     public static final String TENANT_DOMAIN_HEADER_NAME = "TenantDomain";
     public static final String SUPER_TENANT_DOMAIN_NAME = "carbon.super";
+    // Introduced for tenant ec key pair generation
+    public static final String TENANT_EC_KEY_SUFFIX = "_ec";
     public static final int INVALID_TENANT_ID = -1;
 
     public static final String REQUIRE_SUPER_TENANT = "require-super-tenant";

--- a/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/multitenancy/MultitenantConstants.java
+++ b/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/multitenancy/MultitenantConstants.java
@@ -37,7 +37,6 @@ public class MultitenantConstants {
     public static final String TENANT_DOMAIN_HEADER_NAMESPACE = "http://cloud.wso2.com/";
     public static final String TENANT_DOMAIN_HEADER_NAME = "TenantDomain";
     public static final String SUPER_TENANT_DOMAIN_NAME = "carbon.super";
-    public static final String TENANT_EDDSA_KEY_SUFFIX = "_ed";
     public static final int INVALID_TENANT_ID = -1;
 
     public static final String REQUIRE_SUPER_TENANT = "require-super-tenant";

--- a/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/multitenancy/MultitenantConstants.java
+++ b/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/multitenancy/MultitenantConstants.java
@@ -39,6 +39,7 @@ public class MultitenantConstants {
     public static final String SUPER_TENANT_DOMAIN_NAME = "carbon.super";
     // Introduced for tenant ec key pair generation
     public static final String TENANT_EC_KEY_SUFFIX = "_ec";
+    public static final String TENANT_ED_KEY_SUFFIX = "_ed";
     public static final int INVALID_TENANT_ID = -1;
 
     public static final String REQUIRE_SUPER_TENANT = "require-super-tenant";

--- a/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/multitenancy/MultitenantConstants.java
+++ b/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/multitenancy/MultitenantConstants.java
@@ -37,8 +37,7 @@ public class MultitenantConstants {
     public static final String TENANT_DOMAIN_HEADER_NAMESPACE = "http://cloud.wso2.com/";
     public static final String TENANT_DOMAIN_HEADER_NAME = "TenantDomain";
     public static final String SUPER_TENANT_DOMAIN_NAME = "carbon.super";
-    // Introduced for tenant ec key pair generation
-    public static final String TENANT_EC_KEY_SUFFIX = "_ec";
+    // Introduced for tenant ed key pair generation
     public static final String TENANT_ED_KEY_SUFFIX = "_ed";
     public static final int INVALID_TENANT_ID = -1;
 

--- a/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/multitenancy/MultitenantConstants.java
+++ b/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/multitenancy/MultitenantConstants.java
@@ -37,8 +37,7 @@ public class MultitenantConstants {
     public static final String TENANT_DOMAIN_HEADER_NAMESPACE = "http://cloud.wso2.com/";
     public static final String TENANT_DOMAIN_HEADER_NAME = "TenantDomain";
     public static final String SUPER_TENANT_DOMAIN_NAME = "carbon.super";
-    // Introduced for tenant ed key pair generation
-    public static final String TENANT_ED_KEY_SUFFIX = "_ed";
+    public static final String TENANT_EDDSA_KEY_SUFFIX = "_ed";
     public static final int INVALID_TENANT_ID = -1;
 
     public static final String REQUIRE_SUPER_TENANT = "require-super-tenant";


### PR DESCRIPTION
## Purpose
This pull request introduces enhancements to the WSO2 IS key management utilities to natively support **EdDSA (Edwards-curve Digital Signature Algorithm)** keys. 

This is a critical prerequisite for implementing the **OpenID for Verifiable Presentations (OID4VP)** specification. Modern digital credential wallets (such as Inji, Sphereon, etc.) and SSI standards (like SD-JWT and Ed25519Signature2020) heavily prefer or mandate elliptic curve cryptography over traditional RSA.

These changes allow WSO2 IS to manage EdDSA keys alongside legacy RSA keys without breaking existing core authentication flows.

## Goals
* **Enable OID4VP Compatibility:** Provide the underlying cryptographic support required for WSO2 IS to act as an OID4VP Verifier, allowing it to sign Request Objects (JARs) using EdDSA.

## Technical Implementation Details

**1. EdDSA Key Alias and Tenant Support:**
* **`TENANT_ED_KEY_SUFFIX`:** Added a new constant to `MultitenantConstants` to standardize and strictly identify EdDSA key aliases for tenants.
* **`getTenantEdKeyAlias(String tenantDomain)`:** Introduced a utility method in `KeyStoreUtil` to predictably generate a tenant's EdDSA key alias, with validation for non empty tenant domains. This supports multi-tenant OID4VP setups.

**2. Key Alias Management and Backward Compatibility:**
* **`KeyStoreUtil.getPrivateKeyAlias(KeyStore store)`:** Updated to explicitly **skip** aliases ending with the new EdDSA key suffix. This is a crucial safeguard ensuring that standard WSO2 flows (which expect the primary RSA key) do not accidentally pick up the EdDSA key as the default.
* **`KeyStoreUtil.getPrimaryKeyAlias(KeyStore keyStore)`:** Added to retrieve and strictly validate the primary key alias from the configuration, ensuring it exists as a valid `KeyEntry`.

**3. Key Store Access Control Enhancements:**
* **`getDefaultPrivateKey(String alias)` & `getDefaultPublicKey(String alias)`:** Added to `KeyStoreManager` to allow direct retrieval of private/public keys by their specific alias. 
* **Security:** Restricted access of these specific retrieval methods to the super tenant only. An attempt to access them by other tenants will throw a `CarbonException`, improving error handling for unauthorized access.

## Documentation
There is no direct impact on end-user documentation. Internal developer guidelines may be updated to reflect the availability of the `TENANT_ED_KEY_SUFFIX` for future verifiable credential features.