### PR TITLE
Fix: Downgrade FileUploadExecutorManager missing log to debug #4535

### DIFF
--- a/core/org.wso2.carbon.ui/src/main/java/org/wso2/carbon/ui/deployment/UIBundleDeployer.java
+++ b/core/org.wso2.carbon.ui/src/main/java/org/wso2/carbon/ui/deployment/UIBundleDeployer.java
@@ -266,7 +266,10 @@ public class UIBundleDeployer implements SynchronousBundleListener {
             FileUploadExecutorManager executorManager =
                     (FileUploadExecutorManager) fileUploadExecManagerTracker.getService();
             if (executorManager == null) {
-                log.error("FileUploadExecutorManager service is not available");
+                if (log.isDebugEnabled()) {
+                    log.debug("FileUploadExecutorManager service is not available. " +
+                            "Skipping file upload executor registration for component: " + component.getName());
+                }
                 return;
             }
             FileUploadExecutorConfig[] executorConfigs = component.getFileUploadExecutorConfigs();

--- a/core/org.wso2.carbon.ui/src/main/java/org/wso2/carbon/ui/deployment/UIBundleDeployer.java
+++ b/core/org.wso2.carbon.ui/src/main/java/org/wso2/carbon/ui/deployment/UIBundleDeployer.java
@@ -270,9 +270,13 @@ public class UIBundleDeployer implements SynchronousBundleListener {
                     log.debug("FileUploadExecutorManager service is not available. " +
                             "Skipping file upload executor registration for component: " + component.getName());
                 }
+                log.warn("FileUploadExecutorManager service is unavailable. File upload executors will not be registered for component: " + component.getName());
                 return;
             }
-            FileUploadExecutorConfig[] executorConfigs = component.getFileUploadExecutorConfigs();
+            if (log.isDebugEnabled()) {
+                log.debug("Processing file upload executor definitions for component: " + component.getName() + 
+                         " with " + executorConfigs.length + " configurations");
+            }
             for (FileUploadExecutorConfig executorConfig : executorConfigs) {
                 String[] mappingActions = executorConfig.getMappingActionList();
                 for (String mappingAction : mappingActions) {


### PR DESCRIPTION
This PR addresses the startup error log related to FileUploadExecutorManager.

Changes:
Wrapped the FileUploadExecutorManager null check in a log.isDebugEnabled() block.
Downgraded the log level from error to debug to reduce log noise during early startup phases.
Verified the build using mvn clean install for the org.wso2.carbon.ui module.