### PR TITLE
Bump Apache Tomcat version to 9.0.118

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -488,7 +488,7 @@
         <version.synapse>2.1.0-wso2v5</version.synapse>
         <version.lucene.core>2.3.2</version.lucene.core>
 
-        <version.tomcat>9.0.113</version.tomcat>
+        <version.tomcat>9.0.118</version.tomcat>
         <orbit.version.tomcat>${version.tomcat}.wso2v1</orbit.version.tomcat>
         <orbit.version.tomcat.servlet.api>${version.tomcat}.wso2v1</orbit.version.tomcat.servlet.api>
         <orbit.version.tomcat.jsp.api>${version.tomcat}.wso2v1</orbit.version.tomcat.jsp.api>


### PR DESCRIPTION
## Purpose
Bump the embedded Apache Tomcat version from `9.0.113` to `9.0.118`.

This updates the single `version.tomcat` property in `parent/pom.xml`, which cascades to all orbit Tomcat bundle versions (`orbit.version.tomcat`, `orbit.version.tomcat.servlet.api`, `orbit.version.tomcat.jsp.api`, `orbit.version.tomcat.el.api`, `orbit.version.tomcat.ha`) and the `tomcat-embed-*` dependencies.

## Goals
Pick up the latest Apache Tomcat 9.0.x maintenance release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)