### PR TITLE
Bump httpcore5 to 5.4.3.wso2v1 and httpclient5 to 5.6.3.wso2v1

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -544,8 +544,8 @@
         <orbit.version.commons.httpclient>3.1.0.wso2v6</orbit.version.commons.httpclient>
         <orbit.version.commons.pool>1.5.6.wso2v1</orbit.version.commons.pool>
 
-        <orbit.version.httpcore5>5.3.1.wso2v1</orbit.version.httpcore5>
-        <orbit.version.httpclient5>5.4.1.wso2v1</orbit.version.httpclient5>
+        <orbit.version.httpcore5>5.4.3.wso2v1</orbit.version.httpcore5>
+        <orbit.version.httpclient5>5.6.3.wso2v1</orbit.version.httpclient5>
 
         <orbit.version.encoder>1.2.0.wso2v1</orbit.version.encoder>
 


### PR DESCRIPTION
## Purpose

| CVE | Severity | Affected artifact | Installed | Fixed in |
|---|---|---|---|---|
| [CVE-2026-54399](https://avd.aquasec.com/nvd/cve-2026-54399) | HIGH | `httpcore5` — DoS via excessive HTTP headers | 5.3.1 | 5.4.3 |
| [CVE-2026-54428](https://avd.aquasec.com/nvd/cve-2026-54428) | HIGH | `httpcore5-h2` — DoS via oversized HTTP/2 HPACK headers | 5.3.1 | 5.4.3 |
| [CVE-2026-64607](https://avd.aquasec.com/nvd/cve-2026-64607) | MEDIUM | `httpclient5` — connection leak on Content-Encoding decode error → pool exhaustion | 5.4.1 | 5.6.3 |

## Why this was not caught by the scanner

The IS distribution ships these as orbit bundles `httpclient5_5.4.1.wso2v1.jar` and `httpcore5_5.3.1.wso2v1.jar`. Both **inline** the upstream classes and carry only a WSO2 GAV in `META-INF/maven/.../pom.properties`:

```
META-INF/maven/org.wso2.orbit.org.apache.httpcomponents/httpclient5/pom.properties
META-INF/maven/org.wso2.orbit.org.apache.httpcomponents/httpcore5/pom.properties
```

so version matching against the upstream coordinates fails and Trivy reports nothing. The CVEs still apply — 5.4.1 < 5.6.3 and 5.3.1 < 5.4.3.

The same three CVEs *were* reported against `yubico-webauthn_2.5.1.wso2v1.jar`, which embeds the upstream jars whole (so detection worked there). That one is fixed separately by moving to the already-released `yubico-webauthn 2.5.1.wso2v2`.

## Version pairing

`httpclient5-parent-5.6.3` sets `httpcore.version=5.4.3`, so 5.6.3 + 5.4.3 is the pairing upstream builds and tests against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)