### PR TITLE
Bump log4j2 from 2.25.4 to 2.25.5

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -554,8 +554,8 @@
         <version.drools>5.1.1</version.drools>
         <version.jsr94>1.1</version.jsr94>
 
-        <version.log4j.core>2.25.4</version.log4j.core>
-        <version.log4j.jul>2.25.4</version.log4j.jul>
+        <version.log4j.core>2.25.5</version.log4j.core>
+        <version.log4j.jul>2.25.5</version.log4j.jul>
         <version.commons.logging>1.2</version.commons.logging>
         <version.xmlunit>1.1</version.xmlunit>
         <version.jaxen>1.1.1</version.jaxen>


### PR DESCRIPTION
## Purpose

Addresses **CVE-2026-49844** (MEDIUM) — *Apache Log4j API: Malformed JSON output due to improper encoding* — https://avd.aquasec.com/nvd/cve-2026-49844

| Library | Installed | Fixed in |
|---|---|---|
| `org.apache.logging.log4j:log4j-api` | 2.25.4 | 2.25.5, 2.26.1 |

Picked 2.25.5 rather than 2.26.1 to stay on the 2.25.x line and keep the change a patch bump.

## Where it ships

`version.log4j.core` in `parent/pom.xml` drives `log4j-api`, `log4j-core` and `log4j-jcl` (parent/pom.xml lines 1988-2013). `distribution/kernel/pom.xml` copies all three into the distribution `lib/` directory.

Confirmed against a built IS 7.4.0-SNAPSHOT pack — `lib/log4j-api-2.25.4.jar` is the only `log4j-api` in the distribution:

```
./lib/log4j-api-2.25.4.jar
./lib/log4j-core-2.25.4.jar
./lib/log4j-jcl-2.25.4.jar
```

`pax-logging-api` provides its own API implementation and does not embed `log4j-api`, so this property is the single lever.

`version.log4j.jul` is bumped alongside to keep the log4j2 artifacts on one version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)