### PR TITLE
Fix duplicate user conflict handling in concurrent user creation for LDAP and AD user stores

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/UniqueIDActiveDirectoryUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/UniqueIDActiveDirectoryUserStoreManager.java
@@ -275,10 +275,7 @@ public class UniqueIDActiveDirectoryUserStoreManager extends UniqueIDReadWriteLD
                 // If concurrent requests with the same username bypass the existing user validation check, it can throw
                 // a NameAlreadyBoundException. It should be caught and rethrown with the appropriate error code.
                 errorMessage = ERROR_CODE_USER_ALREADY_EXISTS.getCode() + " - " +
-                        String.format(ERROR_CODE_USER_ALREADY_EXISTS.getMessage(), userName);
-                if (logger.isDebugEnabled()) {
-                    logger.debug(errorMessage, e);
-                }
+                        String.format(ERROR_CODE_USER_ALREADY_EXISTS.getMessage(), "");
                 throw new UserStoreException(errorMessage, ERROR_CODE_USER_ALREADY_EXISTS.getCode(), e);
             }
             if (logger.isDebugEnabled()) {

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/UniqueIDActiveDirectoryUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/UniqueIDActiveDirectoryUserStoreManager.java
@@ -31,7 +31,6 @@ import org.wso2.carbon.user.core.UserStoreException;
 import org.wso2.carbon.user.core.claim.ClaimManager;
 import org.wso2.carbon.user.core.common.RoleContext;
 import org.wso2.carbon.user.core.common.User;
-import org.wso2.carbon.user.core.constants.UserCoreErrorConstants;
 import org.wso2.carbon.user.core.profile.ProfileConfigurationManager;
 import org.wso2.carbon.user.core.util.JNDIUtil;
 import org.wso2.carbon.utils.Secret;
@@ -69,6 +68,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static org.wso2.carbon.user.core.constants.UserCoreErrorConstants.ErrorMessages.ERROR_CODE_USER_ALREADY_EXISTS;
 import static org.wso2.carbon.user.core.constants.UserStoreUIConstants.DataCategory.CONNECTION;
 import static org.wso2.carbon.user.core.constants.UserStoreUIConstants.DataCategory.GROUP;
 import static org.wso2.carbon.user.core.constants.UserStoreUIConstants.DataCategory.USER;
@@ -274,13 +274,12 @@ public class UniqueIDActiveDirectoryUserStoreManager extends UniqueIDReadWriteLD
             } else if (e instanceof NameAlreadyBoundException) {
                 // If concurrent requests with the same username bypass the existing user validation check, it can throw
                 // a NameAlreadyBoundException. It should be caught and rethrown with the appropriate error code.
-                errorMessage = UserCoreErrorConstants.ErrorMessages.ERROR_CODE_USER_ALREADY_EXISTS.getCode() + " - " +
-                        UserCoreErrorConstants.ErrorMessages.ERROR_CODE_USER_ALREADY_EXISTS.getMessage();
+                errorMessage = ERROR_CODE_USER_ALREADY_EXISTS.getCode() + " - " +
+                        String.format(ERROR_CODE_USER_ALREADY_EXISTS.getMessage(), userName);
                 if (logger.isDebugEnabled()) {
                     logger.debug(errorMessage, e);
                 }
-                throw new UserStoreException(errorMessage,
-                        UserCoreErrorConstants.ErrorMessages.ERROR_CODE_USER_ALREADY_EXISTS.getCode(), e);
+                throw new UserStoreException(errorMessage, ERROR_CODE_USER_ALREADY_EXISTS.getCode(), e);
             }
             if (logger.isDebugEnabled()) {
                 logger.debug(errorMessage, e);

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/UniqueIDActiveDirectoryUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/UniqueIDActiveDirectoryUserStoreManager.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2019-2026, WSO2 LLC. (http://www.wso2.com).
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
@@ -31,12 +31,14 @@ import org.wso2.carbon.user.core.UserStoreException;
 import org.wso2.carbon.user.core.claim.ClaimManager;
 import org.wso2.carbon.user.core.common.RoleContext;
 import org.wso2.carbon.user.core.common.User;
+import org.wso2.carbon.user.core.constants.UserCoreErrorConstants;
 import org.wso2.carbon.user.core.profile.ProfileConfigurationManager;
 import org.wso2.carbon.user.core.util.JNDIUtil;
 import org.wso2.carbon.utils.Secret;
 import org.wso2.carbon.utils.UnsupportedSecretTypeException;
 
 import javax.naming.Name;
+import javax.naming.NameAlreadyBoundException;
 import javax.naming.NameParser;
 import javax.naming.NamingEnumeration;
 import javax.naming.NamingException;
@@ -269,6 +271,16 @@ public class UniqueIDActiveDirectoryUserStoreManager extends UniqueIDReadWriteLD
                 }
                 errorMessage = "Error while enabling the user account. Please check password policy at DC for user : "
                         + userName;
+            } else if (e instanceof NameAlreadyBoundException) {
+                // If concurrent requests with the same username bypass the existing user validation check, it can throw
+                // a NameAlreadyBoundException. It should be caught and rethrown with the appropriate error code.
+                errorMessage = UserCoreErrorConstants.ErrorMessages.ERROR_CODE_USER_ALREADY_EXISTS.getCode() + " - " +
+                        UserCoreErrorConstants.ErrorMessages.ERROR_CODE_USER_ALREADY_EXISTS.getMessage();
+                if (logger.isDebugEnabled()) {
+                    logger.debug(errorMessage, e);
+                }
+                throw new UserStoreException(errorMessage,
+                        UserCoreErrorConstants.ErrorMessages.ERROR_CODE_USER_ALREADY_EXISTS.getCode(), e);
             }
             if (logger.isDebugEnabled()) {
                 logger.debug(errorMessage, e);

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/UniqueIDReadWriteLDAPUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/UniqueIDReadWriteLDAPUserStoreManager.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2019-2026, WSO2 LLC. (http://www.wso2.com).
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
@@ -354,16 +354,15 @@ public class UniqueIDReadWriteLDAPUserStoreManager extends UniqueIDReadOnlyLDAPU
                     + userName;
 
             if (e instanceof NameAlreadyBoundException) {
-                // If concurrent requests with same username bypass the existing user validation check, it can throw an
-                // exception regarding unique key violation. It should be caught and rethrown as a client exception.
+                // If concurrent requests with the same username bypass the existing user validation check, it can throw
+                // a NameAlreadyBoundException. It should be caught and rethrown with the appropriate error code.
+                errorMessage = UserCoreErrorConstants.ErrorMessages.ERROR_CODE_USER_ALREADY_EXISTS.getCode() + " - " +
+                        UserCoreErrorConstants.ErrorMessages.ERROR_CODE_USER_ALREADY_EXISTS.getMessage();
                 if (log.isDebugEnabled()) {
                     log.debug(errorMessage, e);
                 }
-
-                throw new UserStoreClientException(
-                        UserCoreErrorConstants.ErrorMessages.ERROR_CODE_USER_ALREADY_EXISTS.getCode() + " : " +
-                                UserCoreErrorConstants.ErrorMessages.ERROR_CODE_USER_ALREADY_EXISTS.getMessage(),
-                        UserCoreErrorConstants.ErrorMessages.ERROR_CODE_USER_ALREADY_EXISTS.getCode());
+                throw new UserStoreException(errorMessage,
+                        UserCoreErrorConstants.ErrorMessages.ERROR_CODE_USER_ALREADY_EXISTS.getCode(), e);
             } else {
                 log.error("Failed to persist user: " + userName + ". Error: " + e.getMessage());
                 throw new UserStoreException(errorMessage, e);

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/UniqueIDReadWriteLDAPUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/UniqueIDReadWriteLDAPUserStoreManager.java
@@ -84,6 +84,7 @@ import javax.sql.DataSource;
 import static org.wso2.carbon.user.core.UserStoreConfigConstants.DEFAULT_CONNECTION_RETRY_COUNT;
 import static org.wso2.carbon.user.core.UserStoreConfigConstants.GROUP_ID_ATTRIBUTE;
 import static org.wso2.carbon.user.core.constants.UserCoreErrorConstants.ErrorMessages.ERROR_CODE_DUPLICATE_WHILE_WRITING_TO_DATABASE;
+import static org.wso2.carbon.user.core.constants.UserCoreErrorConstants.ErrorMessages.ERROR_CODE_USER_ALREADY_EXISTS;
 import static org.wso2.carbon.user.core.constants.UserCoreErrorConstants.ErrorMessages.ERROR_EMPTY_GROUP_ID;
 import static org.wso2.carbon.user.core.constants.UserCoreErrorConstants.ErrorMessages.ERROR_EMPTY_GROUP_NAME;
 import static org.wso2.carbon.user.core.constants.UserCoreErrorConstants.ErrorMessages.ERROR_NO_GROUP_FOUND_WITH_ID;
@@ -356,13 +357,12 @@ public class UniqueIDReadWriteLDAPUserStoreManager extends UniqueIDReadOnlyLDAPU
             if (e instanceof NameAlreadyBoundException) {
                 // If concurrent requests with the same username bypass the existing user validation check, it can throw
                 // a NameAlreadyBoundException. It should be caught and rethrown with the appropriate error code.
-                errorMessage = UserCoreErrorConstants.ErrorMessages.ERROR_CODE_USER_ALREADY_EXISTS.getCode() + " - " +
-                        UserCoreErrorConstants.ErrorMessages.ERROR_CODE_USER_ALREADY_EXISTS.getMessage();
+                errorMessage = ERROR_CODE_USER_ALREADY_EXISTS.getCode() + " - " +
+                        String.format(ERROR_CODE_USER_ALREADY_EXISTS.getMessage(), userName);
                 if (log.isDebugEnabled()) {
                     log.debug(errorMessage, e);
                 }
-                throw new UserStoreException(errorMessage,
-                        UserCoreErrorConstants.ErrorMessages.ERROR_CODE_USER_ALREADY_EXISTS.getCode(), e);
+                throw new UserStoreException(errorMessage, ERROR_CODE_USER_ALREADY_EXISTS.getCode(), e);
             } else {
                 log.error("Failed to persist user: " + userName + ". Error: " + e.getMessage());
                 throw new UserStoreException(errorMessage, e);

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/UniqueIDReadWriteLDAPUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/UniqueIDReadWriteLDAPUserStoreManager.java
@@ -358,10 +358,7 @@ public class UniqueIDReadWriteLDAPUserStoreManager extends UniqueIDReadOnlyLDAPU
                 // If concurrent requests with the same username bypass the existing user validation check, it can throw
                 // a NameAlreadyBoundException. It should be caught and rethrown with the appropriate error code.
                 errorMessage = ERROR_CODE_USER_ALREADY_EXISTS.getCode() + " - " +
-                        String.format(ERROR_CODE_USER_ALREADY_EXISTS.getMessage(), userName);
-                if (log.isDebugEnabled()) {
-                    log.debug(errorMessage, e);
-                }
+                        String.format(ERROR_CODE_USER_ALREADY_EXISTS.getMessage(), "");
                 throw new UserStoreException(errorMessage, ERROR_CODE_USER_ALREADY_EXISTS.getCode(), e);
             } else {
                 log.error("Failed to persist user: " + userName + ". Error: " + e.getMessage());


### PR DESCRIPTION
### Purpose 

- When concurrent user creation requests are made, the existing user validation pre-check (`isExistingUser`) in `AbstractUserStoreManager` can be bypassed by multiple threads simultaneously. In LDAP and Active Directory user stores, this results in a `NameAlreadyBoundException`  being thrown during the LDAP bind operation, which was previously propagated as a generic error without a meaningful error code. This fix handles the `NameAlreadyBoundException`.

- https://github.com/wso2/carbon-kernel/pull/4523 introduced`UserStoreClientException` for this path. However, introducing a new exception type is a change for existing callers — including custom user store managers and other WSO2 products — that catch `UserStoreException` but do not handle `UserStoreClientException`. This PR intentionally uses `UserStoreException` to fix the issue without causing any changes for existing customers with customizations.

- The exception is rethrown with error code `30004` (`ERROR_CODE_USER_ALREADY_EXISTS`) and message format `"30004 - UserAlreadyExisting:Username %s already exists in the system..."` — identical to what `AbstractUserStoreManager` throws at line 4690 [1] when the pre-check detects an existing user. This  ensures consistent error propagation regardless of which code path detects the duplicate.

#### No behaviour change for existing customers

- Since `isExistingUser` already throws `UserStoreException` with error code `30004` using the same message format, the kernel change only aligns the LDAP/AD constraint violation path with this pre-existing behaviour, ensuring no behaviour change for existing customers with customizations.

### Issue
- https://github.com/wso2/product-is/issues/26148

[1] https://github.com/wso2/carbon-kernel/blob/53f4838ce4b18e94ec61cd790258b2b932300bff/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java#L5290
