### PR TITLE
Add tenant EC and EdDSA key alias resolution support

### DIFF
--- a/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/util/KeyStoreUtil.java
+++ b/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/util/KeyStoreUtil.java
@@ -37,12 +37,19 @@ import java.security.cert.Certificate;
 import java.util.Arrays;
 import java.util.Enumeration;
 import java.util.Iterator;
+import java.util.Map;
 
 import javax.xml.namespace.QName;
 
+import static org.wso2.carbon.utils.multitenancy.MultitenantConstants.SUPER_TENANT_DOMAIN_NAME;
+
 public class KeyStoreUtil {
 
-    private static final String TENANT_EDDSA_KEY_SUFFIX = "_ed";
+    private static final String TENANT_EDDSA_KEY = "ED";
+    private static final String TENANT_ECDSA_KEY = "EC";
+    private static final Map<String, String> KEY_TYPE_ALIAS_MAPPING = Map.of(
+                    TENANT_ECDSA_KEY, "_ec",
+                    TENANT_EDDSA_KEY, "_ed");
 
     /**
      * KeyStore name will be here.
@@ -55,7 +62,8 @@ public class KeyStoreUtil {
         Enumeration<String> enums = store.aliases();
         while (enums.hasMoreElements()) {
             String name = enums.nextElement();
-            if (store.isKeyEntry(name) && !name.endsWith(TENANT_EDDSA_KEY_SUFFIX)) {
+            if (store.isKeyEntry(name) && !name.endsWith(KEY_TYPE_ALIAS_MAPPING.get(TENANT_ECDSA_KEY))
+                                       && !name.endsWith(KEY_TYPE_ALIAS_MAPPING.get(TENANT_EDDSA_KEY))) {
                 alias = name;
                 break;
             }
@@ -258,17 +266,42 @@ public class KeyStoreUtil {
     }
 
     /**
-     * Get tenant EdDSA Key Alias
+     * Returns the alias used to identify the key pair based on the tenant.
      *
-     * @return Tenant EdDSA Key Alias
-     * @throws CarbonException Exception Carbon Exception for tenants other than tenant -1234
+     * @param tenantDomain     Tenant domain name.
+     * @param keyType          Key type of the key pair.
+     * @return                 The tenant specific EC key alias.
+     * @throws CarbonException Carbon Exception for empty values and unsupported key types.
      */
-    public static String getTenantEdKeyAlias(String tenantDomain) throws CarbonException {
+    public static String getTenantKeyAlias(String tenantDomain, String keyType) throws CarbonException {
 
         if (StringUtils.isBlank(tenantDomain)) {
             throw new CarbonException("Tenant domain must not be empty.");
-        } else {
-            return tenantDomain +  TENANT_EDDSA_KEY_SUFFIX;
         }
+        if (StringUtils.isBlank(keyType)) {
+            throw new CarbonException("Key type must not be empty.");
+        }
+
+        String aliasKeySuffix = KEY_TYPE_ALIAS_MAPPING.get(keyType);
+        if (aliasKeySuffix == null) {
+            throw new CarbonException("Unsupported key type: " + keyType);
+        }
+        String baseAlias = SUPER_TENANT_DOMAIN_NAME.equals(tenantDomain)
+                ? getServerPrimaryKeyAlias()
+                : tenantDomain;
+
+        return baseAlias + aliasKeySuffix;
+    }
+
+    private static String getServerPrimaryKeyAlias() throws CarbonException {
+
+        String primaryKeyAlias = CarbonCoreDataHolder.getInstance()
+                .getServerConfigurationService()
+                .getFirstProperty(RegistryResources.SecurityManagement.SERVER_PRIMARY_KEYSTORE_KEY_ALIAS);
+
+        if (StringUtils.isBlank(primaryKeyAlias)) {
+            throw new CarbonException("Server primary keystore key alias is not configured.");
+        }
+        return primaryKeyAlias;
     }
 }

--- a/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/util/KeyStoreUtil.java
+++ b/core/org.wso2.carbon.core/src/main/java/org/wso2/carbon/core/util/KeyStoreUtil.java
@@ -37,7 +37,6 @@ import java.security.cert.Certificate;
 import java.util.Arrays;
 import java.util.Enumeration;
 import java.util.Iterator;
-import java.util.Map;
 
 import javax.xml.namespace.QName;
 
@@ -45,11 +44,8 @@ import static org.wso2.carbon.utils.multitenancy.MultitenantConstants.SUPER_TENA
 
 public class KeyStoreUtil {
 
-    private static final String TENANT_EDDSA_KEY = "ED";
-    private static final String TENANT_ECDSA_KEY = "EC";
-    private static final Map<String, String> KEY_TYPE_ALIAS_MAPPING = Map.of(
-                    TENANT_ECDSA_KEY, "_ec",
-                    TENANT_EDDSA_KEY, "_ed");
+    private static final String TENANT_EDDSA_KEY_SUFFIX = "_ed";
+    private static final String TENANT_ECDSA_KEY_SUFFIX = "_ec";
 
     /**
      * KeyStore name will be here.
@@ -62,8 +58,8 @@ public class KeyStoreUtil {
         Enumeration<String> enums = store.aliases();
         while (enums.hasMoreElements()) {
             String name = enums.nextElement();
-            if (store.isKeyEntry(name) && !name.endsWith(KEY_TYPE_ALIAS_MAPPING.get(TENANT_ECDSA_KEY))
-                                       && !name.endsWith(KEY_TYPE_ALIAS_MAPPING.get(TENANT_EDDSA_KEY))) {
+            if (store.isKeyEntry(name) && !name.endsWith(TENANT_EDDSA_KEY_SUFFIX)
+                                       && !name.endsWith(TENANT_ECDSA_KEY_SUFFIX)) {
                 alias = name;
                 break;
             }
@@ -266,31 +262,39 @@ public class KeyStoreUtil {
     }
 
     /**
-     * Returns the alias used to identify the key pair based on the tenant.
+     * Returns the alias used to identify the EDDSA key pair based on the tenant.
      *
      * @param tenantDomain     Tenant domain name.
-     * @param keyType          Key type of the key pair.
-     * @return                 The tenant specific EC key alias.
-     * @throws CarbonException Carbon Exception for empty values and unsupported key types.
+     * @return                 The tenant specific EDDSA key alias.
+     * @throws CarbonException Carbon Exception for empty values.
      */
-    public static String getTenantKeyAlias(String tenantDomain, String keyType) throws CarbonException {
+    public static String getTenantEdKeyAlias(String tenantDomain) throws CarbonException {
 
         if (StringUtils.isBlank(tenantDomain)) {
             throw new CarbonException("Tenant domain must not be empty.");
+        } else if (SUPER_TENANT_DOMAIN_NAME.equals(tenantDomain)) {
+            return  getServerPrimaryKeyAlias() + TENANT_EDDSA_KEY_SUFFIX;
+        } else {
+            return tenantDomain + TENANT_EDDSA_KEY_SUFFIX;
         }
-        if (StringUtils.isBlank(keyType)) {
-            throw new CarbonException("Key type must not be empty.");
-        }
+    }
 
-        String aliasKeySuffix = KEY_TYPE_ALIAS_MAPPING.get(keyType);
-        if (aliasKeySuffix == null) {
-            throw new CarbonException("Unsupported key type: " + keyType);
-        }
-        String baseAlias = SUPER_TENANT_DOMAIN_NAME.equals(tenantDomain)
-                ? getServerPrimaryKeyAlias()
-                : tenantDomain;
+    /**
+     * Returns the alias used to identify the ECDSA key pair based on the tenant.
+     *
+     * @param tenantDomain     Tenant domain name.
+     * @return                 The tenant specific ECDSA key alias.
+     * @throws CarbonException Carbon Exception for empty values.
+     */
+    public static String getTenantECKeyAlias(String tenantDomain) throws CarbonException {
 
-        return baseAlias + aliasKeySuffix;
+        if (StringUtils.isBlank(tenantDomain)) {
+            throw new CarbonException("Tenant domain must not be empty.");
+        } else if (SUPER_TENANT_DOMAIN_NAME.equals(tenantDomain)) {
+            return  getServerPrimaryKeyAlias() + TENANT_ECDSA_KEY_SUFFIX;
+        } else {
+            return tenantDomain + TENANT_ECDSA_KEY_SUFFIX;
+        }
     }
 
     private static String getServerPrimaryKeyAlias() throws CarbonException {


### PR DESCRIPTION
## PR Description
This change introduces support for resolving tenant specific `EC` and `EdDSA` key aliases in `KeyStoreUtil`.

The new method `getTenantECKeyAlias(String tenantDomain)` resolves the ec alias based on the tenant domain and appends `_ec` at the end. For the super tenant, the alias is derived from the server primary keystore alias.

This improves maintainability and ensures consistent handling of tenant ECDSA key aliases.

### Related issues: 
https://github.com/wso2/product-is/issues/26486