### PR TITLE
Add shareddb script changes for oracle RAC

### DIFF
--- a/distribution/kernel/carbon-home/dbscripts/oracle_rac_21c.sql
+++ b/distribution/kernel/carbon-home/dbscripts/oracle_rac_21c.sql
@@ -498,7 +498,7 @@ CREATE TABLE UM_ROLE (
                     UM_ID INTEGER,
                     UM_ROLE_NAME VARCHAR2(255) NOT NULL,
                     UM_TENANT_ID INTEGER DEFAULT 0,
-		            UM_SHARED_ROLE BOOLEAN DEFAULT FALSE,
+		            UM_SHARED_ROLE CHAR(1) DEFAULT 0,
                     PRIMARY KEY (UM_ID, UM_TENANT_ID),
                     UNIQUE(UM_ROLE_NAME, UM_TENANT_ID))
 /


### PR DESCRIPTION
### Purpose

- Add new dbscripts for older oracle versions to preserve char(1) datatype.
- Changed the dbscripts replacing char(1) with Boolean to be compatible with newer oracle versions.