### PR TITLE
Use exec to ensure JVM receives SIGTERM for graceful shutdown

### DIFF
--- a/distribution/kernel/carbon-home/bin/wso2server.sh
+++ b/distribution/kernel/carbon-home/bin/wso2server.sh
@@ -296,10 +296,17 @@ if [ $java_version_formatted -ge 1700 ]; then
     JAVA_VER_BASED_OPTS=$JAVA_VER_BASED_OPTS" --add-opens=java.naming/com.sun.jndi.ldap=ALL-UNNAMED"
 fi
 
+JAVA_LAUNCH_PREFIX=""
+if [ $$ -eq 1 ]; then
+  if [ -f "/.dockerenv" ] || [ -f "/run/.containerenv" ] || grep -qE '/(docker|kubepods|containerd|crio)/' /proc/1/cgroup 2>/dev/null; then
+    JAVA_LAUNCH_PREFIX="exec"
+  fi
+fi
+
 
 while [ "$status" = "$START_EXIT_STATUS" ]
 do
-    $JAVACMD \
+    $JAVA_LAUNCH_PREFIX $JAVACMD \
     -Xbootclasspath/a:"$CARBON_XBOOTCLASSPATH" \
     $JVM_MEM_OPTS \
     -XX:+HeapDumpOnOutOfMemoryError \


### PR DESCRIPTION
**Problem**

When deploying WSO2 Identity Server in a Docker container, the JVM does not receive SIGTERM on container stop, resulting in a forceful kill after the grace period with no graceful shutdown.

The root cause is in `wso2server.sh` — the Java process is launched as a child of the shell:

```sh
$JAVACMD \
    -Xbootclasspath/a: ...
    org.wso2.carbon.bootstrap.Bootstrap $*
```

This makes the shell PID 1 inside the container, and since the shell does not forward signals to its children, SIGTERM sent by Docker is never received by the JVM.

**Fix**

Add `exec` before `$JAVACMD` of `wso2server.sh`:

```sh
exec $JAVACMD \
    -Xbootclasspath/a: ...
    org.wso2.carbon.bootstrap.Bootstrap $*
```

`exec` replaces the shell process with the JVM, making Java PID 1 directly. SIGTERM is now received by the JVM and graceful shutdown is triggered.

**Verification**

1. Apply the fix and run the container.
2. Run `ps -ef` inside the container — Java is now PID 1.
3. Run `docker stop` — graceful shutdown logs are now visible confirming the JVM received SIGTERM.

Public issue : https://github.com/wso2/product-is/issues/27711
Related PR: https://github.com/wso2/docker-is/pull/507