### PR TITLE
Improve username claim validation to handle domain-prefixed usernames during JIT provisioning

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
@@ -5090,9 +5090,11 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
         }
 
         String userNameWithoutDomain = UserCoreUtil.removeDomainFromName(userName);
-        // If the username claims presents, the value should be equal to the username attribute.
+        // If the username claim is present, the value should be equal to the username attribute.
+        // Both sides are stripped of domain prefix to handle cases where either or both contain a
+        // userstore domain (e.g. "PRIMARY/user1" vs "user1", or "SECONDARY/John" vs "SECONDARY/John").
         if (claims != null && claims.containsKey(USERNAME_CLAIM_URI) &&
-                !claims.get(USERNAME_CLAIM_URI).equals(userNameWithoutDomain)) {
+                !UserCoreUtil.removeDomainFromName(claims.get(USERNAME_CLAIM_URI)).equals(userNameWithoutDomain)) {
             // If not we cannot continue.
             throw new UserStoreException("Username and the username claim value should be same.");
         }
@@ -15815,10 +15817,9 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
             throw new UserStoreException(errorCode + " - " + message, errorCode);
         }
 
-        // If the username claims presents, the value should be equal to the username attribute.
         String userNameWithoutDomain = UserCoreUtil.removeDomainFromName(userName);
         if (claims != null && claims.containsKey(USERNAME_CLAIM_URI) &&
-                !claims.get(USERNAME_CLAIM_URI).equals(userNameWithoutDomain)) {
+                !UserCoreUtil.removeDomainFromName(claims.get(USERNAME_CLAIM_URI)).equals(userNameWithoutDomain)) {
             // If not we cannot continue.
             throw new UserStoreException("Username and the username claim value should be same.");
         }

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
@@ -5093,10 +5093,13 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
         // If the username claim is present, the value should be equal to the username attribute.
         // Both sides are stripped of domain prefix to handle cases where either or both contain a
         // userstore domain (e.g. "PRIMARY/user1" vs "user1", or "SECONDARY/John" vs "SECONDARY/John").
-        if (claims != null && claims.containsKey(USERNAME_CLAIM_URI) &&
-                !UserCoreUtil.removeDomainFromName(claims.get(USERNAME_CLAIM_URI)).equals(userNameWithoutDomain)) {
-            // If not we cannot continue.
-            throw new UserStoreException("Username and the username claim value should be same.");
+        if (claims != null && claims.containsKey(USERNAME_CLAIM_URI)) {
+            String usernameClaimValue = claims.get(USERNAME_CLAIM_URI);
+            if (usernameClaimValue == null ||
+                    !UserCoreUtil.removeDomainFromName(usernameClaimValue).equals(userNameWithoutDomain)) {
+                // If not we cannot continue.
+                throw new UserStoreException("Username and the username claim value should be same.");
+            }
         }
 
         // Get the user store that this user should be added from the domain name that is appended to the username.
@@ -15818,10 +15821,13 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
         }
 
         String userNameWithoutDomain = UserCoreUtil.removeDomainFromName(userName);
-        if (claims != null && claims.containsKey(USERNAME_CLAIM_URI) &&
-                !UserCoreUtil.removeDomainFromName(claims.get(USERNAME_CLAIM_URI)).equals(userNameWithoutDomain)) {
-            // If not we cannot continue.
-            throw new UserStoreException("Username and the username claim value should be same.");
+        if (claims != null && claims.containsKey(USERNAME_CLAIM_URI)) {
+            String usernameClaimValue = claims.get(USERNAME_CLAIM_URI);
+            if (usernameClaimValue == null ||
+                    !UserCoreUtil.removeDomainFromName(usernameClaimValue).equals(userNameWithoutDomain)) {
+                // If not we cannot continue.
+                throw new UserStoreException("Username and the username claim value should be same.");
+            }
         }
 
         UserStore userStore = getUserStore(userName);


### PR DESCRIPTION
### Problem 

Self registration of a user to a secondary userstore fails with:</p><pre><code>WorkflowException: Username and the username claim value should be same.
</code></pre><p>This issue is caused by a flaw in the existing username claim validation logic in <code inline="">AbstractUserStoreManager</code>:</p><pre><code class="language-java">String userNameWithoutDomain = UserCoreUtil.removeDomainFromName(userName);
if (claims != null &amp;&amp; claims.containsKey(USERNAME_CLAIM_URI) &amp;&amp;
        !claims.get(USERNAME_CLAIM_URI).equals(userNameWithoutDomain)) {
    throw new UserStoreException("Username and the username claim value should be same.");
}
</code></pre><h3>Root Cause</h3><p>The current logic removes the domain prefix from <code inline="">userName</code> (e.g., <code inline="">PRIMARY/user1 → user1</code>) before comparison, but <strong>does not normalize the <code inline="">USERNAME_CLAIM_URI</code> claim value</strong>.</p><p>This leads to incorrect mismatches in scenarios such as:</p><ul><li><p>If the claim value has <strong>no domain</strong> (e.g., <code inline="">user1</code>) and the username includes a domain (e.g., <code inline="">PRIMARY/user1</code>), the comparison may incorrectly fail.</p></li><li><p>If both the username and claim value include a <strong>secondary user store domain</strong> (e.g., <code inline="">SECONDARY/John</code>), removing the domain only from the username results in:</p><pre><code>John != SECONDARY/John
</code></pre><p>causing a false mismatch.</p></li></ul><hr><h2>Fix</h2><p>Normalize both values by applying <code inline="">UserCoreUtil.removeDomainFromName()</code> to the claim value as well:</p><pre><code class="language-java">!UserCoreUtil.removeDomainFromName(claims.get(USERNAME_CLAIM_URI))
        .equals(userNameWithoutDomain)
</code></pre><p>This ensures the comparison is always performed between <strong>domain-free usernames</strong>.</p><hr><h2>Behavior Comparison</h2>
userName | Claim Value | Existing Logic Result | Fixed Logic Result
-- | -- | -- | --
PRIMARY/user1 | user1 | ❌ user1 != user1 (false mismatch) | ✅ user1 == user1
SECONDARY/John | SECONDARY/John | ❌ SECONDARY/John != John | ✅ John == John
user1 | user1 | ✅ user1 == user1 | ✅ user1 == user1

<hr><h2>Scope of Fix</h2><p>The fix is applied to both:</p><ul><li><p><code inline="">addUser</code></p></li><li><p><code inline="">addUserWithID</code></p></li></ul><p>methods in <code inline="">AbstractUserStoreManager</code>.