### PR TITLE
Fix user filtering issue of DB2 in uniqueidjdbcuserstoremanager

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCUserStoreManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2025, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2019-2026, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -4649,8 +4649,9 @@ public class UniqueIDJDBCUserStoreManager extends JDBCUserStoreManager {
             String roleUserJoinClause =  isGroupFilteringWithNEOperator ? RIGHT_JOIN : INNER_JOIN;
 
             if (DB2.equals(dbType)) {
-                sqlStatement = new StringBuilder("SELECT U.UM_USER_ID, U.UM_USER_NAME FROM (SELECT "
-                        + "ROW_NUMBER() OVER (ORDER BY UM_USER_NAME) AS rn, p.*  FROM (SELECT DISTINCT UM_USER_NAME  "
+                sqlStatement = new StringBuilder("SELECT UM_USER_ID, UM_USER_NAME FROM (SELECT "
+                        + "ROW_NUMBER() OVER (ORDER BY UM_USER_NAME) AS rn, UM_USER_ID, UM_USER_NAME "
+                        + "FROM (SELECT DISTINCT U.UM_USER_ID, U.UM_USER_NAME "
                         + "FROM UM_ROLE R INNER JOIN UM_USER_ROLE UR ON R.UM_ID = UR.UM_ROLE_ID"
                         + roleUserJoinClause + "UM_USER U "
                         + "ON UR.UM_USER_ID =U.UM_ID INNER JOIN UM_USER_ATTRIBUTE UA ON U.UM_ID = UA.UM_USER_ID");
@@ -4690,8 +4691,9 @@ public class UniqueIDJDBCUserStoreManager extends JDBCUserStoreManager {
 
             if (DB2.equals(dbType)) {
                 sqlStatement = new StringBuilder(
-                        "SELECT U.UM_USER_ID, U.UM_USER_NAME FROM (SELECT ROW_NUMBER() OVER (ORDER BY "
-                                + "UM_USER_NAME) AS rn, p.*  FROM (SELECT DISTINCT UM_USER_NAME  FROM UM_ROLE R INNER"
+                        "SELECT UM_USER_ID, UM_USER_NAME FROM (SELECT ROW_NUMBER() OVER (ORDER BY "
+                                + "UM_USER_NAME) AS rn, UM_USER_ID, UM_USER_NAME FROM (SELECT DISTINCT "
+                                + "U.UM_USER_ID, U.UM_USER_NAME FROM UM_ROLE R INNER"
                                 + " JOIN UM_USER_ROLE UR ON R.UM_ID = UR.UM_ROLE_ID" + roleUserJoinClause
                                 + "UM_USER U ON UR.UM_USER_ID = U.UM_ID ");
             } else if (H2.equals(dbType)) {


### PR DESCRIPTION
This pull request updates the DB2 query logic in the `UniqueIDJDBCUserStoreManager` class to ensure `UM_USER_ID` is properly selected and included in the results, improving accuracy in user retrieval. It also updates the copyright year.

**Database query improvements:**
* Modified the DB2-specific SQL query in `getQueryString` to explicitly select both `UM_USER_ID` and `UM_USER_NAME` at all levels of the subquery, ensuring `UM_USER_ID` is available in the result set. [[1]](diffhunk://#diff-7d8d31b47cc7e48c8e41e743c605e47d2e9730ab791be9e294ec9b99c8a25cd8L4652-R4654) [[2]](diffhunk://#diff-7d8d31b47cc7e48c8e41e743c605e47d2e9730ab791be9e294ec9b99c8a25cd8L4693-R4696)


### Related issue
- https://github.com/wso2/product-is/issues/27795