### PR TITLE
Add WebappManagement.WatchedResourceReloadEnabled config to carbon.xml

### DIFF
--- a/distribution/kernel/carbon-home/repository/resources/conf/templates/repository/conf/carbon.xml.j2
+++ b/distribution/kernel/carbon-home/repository/resources/conf/templates/repository/conf/carbon.xml.j2
@@ -977,4 +977,13 @@
         {% endfor %}
     </DeniedAdminServices>
 
+    {% if server.webapp.watched_resource_reload_enabled is defined %}
+    <!-- Reload a deployed webapp's context when a watched resource (WEB-INF/web.xml, WEB-INF/lib,
+         WEB-INF/classes) is modified at runtime. Set false to stop the spurious reload seen on
+         NFS-shared, multi-node deployments. Unrelated to JSP hot deployment. -->
+    <WebappManagement>
+        <WatchedResourceReloadEnabled>{{server.webapp.watched_resource_reload_enabled}}</WatchedResourceReloadEnabled>
+    </WebappManagement>
+    {% endif %}
+
 </Server>


### PR DESCRIPTION
### Root cause & fix
- A deployed webapp's watched-resource reload (`context.reload()` on `WEB-INF` changes) on a Carbon context leaves Jasper's `TldCache` null, causing a taglib-JSP `getTldResourcePath` NPE after the refresh. On NFS-shared, multi-node deployments this reload fires spuriously on pod scale-up.
- This change exposes a config to control that reload: renders `<WebappManagement><WatchedResourceReloadEnabled>` in `carbon.xml` from the `deployment.toml` key `server.webapp.watched_resource_reload_enabled`.
- Consumed by `carbon-deployment` `AbstractWebappDeployer`, which defaults to enabled when the property is absent (legacy behavior preserved). Setting it `false` stops the reload entirely.

```toml
[server.webapp]
watched_resource_reload_enabled = false   # default true
```

### Source fix / pairs with
- carbon-deployment (master line): wso2/carbon-deployment#437
- IS 6.1.0 support fix: wso2-support/carbon-deployment#147 + wso2-support/product-is#2164

### Tracking issue
wso2/product-is#26547

> Generated with assistance from Claude Code — please review carefully.