### PR TITLE
Bump pax-logging version to 2.2.9-wso2v2

### DIFF
--- a/launcher/src/main/resources/launch.properties
+++ b/launcher/src/main/resources/launch.properties
@@ -23,8 +23,8 @@ carbon.osgi.framework=file\:plugins/org.eclipse.osgi_3.14.0.v20190517-1309.jar
 carbon.initial.osgi.bundles=\
   file\:plugins/org.eclipse.osgi.services_3.5.100.v20160504-1419.jar@1\:true,\
   file\:plugins/org.eclipse.equinox.cm_1.1.200.v20160324-1850.jar@2\:true,\
-  file\:plugins/org.ops4j.pax.logging.pax-logging-api_2.2.2.wso2v1.jar@2\:true,\
-  file\:plugins/org.ops4j.pax.logging.pax-logging-log4j2_2.2.2.wso2v1.jar@2\:true,\
+  file\:plugins/org.ops4j.pax.logging.pax-logging-api_2.2.9.wso2v2.jar@2\:true,\
+  file\:plugins/org.ops4j.pax.logging.pax-logging-log4j2_2.2.9.wso2v2.jar@2\:true,\
   file\:plugins/org.eclipse.equinox.simpleconfigurator_1.1.200.v20160504-1450.jar@3\:true
 
 osgi.install.area=file\:${wso2.runtime}

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -746,8 +746,8 @@
         <org.eclipse.equinox.p2.metadata.version>2.2.0.v20131211-1531</org.eclipse.equinox.p2.metadata.version>
 
         <!--PAX Logging related dependency versions-->
-        <pax.logging.api.version>2.2.2-wso2v1</pax.logging.api.version>
-        <pax.logging.log4j2.version>2.2.2-wso2v1</pax.logging.log4j2.version>
+        <pax.logging.api.version>2.2.9-wso2v2</pax.logging.api.version>
+        <pax.logging.log4j2.version>2.2.9-wso2v2</pax.logging.log4j2.version>
 
         <!--Maven Plugins -->
         <maven.wagon.ssh.version>2.1</maven.wagon.ssh.version>


### PR DESCRIPTION
## Summary
- Bump `pax-logging-api` and `pax-logging-log4j2` from `2.2.2-wso2v1` to `2.2.9-wso2v2` in `parent/pom.xml`
- Update bundle filenames in `launcher/src/main/resources/launch.properties` to match the new version

## Test plan
- [ ] Verify Maven build resolves `org.wso2.org.ops4j.pax.logging:pax-logging-api:2.2.9-wso2v2` successfully
- [ ] Run full build: `mvn clean install`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)