### PR TITLE
Update debug command to work with Java 25

### DIFF
--- a/distribution/kernel/carbon-home/bin/wso2server.sh
+++ b/distribution/kernel/carbon-home/bin/wso2server.sh
@@ -170,7 +170,7 @@ if [ "$CMD" = "--debug" ]; then
     echo "Warning !!!. User specified JAVA_OPTS will be ignored, once you give the --debug option."
   fi
   CMD="RUN"
-  JAVA_OPTS="-Xdebug -Xnoagent -Djava.compiler=NONE -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=$PORT"
+  JAVA_OPTS="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:$PORT"
   echo "Please start the remote debugging client to continue..."
 elif [ "$CMD" = "start" ]; then
   if [ -e "$CARBON_HOME/wso2carbon.pid" ]; then


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated remote debugging configuration in server startup script to use modern JVM agent library syntax while maintaining existing remote debugging functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->