### PR TITLE
Add default cipher suites for HTTPS transport SSL configuration

### DIFF
--- a/distribution/kernel/carbon-home/repository/resources/conf/default.json
+++ b/distribution/kernel/carbon-home/repository/resources/conf/default.json
@@ -86,6 +86,7 @@
   "transport.https.sslHostConfig.properties.truststoreFile": "${carbon.home}/repository/resources/security/$ref{truststore.file_name}",
   "transport.https.sslHostConfig.properties.truststorePassword": "$ref{truststore.password}",
   "transport.https.sslHostConfig.properties.truststoreType": "$ref{truststore.type}",
+  "transport.https.sslHostConfig.properties.ciphers": "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,TLS_DHE_RSA_WITH_AES_128_GCM_SHA256,TLS_DHE_RSA_WITH_AES_256_GCM_SHA384,TLS_DHE_RSA_WITH_CHACHA20_POLY1305_SHA256,TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384,TLS_CHACHA20_POLY1305_SHA256",
   "transport.https.sslHostConfig.certificate.properties.certificateKeystoreFile": "${carbon.home}/repository/resources/security/$ref{keystore.tls.file_name}",
   "transport.https.sslHostConfig.certificate.properties.certificateKeystorePassword": "$ref{keystore.tls.password}",
   "transport.https.sslHostConfig.certificate.properties.certificateKeystoreType": "$ref{keystore.tls.type}",


### PR DESCRIPTION
## Purpose
Add a default set of secure TLS cipher suites to the HTTPS transport SSL host configuration in \`default.json\`. This ensures that when users configure HTTPS transport, only strong, modern cipher suites are used by default — including ECDHE, DHE, and TLS 1.3 suites — improving the security posture of the server out of the box without requiring manual configuration.

## Implementation
Added the \`transport.https.sslHostConfig.properties.ciphers\` key to \`distribution/kernel/carbon-home/repository/resources/conf/default.json\` with a curated list of secure cipher suites:

These suites were selected based on the [Mozilla SSL Configuration Generator](https://ssl-config.mozilla.org/#server=tomcat&version=11.0.1&config=intermediate&guideline=5.7) (Intermediate configuration for Tomcat 11.0.1, Guideline 5.7) to ensure a balance between strong security and broad client compatibility:

- **TLS 1.2 ECDHE suites:** \`TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256\`, \`TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256\`, \`TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384\`, \`TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384\`, \`TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256\`, \`TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256\`
- **TLS 1.2 DHE suites:** \`TLS_DHE_RSA_WITH_AES_128_GCM_SHA256\`, \`TLS_DHE_RSA_WITH_AES_256_GCM_SHA384\`, \`TLS_DHE_RSA_WITH_CHACHA20_POLY1305_SHA256\`
- **TLS 1.3 suites:** \`TLS_AES_128_GCM_SHA256\`, \`TLS_AES_256_GCM_SHA384\`, \`TLS_CHACHA20_POLY1305_SHA256\`

## Related Issue
wso2/product-is#27335