### PR TITLE
Bump pax-logging to 2.2.9-wso2v3 to fix log4j CVEs

### DIFF
--- a/launcher/src/main/resources/launch.properties
+++ b/launcher/src/main/resources/launch.properties
@@ -23,8 +23,8 @@ carbon.osgi.framework=file\:plugins/org.eclipse.osgi_3.14.0.v20190517-1309.jar
 carbon.initial.osgi.bundles=\
   file\:plugins/org.eclipse.osgi.services_3.5.100.v20160504-1419.jar@1\:true,\
   file\:plugins/org.eclipse.equinox.cm_1.1.200.v20160324-1850.jar@2\:true,\
-  file\:plugins/org.ops4j.pax.logging.pax-logging-api_2.2.9.wso2v2.jar@2\:true,\
-  file\:plugins/org.ops4j.pax.logging.pax-logging-log4j2_2.2.9.wso2v2.jar@2\:true,\
+  file\:plugins/org.ops4j.pax.logging.pax-logging-api_2.2.9.wso2v3.jar@2\:true,\
+  file\:plugins/org.ops4j.pax.logging.pax-logging-log4j2_2.2.9.wso2v3.jar@2\:true,\
   file\:plugins/org.eclipse.equinox.simpleconfigurator_1.1.200.v20160504-1450.jar@3\:true
 
 osgi.install.area=file\:${wso2.runtime}

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -746,8 +746,8 @@
         <org.eclipse.equinox.p2.metadata.version>2.2.0.v20131211-1531</org.eclipse.equinox.p2.metadata.version>
 
         <!--PAX Logging related dependency versions-->
-        <pax.logging.api.version>2.2.9-wso2v2</pax.logging.api.version>
-        <pax.logging.log4j2.version>2.2.9-wso2v2</pax.logging.log4j2.version>
+        <pax.logging.api.version>2.2.9-wso2v3</pax.logging.api.version>
+        <pax.logging.log4j2.version>2.2.9-wso2v3</pax.logging.log4j2.version>
 
         <!--Maven Plugins -->
         <maven.wagon.ssh.version>2.1</maven.wagon.ssh.version>


### PR DESCRIPTION
## Summary

- Upgrades `pax-logging-api` and `pax-logging-log4j2` from `2.2.9-wso2v2` to `2.2.9-wso2v3` in `parent/pom.xml`
- Updates OSGi boot bundle filenames in `launcher/src/main/resources/launch.properties` to match the new versions
- The `wso2v3` build of `pax-logging-log4j2` embeds **log4j-core 2.25.4** (up from 2.25.3), resolving **4 MEDIUM CVEs**

## Why both bundles must move together

`pax-logging-log4j2 2.2.9-wso2v3` has `Import-Package: org.apache.logging.log4j.*;version="2.25.4"`. The `pax-logging-api 2.2.9-wso2v2` bundle only exports those packages at `2.25.3`, so OSGi/p2 resolution fails unless `pax-logging-api` is also on `wso2v3` (which exports at `2.25.4`).

## CVEs resolved

All CVEs associated with `log4j-core` at version 2.25.3 (embedded in pax-logging-log4j2 wso2v2) are resolved in 2.25.4. The specific IDs are tracked in the SI 4.4.0 security scan report.

## Test plan

- [ ] Build carbon-kernel with `mvn clean install -DskipTests` on Java 11 — expect success (p2 director resolves the bundle wiring)
- [ ] Verify the OSGi feature zip contains `pax-logging-api_2.2.9.wso2v3.jar` and `pax-logging-log4j2_2.2.9.wso2v3.jar`
- [ ] Confirm `META-INF/maven/org.apache.logging.log4j/log4j-core/pom.properties` inside the log4j2 bundle shows `version=2.25.4`
- [ ] Run a grype/trivy binary scan on the downstream SI pack and confirm zero log4j CVEs

🤖 Generated with [Claude Code](https://claude.com/claude-code)