### PR TITLE
[carbon-kernel] Bump Jackson to 2.21.2

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -643,10 +643,11 @@
         <version.hubspot.immutables>1.11.2</version.hubspot.immutables>
         <version.cava-toml>0.5.0</version.cava-toml>
         <version.checkstyle>7.8.2</version.checkstyle>
-        <version.jackson>2.16.1</version.jackson>
-        <version.jackson.databind>2.16.1</version.jackson.databind>
-        <version.jackson.dataformat>2.16.1</version.jackson.dataformat>
-        <version.jackson.datatype>2.16.1</version.jackson.datatype>
+        <version.jackson>2.21.2</version.jackson>
+        <version.jackson.annotations>2.21</version.jackson.annotations>
+        <version.jackson.databind>2.21.2</version.jackson.databind>
+        <version.jackson.dataformat>2.21.2</version.jackson.dataformat>
+        <version.jackson.datatype>2.21.2</version.jackson.datatype>
         <version.jsoup>1.15.3</version.jsoup>
         <!--Please make sure to update the Guava and Guava FailureAccess versions in the carbon-registry repository as
         well.-->
@@ -1853,7 +1854,7 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-annotations</artifactId>
-                <version>${version.jackson}</version>
+                <version>${version.jackson.annotations}</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.dataformat</groupId>


### PR DESCRIPTION
## Purpose
Upgrade Jackson Databind and related libraries to the latest stable 2.21.x release.

## Goals
- Align all Jackson artifacts to a consistent 2.21.x baseline across the IS dependency tree
- Replace the 2.16.x versions that are no longer receiving upstream fixes

## Approach
Version property bumps only — no code or logic changes. The following properties were updated in `parent/pom.xml`:
- `version.jackson` → `2.21.2`
- `version.jackson.databind` → `2.21.2`
- `version.jackson.dataformat` → `2.21.2`
- `version.jackson.datatype` → `2.21.2`