### PR TITLE
Add Configurable Schema support for PostreSQL DB.

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/hybrid/HybridRoleManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/hybrid/HybridRoleManager.java
@@ -22,6 +22,7 @@ import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.apache.tomcat.jdbc.pool.DataSourceProxy;
 import org.wso2.carbon.CarbonConstants;
 import org.wso2.carbon.base.ServerConfiguration;
 import org.wso2.carbon.user.api.RealmConfiguration;
@@ -53,6 +54,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 import java.util.UUID;
 
 import static org.wso2.carbon.user.core.constants.UserCoreDBConstants.CASE_INSENSITIVE_SQL_STATEMENT_PARAMETER_PLACEHOLDER;
@@ -79,6 +81,8 @@ public class HybridRoleManager {
     private static final String CASE_INSENSITIVE_USERNAME = "CaseInsensitiveUsername";
 
     private static final String DB2 = "db2";
+    private static final String POSTGRE_SQL = "PostgreSQL";
+    private static final String POSTGRES_SCHEMA = "postgresSchema";
 
     private static boolean hybridRoleAudienceTableExists = false;
 
@@ -1533,6 +1537,15 @@ public class HybridRoleManager {
             }
             String schemaName = connection.getSchema();
             String catalogName = connection.getCatalog();
+
+            // For PostgreSQL, use the configured schema if available. This handles cases where tables reside in a
+            // non-default schema that differs from the first entry in the database user's search path.
+            if (POSTGRE_SQL.equalsIgnoreCase(connection.getMetaData().getDatabaseProductName())) {
+                String postgresSchema = getPostgresSchema();
+                if (org.apache.commons.lang.StringUtils.isNotBlank(postgresSchema)) {
+                    schemaName = postgresSchema.trim();
+                }
+            }
             try (ResultSet resultSet = metaData.getTables(catalogName, schemaName, tableName, new String[]{"TABLE"})) {
                 if (resultSet.next()) {
                     return true;
@@ -1544,5 +1557,18 @@ public class HybridRoleManager {
             return false;
         }
         return false;
+    }
+
+    private String getPostgresSchema() {
+
+        String customSchema = null;
+        if (!(dataSource instanceof DataSourceProxy)) {
+            return null;
+        }
+        Properties properties = ((DataSourceProxy) dataSource).getDbProperties();
+        if (properties != null) {
+            customSchema = properties.getProperty(POSTGRES_SCHEMA);
+        }
+        return customSchema;
     }
 }


### PR DESCRIPTION
**Related Issues**

- [x] https://github.com/wso2/product-is/issues/27332

In order to configure a non default schema for postgreSQL following config should be added to db configs.

```
[database.shared_db]
type = "postgresql"
url = <url>
username = <db_user_username>
password = <db_user_password>
driver = <driver>
db_props.postgresSchema = <custom_schema>
```

See the following example

```
type = "postgresql"
url = "jdbc:postgresql://localhost:5432/is_db_72_patch"
username = "IS_DB_72_PATCH"
password = "123"
driver = "org.postgresql.Driver"
db_props.postgresSchema = "IS_DB_72_PATCH"
```

This pull request enhances the `HybridRoleManager` to better support PostgreSQL databases, particularly when tables are located in a non-default schema. The main changes ensure that the correct schema is used when checking for table existence, improving compatibility in environments with custom PostgreSQL schemas.

**PostgreSQL schema support improvements:**

* Added logic in `isTableExists` to detect when the database is PostgreSQL and override the schema name with a configured value if present, ensuring accurate table existence checks in custom schemas.
* Introduced the `getPostgresSchema` method to retrieve the `postgresSchema` property from the data source configuration, used to determine the correct schema for PostgreSQL.
* Defined new constants `POSTGRE_SQL` and `POSTGRES_SCHEMA` for improved code clarity and maintainability.

**Dependency and import updates:**

* Added imports for `DataSourceProxy` and `Properties` to support the new schema detection logic. [[1]](diffhunk://#diff-f6ab77b823d681c42be1e812cb3a94308276ef2f08a8407e87de496bbb84e74cR25) [[2]](diffhunk://#diff-f6ab77b823d681c42be1e812cb3a94308276ef2f08a8407e87de496bbb84e74cR57)