### PR TITLE
Release outstanding sorted-paged LDAP search session on early exit

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/UniqueIDReadOnlyLDAPUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/UniqueIDReadOnlyLDAPUserStoreManager.java
@@ -1854,6 +1854,9 @@ public class UniqueIDReadOnlyLDAPUserStoreManager extends ReadOnlyLDAPUserStoreM
                         generatePaginatedList(pageIndex, offset, pageSize, tempGroupList, finalGroups);
                         int needMore = pageSize - finalGroups.size();
                         if (needMore == 0) {
+                            releasePagedSearchSession(ldapContext,
+                                    parseControls(ldapContext.getResponseControls()), searchBase, searchFilter,
+                                    searchControls, sortAttribute);
                             break;
                         }
                     }
@@ -2235,6 +2238,8 @@ public class UniqueIDReadOnlyLDAPUserStoreManager extends ReadOnlyLDAPUserStoreM
                     generatePaginatedGroupsList(pageIndex, offset, pageSize, tempGroupsList, groups);
                     int needMore = pageSize - groups.size();
                     if (needMore == 0) {
+                        releasePagedSearchSession(ldapContext, parseControls(ldapContext.getResponseControls()),
+                                searchBase, groupFilter, searchControls, sortingProperty);
                         break;
                     }
                     cookie = parseControls(ldapContext.getResponseControls());
@@ -3290,6 +3295,29 @@ public class UniqueIDReadOnlyLDAPUserStoreManager extends ReadOnlyLDAPUserStoreM
     }
 
     /**
+     * Release any outstanding server-side sorted/paged search session (RFC 2696 cancellation) before the LDAP
+     * context is returned to the JNDI connection pool, so a reused connection does not carry a still-active sort.
+     */
+    private void releasePagedSearchSession(LdapContext ldapContext, byte[] cookie, String searchBase,
+                                           String searchFilter, SearchControls searchControls, String sortAttribute) {
+
+        if (cookie == null || cookie.length == 0) {
+            return;
+        }
+        try {
+            ldapContext.setRequestControls(new Control[]{new PagedResultsControl(0, cookie, Control.CRITICAL),
+                    new SortControl(sortAttribute, Control.NONCRITICAL)});
+            JNDIUtil.closeNamingEnumeration(
+                    ldapContext.search(escapeDNForSearch(searchBase), searchFilter, searchControls));
+        } catch (NamingException | IOException e) {
+            if (log.isDebugEnabled()) {
+                log.debug("Error while releasing the outstanding paged search session before returning the LDAP "
+                        + "context to the connection pool.", e);
+            }
+        }
+    }
+
+    /**
      * Do LDAP paginated search and return user objects as a list.
      *
      * @param ldapContext             LDAP connection context.
@@ -3402,12 +3430,17 @@ public class UniqueIDReadOnlyLDAPUserStoreManager extends ReadOnlyLDAPUserStoreM
                              */
                             users = membershipGroupFilterPostProcessing(isUsernameFiltering, isClaimFiltering,
                                     expressionConditions, tempUsersList);
+                            releasePagedSearchSession(ldapContext, parseControls(ldapContext.getResponseControls()),
+                                    searchBase, searchFilter, searchControls, userNameAttribute);
                             break;
                         } else {
                             // Handle pagination depending on given offset, i.e. start index.
                             generatePaginatedUserList(pageIndex, offset, pageSize, tempUsersList, users);
                             int needMore = pageSize - users.size();
                             if (needMore == 0) {
+                                releasePagedSearchSession(ldapContext,
+                                        parseControls(ldapContext.getResponseControls()), searchBase, searchFilter,
+                                        searchControls, userNameAttribute);
                                 break;
                             }
                         }


### PR DESCRIPTION
## Problem

When IS lists users/groups from an Active-Directory-backed secondary user store with JNDI connection pooling enabled, a server-side sorted + paged listing exits before the paging cookie is exhausted (the requested page is filled and the loop breaks early). AD still holds an in-progress sorted/paged operation bound to that physical connection. When the connection is returned to the JNDI pool and reused, the next sorted search fails intermittently with:

```
javax.naming.ServiceUnavailableException: [LDAP: error code 51 - Other sort requests already in progress]
```

## Root cause

In `UniqueIDReadOnlyLDAPUserStoreManager`, the sorted/paged listing paths (`performLDAPSearch`, `performLDAPGroupSearch`, `getListOfGroups`) break out of the `do/while` paged loop as soon as the requested page is filled. On an early break the paging cookie is not exhausted, so AD keeps the sorted/paged session active on the connection; `close()` returns it to the pool with that session still open.

## Fix

On every early-exit path, release the outstanding session via RFC 2696 cancellation before breaking. A new helper `releasePagedSearchSession(...)` re-issues the search with `PagedResultsControl(0, lastCookie)` + the same `SortControl` so AD completes and releases the operation, returning a clean connection to the pool. A non-empty response cookie is itself the signal the session is still open, so the call is a no-op otherwise; any failure is logged at debug and swallowed. No config/property change.

## Related Issue

- https://github.com/wso2/product-is/issues/28057