### PR TITLE
Ensure cache listeners are correctly notified on cache invalidation

### DIFF
--- a/core/javax.cache/src/main/java/org/wso2/carbon/caching/impl/CacheImpl.java
+++ b/core/javax.cache/src/main/java/org/wso2/carbon/caching/impl/CacheImpl.java
@@ -438,7 +438,11 @@ public class CacheImpl<K, V> implements Cache<K, V> {
 
     private void notifyCacheEntryCreated(K key, V value) {
         CacheEntryEvent event = createCacheEntryEvent(key, value);
-        for (CacheEntryListener cacheEntryListener : cacheEntryListeners) {
+
+        // Use DataHolder to fetch cache entry listeners to ensure all listeners registered
+        // during and after server startup are notified. The local cacheEntryListeners field
+        // may not include all listeners at early startup stages.
+        for (CacheEntryListener cacheEntryListener : DataHolder.getInstance().getCacheEntryListeners()) {
             if (cacheEntryListener instanceof CacheEntryCreatedListener) {
                 if (log.isDebugEnabled()) {
                     log.debug("Notification event trigger for cache entry create : " + cacheEntryListener.getClass());
@@ -450,7 +454,7 @@ public class CacheImpl<K, V> implements Cache<K, V> {
 
     private void notifyCacheEntryUpdated(K key, V value) {
         CacheEntryEvent event = createCacheEntryEvent(key, value);
-        for (CacheEntryListener cacheEntryListener : cacheEntryListeners) {
+        for (CacheEntryListener cacheEntryListener : DataHolder.getInstance().getCacheEntryListeners()) {
             if (cacheEntryListener instanceof CacheEntryUpdatedListener) {
                 if (log.isDebugEnabled()) {
                     log.debug("Notification event trigger for cache entry update : " + cacheEntryListener.getClass());
@@ -462,7 +466,7 @@ public class CacheImpl<K, V> implements Cache<K, V> {
 
     private void notifyCacheEntryRead(K key, V value) {
         CacheEntryEvent event = createCacheEntryEvent(key, value);
-        for (CacheEntryListener cacheEntryListener : cacheEntryListeners) {
+        for (CacheEntryListener cacheEntryListener : DataHolder.getInstance().getCacheEntryListeners()) {
             if (cacheEntryListener instanceof CacheEntryReadListener) {
                 if (log.isDebugEnabled()) {
                     log.debug("Notification event trigger for cache entry read : " + cacheEntryListener.getClass());
@@ -474,7 +478,7 @@ public class CacheImpl<K, V> implements Cache<K, V> {
 
     private void notifyCacheEntryRemoved(K key, V value) {
         CacheEntryEvent event = createCacheEntryEvent(key, value);
-        for (CacheEntryListener cacheEntryListener : cacheEntryListeners) {
+        for (CacheEntryListener cacheEntryListener : DataHolder.getInstance().getCacheEntryListeners()) {
             if (cacheEntryListener instanceof CacheEntryRemovedListener) {
                 if (cacheEntryListener instanceof CacheInvalidationRequestSender) {
                     //this is handled separately in the #remove method
@@ -557,8 +561,13 @@ public class CacheImpl<K, V> implements Cache<K, V> {
         boolean removed = removeLocal(key);
         if (cacheName.startsWith(CachingConstants.LOCAL_CACHE_PREFIX) && forceLocalCache) {
             CacheEntryEvent cacheEntryEvent = createCacheEntryEvent((K) key, null);
-            CacheEntryInfo cacheInfo = Util.createCacheInfo(cacheEntryEvent);
-            DataHolder.getInstance().getConfiguredCacheInvalidationSender().send(cacheInfo);
+            for (CacheEntryListener cacheEntryListener : DataHolder.getInstance().getCacheEntryListeners()) {
+                if (cacheEntryListener instanceof CacheEntryRemovedListener) {
+                    if (cacheEntryListener instanceof CacheInvalidationRequestSender) {
+                        ((CacheEntryRemovedListener) cacheEntryListener).entryRemoved(cacheEntryEvent);
+                    }
+                }
+            }
         }
 
         return removed;

--- a/core/javax.cache/src/test/java/org/wso2/carbon/caching/impl/CacheListenerTestCase.java
+++ b/core/javax.cache/src/test/java/org/wso2/carbon/caching/impl/CacheListenerTestCase.java
@@ -63,14 +63,25 @@ public class CacheListenerTestCase {
 
         cacheEntryCreatedListener = new CacheEntryCreatedListenerImpl<String, Long>();
         cache.registerCacheEntryListener(cacheEntryCreatedListener);
+        DataHolder.getInstance().getCacheEntryListeners().add(cacheEntryCreatedListener);
         cacheEntryExpiredListener = new CacheEntryExpiredListenerImpl<String, Long>();
         cache.registerCacheEntryListener(cacheEntryExpiredListener);
+        DataHolder.getInstance().getCacheEntryListeners().add(cacheEntryExpiredListener);
         cacheEntryReadListener = new CacheEntryReadListenerImpl<String, Long>();
         cache.registerCacheEntryListener(cacheEntryReadListener);
+        DataHolder.getInstance().getCacheEntryListeners().add(cacheEntryReadListener);
         cacheEntryRemovedListener = new CacheEntryRemovedListenerImpl<String, Long>();
         cache.registerCacheEntryListener(cacheEntryRemovedListener);
+        DataHolder.getInstance().getCacheEntryListeners().add(cacheEntryRemovedListener);
         cacheEntryUpdatedListener = new CacheEntryUpdatedListenerImpl<String, Long>();
         cache.registerCacheEntryListener(cacheEntryUpdatedListener);
+        DataHolder.getInstance().getCacheEntryListeners().add(cacheEntryUpdatedListener);
+    }
+
+    @AfterClass
+    public void cleanUp() {
+        
+        DataHolder.getInstance().getCacheEntryListeners().clear();
     }
 
     @Test(groups = {"org.wso2.carbon.clustering.hazelcast.jsr107"},

--- a/core/javax.cache/src/test/java/org/wso2/carbon/caching/impl/CacheListenerTestCase.java
+++ b/core/javax.cache/src/test/java/org/wso2/carbon/caching/impl/CacheListenerTestCase.java
@@ -18,6 +18,7 @@
  */
 package org.wso2.carbon.caching.impl;
 
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 import org.wso2.carbon.context.PrivilegedCarbonContext;


### PR DESCRIPTION
#### Problem

Fixing the below two issues in the cache invalidation

1. **Cache Entry Listener Registration**

   * **Problem:** At server startup and early runtime, cache entry listeners were sometimes not fully registered when cache events occurred. `CacheImpl` previously relied on a local `cacheEntryListeners` collection, which could result in only a subset of listeners being notified.
   * **Impact:** Critical cache events such as creation, update, removal, and expiration might not reach all registered listeners. This could lead to inconsistent cache state and, in particular, failures in propagating token revocation events across clusters.

2. **Centralization of Removal Notifications**

   * **Problem:** Some local cache removals previously triggered removal events inline, rather than using a centralized mechanism.
   * **Impact:** This could result in inconsistent listener notifications and duplicated logic across the system, making it harder to guarantee that all listeners (including JMS invalidation senders) are properly notified for cache entry removals.

#### Changes Introduced

This PR addresses both issues:

* **Ensuring Listener Consistency**

  * All cache entry notifications now fetch listeners directly from `DataHolder` at event time.
  * Guarantees that all registered listeners are notified, even if they were registered after cache initialization.
  * Applies uniformly to cache create, update, read, remove, and expire events.

* **Centralizing Removal Notifications**

  * Local cache removals now consistently reuse the `notifyCacheEntryRemoved(...)` logic.
  * Avoids duplicated removal handling and ensures all relevant listeners are invoked reliably.