### PR TITLE
Add unit tests for ClassUtils to cover exception paths

### DIFF
--- a/core/src/test/java/org/wso2/carbon/kernel/utils/ClassUtilsTest.java
+++ b/core/src/test/java/org/wso2/carbon/kernel/utils/ClassUtilsTest.java
@@ -1,0 +1,29 @@
+package org.wso2.carbon.utils;
+
+import org.testng.annotations.Test;
+
+public class ClassUtilsTest {
+
+    // 1. We create a tiny fake object to test with
+    private static class TestTarget {
+        private String secretMessage = "Hello";
+    }
+
+    // Test 1: Test that it works perfectly under normal conditions
+    @Test
+    public void testSetToPrivateFieldSuccess() {
+        TestTarget target = new TestTarget();
+        
+        // Change "secretMessage" to "Success"
+        ClassUtils.setToPrivateField(target, "secretMessage", "Success");
+    }
+
+    // Test 2: THE GAP FIX! Test what happens when a field doesn't exist
+    @Test(expectedExceptions = RuntimeException.class)
+    public void testSetToPrivateFieldThrowsExceptionWhenFieldNotFound() {
+        TestTarget target = new TestTarget();
+
+        // This forces ClassUtils to jump into the catch block and throw a RuntimeException.
+        ClassUtils.setToPrivateField(target, "thisFieldDoesNotExist", "Boom");
+    }
+}


### PR DESCRIPTION
Added unit tests for ClassUtils.java inside the core module. This introduces test coverage for the NoSuchFieldException and IllegalAccessException catch block within the setToPrivateField method, helping close test coverage gaps.