### PR TITLE
Expose axis2_client connection-pool sizing via deployment.toml

### DIFF
--- a/distribution/kernel/carbon-home/repository/resources/conf/default.json
+++ b/distribution/kernel/carbon-home/repository/resources/conf/default.json
@@ -93,6 +93,8 @@
   "transport.https.sslHostConfig.certificate.properties.certificateKeyAlias": "$ref{keystore.tls.alias}",
   "transport.https.sslHostConfig.certificate.properties.certificateKeyPassword": "$ref{keystore.tls.key_password}",
   "http_access_log.pattern": "%h %l %u %t %r %s %b %{Referer}i %{User-Agent}i %T",
+  "axis2_client.default_max_connections_per_host": "500",
+  "axis2_client.max_total_connections": "15000",
   "message_formatters.form_urlencoded": "org.apache.axis2.transport.http.XFormURLEncodedFormatter",
   "message_formatters.multipart_form_data": "org.apache.axis2.transport.http.MultipartFormDataFormatter",
   "message_formatters.application_xml": "org.apache.axis2.transport.http.ApplicationXMLFormatter",

--- a/distribution/kernel/carbon-home/repository/resources/conf/templates/repository/conf/axis2/axis2_client.xml.j2
+++ b/distribution/kernel/carbon-home/repository/resources/conf/templates/repository/conf/axis2/axis2_client.xml.j2
@@ -23,9 +23,9 @@
     <parameter name="enableMTOM">false</parameter>
 
     <!-- commons-http-client defaultMaxConnPerHost -->
-    <parameter name="defaultMaxConnPerHost">500</parameter>
+    <parameter name="defaultMaxConnPerHost">{{axis2_client.default_max_connections_per_host}}</parameter>
     <!-- commons-http-client maxTotalConnections -->
-    <parameter name="maxTotalConnections">15000</parameter>
+    <parameter name="maxTotalConnections">{{axis2_client.max_total_connections}}</parameter>
 
     <!--If turned on with use the Accept header of the request to determine the contentType of the
     response-->


### PR DESCRIPTION
## Summary

- Replace hardcoded `defaultMaxConnPerHost` (500) and `maxTotalConnections` (15000) in `axis2_client.xml.j2` with Jinja2 placeholders bound to `[axis2_client]` TOML keys.
- Register defaults in `default.json` matching the legacy hardcoded values — packs without overrides emit byte-identical XML to the unpatched build.

Customers can tune the outbound Axis2 commons-http-client pool via:

```toml
[axis2_client]
default_max_connections_per_host = 1000
max_total_connections = 30000
```

Public bug: wso2/product-is#27481

## Test plan

- [ ] Build pack, confirm rendered `axis2.xml` (client) emits `500` / `15000` with no override.
- [ ] Set `[axis2_client]` keys in `deployment.toml`, confirm overrides flow to rendered XML.
- [ ] Server starts cleanly with both default and overridden config.