### PR TITLE
Support OR based conditional filtering in the JDBC user store

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
@@ -11522,19 +11522,92 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
 
     private void validateCondition(Condition condition) throws UserStoreException {
 
+        validateCondition(condition, false);
+    }
+
+    /**
+     * Validate a filter condition against the user store manager that is going to evaluate it.
+     *
+     * @param condition            Condition tree.
+     * @param userStoreManager     User store manager resolved for the requested domain.
+     * @throws UserStoreException If the condition holds an operation that the user store manager cannot evaluate.
+     */
+    private void validateCondition(Condition condition, UserStoreManager userStoreManager)
+            throws UserStoreException {
+
+        validateCondition(condition, isOrConditionSupported(userStoreManager));
+    }
+
+    private void validateCondition(Condition condition, boolean orOperationAllowed) throws UserStoreException {
+
         if (condition instanceof ExpressionCondition) {
             if (isNotSupportedExpressionOperation(condition)) {
                 throw new UserStoreException("Unsupported expression operation: " + condition.getOperation());
             }
         } else if (condition instanceof OperationalCondition) {
             Condition leftCondition = ((OperationalCondition) condition).getLeftCondition();
-            validateCondition(leftCondition);
+            validateCondition(leftCondition, orOperationAllowed);
             Condition rightCondition = ((OperationalCondition) condition).getRightCondition();
             String operation = condition.getOperation();
-            if (!OperationalOperation.AND.toString().equals(operation)) {
+            if (!OperationalOperation.AND.toString().equals(operation)
+                    && !(orOperationAllowed && OperationalOperation.OR.toString().equals(operation))) {
                 throw new UserStoreException("Unsupported Conditional operation: " + condition.getOperation());
             }
-            validateCondition(rightCondition);
+            validateCondition(rightCondition, orOperationAllowed);
+        }
+    }
+
+    private boolean isOrConditionSupported(UserStoreManager userStoreManager) {
+
+        return userStoreManager instanceof AbstractUserStoreManager
+                && ((AbstractUserStoreManager) userStoreManager).isOrConditionSupported();
+    }
+
+    /**
+     * Whether this user store manager can evaluate a filter condition whose expressions are combined with the OR
+     * operation. Mixing AND and OR in the same filter is not supported by any user store manager.
+     *
+     * @return True if the OR operation is supported.
+     */
+    protected boolean isOrConditionSupported() {
+
+        return false;
+    }
+
+    /**
+     * Check whether the given condition tree holds an OR operation.
+     *
+     * @param condition Condition tree.
+     * @return True if at least one operational node of the tree is an OR operation.
+     */
+    private boolean containsOrOperation(Condition condition) {
+
+        if (!(condition instanceof OperationalCondition)) {
+            return false;
+        }
+        if (OperationalOperation.OR.toString().equals(condition.getOperation())) {
+            return true;
+        }
+        return containsOrOperation(((OperationalCondition) condition).getLeftCondition())
+                || containsOrOperation(((OperationalCondition) condition).getRightCondition());
+    }
+
+    /**
+     * Identity claim filters are evaluated against the identity data store and then intersected with the user store
+     * results, which carries AND semantics. That merge cannot express an OR filter, so the combination is rejected
+     * instead of silently returning the intersection.
+     *
+     * @param condition            Condition tree.
+     * @param expressionConditions Expressions of the condition, with the identity claims already mapped.
+     * @throws UserStoreException If the condition combines the OR operation with an identity claim.
+     */
+    private void validateOrConditionWithIdentityClaims(Condition condition,
+                                                       List<ExpressionCondition> expressionConditions)
+            throws UserStoreException {
+
+        if (containsOrOperation(condition) && containsIdentityClaims(expressionConditions)) {
+            throw new UserStoreClientException("Filtering with the " + OperationalOperation.OR
+                    + " operation is not supported when the filter contains identity claims.");
         }
     }
 
@@ -16905,13 +16978,13 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
     public List<User> getUserListWithID(Condition condition, String domain, String profileName, int limit, int offset,
                                         String sortBy, String sortOrder) throws UserStoreException {
 
-        validateCondition(condition);
-        if (StringUtils.isNotEmpty(sortBy) && StringUtils.isNotEmpty(sortOrder)) {
-            throw new UserStoreException("Sorting is not supported.");
-        }
-
         if (StringUtils.isEmpty(domain)) {
             domain = UserCoreConstants.PRIMARY_DEFAULT_DOMAIN_NAME;
+        }
+
+        validateCondition(condition, getSecondaryUserStoreManager(domain));
+        if (StringUtils.isNotEmpty(sortBy) && StringUtils.isNotEmpty(sortOrder)) {
+            throw new UserStoreException("Sorting is not supported.");
         }
 
         if (StringUtils.isEmpty(profileName)) {
@@ -16939,6 +17012,7 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
 
         // Check whether the request has IdentityClaims in filters.
         mapAttributesToLocalIdentityClaims(expressionConditions, domain, secondaryUserStoreManager);
+        validateOrConditionWithIdentityClaims(condition, expressionConditions);
         boolean identityClaimsExistsInInitialCondition = containsIdentityClaims(expressionConditions);
 
         if (identityClaimsExistsInInitialCondition) {
@@ -17071,13 +17145,13 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
             throws UserStoreException {
 
         PaginatedUserResponse paginatedUserResponse = new PaginatedUserResponse();
-        validateCondition(condition);
-        if (StringUtils.isNotEmpty(sortBy) && StringUtils.isNotEmpty(sortOrder)) {
-            throw new UserStoreException("Sorting is not supported.");
-        }
-
         if (StringUtils.isEmpty(domain)) {
             domain = UserCoreConstants.PRIMARY_DEFAULT_DOMAIN_NAME;
+        }
+
+        validateCondition(condition, getSecondaryUserStoreManager(domain));
+        if (StringUtils.isNotEmpty(sortBy) && StringUtils.isNotEmpty(sortOrder)) {
+            throw new UserStoreException("Sorting is not supported.");
         }
 
         if (StringUtils.isEmpty(profileName)) {
@@ -17097,6 +17171,7 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
         Condition duplicateCondition = getDuplicateCondition(condition);
         getExpressionConditions(duplicateCondition, expressionConditions);
         mapAttributesToLocalIdentityClaims(expressionConditions, domain, secondaryUserStoreManager);
+        validateOrConditionWithIdentityClaims(condition, expressionConditions);
 
         /* *****************************************************
          * Logic to Filter Users Based on Identity & Non Identity Claims
@@ -17192,11 +17267,11 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
     public int getUsersCount(Condition condition, String domain, String profileName, int limit, int offset,
                              boolean isRemoveDuplicateUsersEnabled) throws UserStoreException {
 
-        validateCondition(condition);
-
         if (StringUtils.isEmpty(domain)) {
             domain = UserCoreConstants.PRIMARY_DEFAULT_DOMAIN_NAME;
         }
+
+        validateCondition(condition, getSecondaryUserStoreManager(domain));
 
         if (StringUtils.isEmpty(profileName)) {
             profileName = UserCoreConstants.DEFAULT_PROFILE;
@@ -17217,6 +17292,7 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
 
         // Check whether the request has IdentityClaims in filters.
         mapAttributesToLocalIdentityClaims(expressionConditions, domain, secondaryUserStoreManager);
+        validateOrConditionWithIdentityClaims(condition, expressionConditions);
         boolean identityClaimsExistsInInitialCondition = countIdentityClaims(expressionConditions) > 0;
 
         if (identityClaimsExistsInInitialCondition) {

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCUserStoreManager.java
@@ -56,6 +56,7 @@ import org.wso2.carbon.user.core.model.ExpressionAttribute;
 import org.wso2.carbon.user.core.model.ExpressionCondition;
 import org.wso2.carbon.user.core.model.ExpressionOperation;
 import org.wso2.carbon.user.core.model.OperationalCondition;
+import org.wso2.carbon.user.core.model.OperationalOperation;
 import org.wso2.carbon.user.core.model.SqlBuilder;
 import org.wso2.carbon.user.core.profile.ProfileConfigurationManager;
 import org.wso2.carbon.user.core.util.DatabaseUtil;
@@ -87,6 +88,7 @@ import java.util.Comparator;
 import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -3799,11 +3801,8 @@ public class UniqueIDJDBCUserStoreManager extends JDBCUserStoreManager {
             OffsetLimit offsetLimit = new OffsetLimit(offset, limit);
             adjustOffsetForDatabase(type, offsetLimit);
 
-            SqlBuilder sqlBuilder =
-                    getQueryString(filterConfigs.isGroupFiltering(), filterConfigs.isUsernameFiltering(),
-                            filterConfigs.isClaimFiltering(), filterConfigs.getExpressionConditions(),
-                            offsetLimit.getLimit(), offsetLimit.getOffset(), sortBy, sortOrder, profileName, type,
-                            filterConfigs.getTotalMultiGroupFilters(), filterConfigs.getTotalMultiClaimFilters());
+            SqlBuilder sqlBuilder = buildFilterQuery(filterConfigs, offsetLimit, sortBy, sortOrder, profileName,
+                    type);
 
             users = executeQueryAndGetUsers(dbConnection, sqlBuilder, filterConfigs, type);
             result.setUsers(users);
@@ -3841,11 +3840,8 @@ public class UniqueIDJDBCUserStoreManager extends JDBCUserStoreManager {
             OffsetLimit offsetLimit = new OffsetLimit(offset, limit);
             adjustOffsetForDatabase(type, offsetLimit);
 
-            SqlBuilder sqlBuilder =
-                    getQueryString(filterConfigs.isGroupFiltering(), filterConfigs.isUsernameFiltering(),
-                            filterConfigs.isClaimFiltering(), filterConfigs.getExpressionConditions(),
-                            offsetLimit.getLimit(), offsetLimit.getOffset(), sortBy, sortOrder, profileName, type,
-                            filterConfigs.getTotalMultiGroupFilters(), filterConfigs.getTotalMultiClaimFilters());
+            SqlBuilder sqlBuilder = buildFilterQuery(filterConfigs, offsetLimit, sortBy, sortOrder, profileName,
+                    type);
 
             usernames = executeQueryAndGetUsernames(dbConnection, sqlBuilder, filterConfigs, type);
             result.setUsers(usernames);
@@ -3859,6 +3855,33 @@ public class UniqueIDJDBCUserStoreManager extends JDBCUserStoreManager {
         }
 
         return result;
+    }
+
+    /**
+     * Build the query for a conditional filter. An OR filter is built by a dedicated builder, since widening the
+     * result set needs a fundamentally different query shape than narrowing it.
+     *
+     * @param filterConfigs Filter configurations resolved from the condition.
+     * @param offsetLimit   Database adjusted offset and limit.
+     * @param sortBy        Sort by.
+     * @param sortOrder     Sort order.
+     * @param profileName   Profile name.
+     * @param dbType        Database type.
+     * @return SQL builder holding the query and its parameters.
+     * @throws UserStoreException If the filter cannot be translated into a query.
+     */
+    private SqlBuilder buildFilterQuery(FilterConfigs filterConfigs, OffsetLimit offsetLimit, String sortBy,
+                                        String sortOrder, String profileName, String dbType)
+            throws UserStoreException {
+
+        if (filterConfigs.isOrOperation()) {
+            return getQueryStringForOrOperation(filterConfigs.getExpressionConditions(), offsetLimit.getLimit(),
+                    offsetLimit.getOffset(), profileName, dbType);
+        }
+        return getQueryString(filterConfigs.isGroupFiltering(), filterConfigs.isUsernameFiltering(),
+                filterConfigs.isClaimFiltering(), filterConfigs.getExpressionConditions(), offsetLimit.getLimit(),
+                offsetLimit.getOffset(), sortBy, sortOrder, profileName, dbType,
+                filterConfigs.getTotalMultiGroupFilters(), filterConfigs.getTotalMultiClaimFilters());
     }
 
     private List<User> executeQueryAndGetUsers(Connection dbConnection, SqlBuilder sqlBuilder,
@@ -3911,6 +3934,7 @@ public class UniqueIDJDBCUserStoreManager extends JDBCUserStoreManager {
     private FilterConfigs initializeFilterConfigs(Condition condition) throws UserStoreException {
 
         FilterConfigs filterConfigs = new FilterConfigs(false, false, false, 0, 0);
+        filterConfigs.setOrOperation(isOrOperation(condition));
         getExpressionConditions(condition, filterConfigs.getExpressionConditions());
 
         for (ExpressionCondition expressionCondition : filterConfigs.getExpressionConditions()) {
@@ -3946,6 +3970,10 @@ public class UniqueIDJDBCUserStoreManager extends JDBCUserStoreManager {
 
     private boolean needsMultiFilterHandling(String type, FilterConfigs filterConfigs) {
 
+        if (filterConfigs.isOrOperation()) {
+            // An OR filter is always built as a single query, hence there is nothing to combine.
+            return false;
+        }
         return (MYSQL.equals(type) || MARIADB.equals(type)) && filterConfigs.getTotalMultiGroupFilters() > 1 &&
                 filterConfigs.getTotalMultiClaimFilters() > 1;
     }
@@ -4056,6 +4084,7 @@ public class UniqueIDJDBCUserStoreManager extends JDBCUserStoreManager {
         private boolean isClaimFiltering;
         private int totalMultiGroupFilters;
         private int totalMultiClaimFilters;
+        private boolean isOrOperation;
         private final List<ExpressionCondition> expressionConditions;
 
         public FilterConfigs(boolean isGroupFiltering, boolean isUsernameFiltering, boolean isClaimFiltering,
@@ -4117,6 +4146,16 @@ public class UniqueIDJDBCUserStoreManager extends JDBCUserStoreManager {
         public void setTotalMultiClaimFilters(int totalMultiClaimFilters) {
 
             this.totalMultiClaimFilters = totalMultiClaimFilters;
+        }
+
+        public boolean isOrOperation() {
+
+            return isOrOperation;
+        }
+
+        public void setOrOperation(boolean orOperation) {
+
+            isOrOperation = orOperation;
         }
 
         public List<ExpressionCondition> getExpressionConditions() {
@@ -4878,6 +4917,224 @@ public class UniqueIDJDBCUserStoreManager extends JDBCUserStoreManager {
         return sqlBuilder;
     }
 
+    /**
+     * Build the query for a filter whose expressions are combined only with the OR operation.
+     * <p>
+     * The AND path narrows the result set, and does so by intersecting one query per expression. An OR filter widens
+     * it instead, so each expression is rendered as an independent predicate against UM_USER and the predicates are
+     * combined with OR. Role and claim expressions become correlated (NOT) EXISTS sub queries, which keeps the result
+     * at one row per user - so no DISTINCT is needed and LIMIT/OFFSET pagination stays correct - and lets each sub
+     * query use its own index.
+     *
+     * @param expressionConditions Filter expressions.
+     * @param limit                Limit.
+     * @param offset               Offset.
+     * @param profileName          Profile name.
+     * @param dbType               Database type.
+     * @return SQL builder holding the query and its parameters.
+     * @throws UserStoreException If the filter holds no expression, or an expression that cannot be translated.
+     */
+    protected SqlBuilder getQueryStringForOrOperation(List<ExpressionCondition> expressionConditions, int limit,
+                                                      int offset, String profileName, String dbType)
+            throws UserStoreException {
+
+        if (expressionConditions.isEmpty()) {
+            throw new UserStoreException("Condition is not valid.");
+        }
+
+        StringBuilder sqlStatement;
+        if (DB2.equals(dbType)) {
+            sqlStatement = new StringBuilder(
+                    "SELECT UM_USER_ID, UM_USER_NAME FROM (SELECT ROW_NUMBER() OVER (ORDER BY "
+                            + "UM_USER_NAME) AS rn, p.*  FROM (SELECT DISTINCT UM_USER_ID, UM_USER_NAME  FROM "
+                            + "UM_USER U");
+        } else if (ORACLE.equals(dbType)) {
+            sqlStatement = new StringBuilder(
+                    "SELECT UM_USER_ID, UM_USER_NAME FROM (SELECT UM_USER_ID, UM_USER_NAME, rownum AS rnum "
+                            + "FROM (SELECT UM_USER_ID, UM_USER_NAME FROM UM_USER U");
+        } else {
+            sqlStatement = new StringBuilder("SELECT U.UM_USER_ID, U.UM_USER_NAME FROM UM_USER U");
+        }
+
+        SqlBuilder sqlBuilder = new SqlBuilder(sqlStatement).where("U.UM_TENANT_ID = ?", tenantId);
+
+        for (ExpressionCondition expressionCondition : expressionConditions) {
+            addOrPredicate(sqlBuilder, expressionCondition, profileName);
+        }
+
+        if (DB2.equals(dbType)) {
+            sqlBuilder.setTail(") AS p) WHERE rn BETWEEN ? AND ?", limit, offset);
+        } else if (MSSQL.equals(dbType)) {
+            sqlBuilder.setTail(" ORDER BY UM_USER_NAME ASC OFFSET ? ROWS FETCH NEXT ? ROWS ONLY", offset, limit);
+        } else if (ORACLE.equals(dbType)) {
+            sqlBuilder.setTail(" ORDER BY UM_USER_NAME) where rownum <= ?) WHERE  rnum > ?", limit, offset);
+        } else {
+            sqlBuilder.setTail(" ORDER BY UM_USER_NAME ASC LIMIT ? OFFSET ?", limit, offset);
+        }
+        return sqlBuilder;
+    }
+
+    private void addOrPredicate(SqlBuilder sqlBuilder, ExpressionCondition expressionCondition, String profileName)
+            throws UserStoreException {
+
+        String attributeName = expressionCondition.getAttributeName();
+        String operation = expressionCondition.getOperation();
+        String attributeValue = expressionCondition.getAttributeValue();
+
+        if (ExpressionAttribute.ROLE.toString().equals(attributeName)) {
+            addGroupOrPredicate(sqlBuilder, operation, attributeValue);
+        } else if (ExpressionAttribute.USERNAME.toString().equals(attributeName)) {
+            addUsernameOrPredicate(sqlBuilder, operation, attributeValue);
+        } else {
+            addClaimOrPredicate(sqlBuilder, attributeName, operation, attributeValue, profileName);
+        }
+    }
+
+    private void addUsernameOrPredicate(SqlBuilder sqlBuilder, String operation, String attributeValue)
+            throws UserStoreException {
+
+        boolean caseSensitive = isCaseSensitiveUsername();
+        String column = caseSensitive ? "U.UM_USER_NAME" : "LOWER(U.UM_USER_NAME)";
+        String placeHolder = caseSensitive ? "?" : "LOWER(?)";
+
+        if (ExpressionOperation.EQ.toString().equals(operation)) {
+            sqlBuilder.orWhere(column + " = " + placeHolder, orParameters(attributeValue));
+        } else if (ExpressionOperation.CO.toString().equals(operation)) {
+            sqlBuilder.orWhere(column + " LIKE " + placeHolder, orParameters("%" + attributeValue + "%"));
+        } else if (ExpressionOperation.EW.toString().equals(operation)) {
+            sqlBuilder.orWhere(column + " LIKE " + placeHolder, orParameters("%" + attributeValue));
+        } else if (ExpressionOperation.SW.toString().equals(operation)) {
+            sqlBuilder.orWhere(column + " LIKE " + placeHolder, orParameters(attributeValue + "%"));
+        } else if (ExpressionOperation.NE.toString().equals(operation)) {
+            sqlBuilder.orWhere(column + " <> " + placeHolder, orParameters(attributeValue));
+        } else if (ExpressionOperation.GE.toString().equals(operation)) {
+            sqlBuilder.orWhere(column + " >= " + placeHolder, orParameters(attributeValue));
+        } else if (ExpressionOperation.LE.toString().equals(operation)) {
+            sqlBuilder.orWhere(column + " <= " + placeHolder, orParameters(attributeValue));
+        } else {
+            throw new UserStoreClientException("Unsupported expression operation: " + operation);
+        }
+    }
+
+    private void addClaimOrPredicate(SqlBuilder sqlBuilder, String attributeName, String operation,
+                                     String attributeValue, String profileName) throws UserStoreException {
+
+        /*
+         * NE has to match the users that do not carry the given value, including the ones that do not carry the
+         * attribute at all. Under OR that cannot be expressed as an inequality on a joined attribute row, so it is
+         * rendered as a NOT EXISTS over the equality match.
+         */
+        boolean isNotEqualOperation = ExpressionOperation.NE.toString().equals(operation);
+        String effectiveOperation = isNotEqualOperation ? ExpressionOperation.EQ.toString() : operation;
+
+        boolean caseSensitive = isCaseSensitiveUsername();
+        String column = caseSensitive ? "UA.UM_ATTR_VALUE" : "LOWER(UA.UM_ATTR_VALUE)";
+        String placeHolder = caseSensitive ? "?" : "LOWER(?)";
+        String comparison;
+        String value = attributeValue;
+
+        if (ExpressionOperation.EQ.toString().equals(effectiveOperation)) {
+            comparison = " = " + placeHolder;
+        } else if (ExpressionOperation.CO.toString().equals(effectiveOperation)) {
+            comparison = " LIKE " + placeHolder;
+            value = "%" + attributeValue + "%";
+        } else if (ExpressionOperation.EW.toString().equals(effectiveOperation)) {
+            comparison = " LIKE " + placeHolder;
+            value = "%" + attributeValue;
+        } else if (ExpressionOperation.SW.toString().equals(effectiveOperation)) {
+            comparison = " LIKE " + placeHolder;
+            value = attributeValue + "%";
+        } else if (ExpressionOperation.GE.toString().equals(effectiveOperation)) {
+            comparison = " >= " + placeHolder;
+        } else if (ExpressionOperation.LE.toString().equals(effectiveOperation)) {
+            comparison = " <= " + placeHolder;
+        } else {
+            throw new UserStoreClientException("Unsupported expression operation: " + operation);
+        }
+
+        String subQuery = "SELECT 1 FROM UM_USER_ATTRIBUTE UA WHERE UA.UM_USER_ID = U.UM_ID AND UA.UM_TENANT_ID = ? "
+                + "AND UA.UM_PROFILE_ID = ? AND UA.UM_ATTR_NAME = ? AND " + column + comparison;
+        sqlBuilder.orWhere(existsPredicate(subQuery, isNotEqualOperation),
+                orParameters(tenantId, profileName, attributeName, value));
+    }
+
+    private void addGroupOrPredicate(SqlBuilder sqlBuilder, String operation, String attributeValue)
+            throws UserStoreException {
+
+        /*
+         * As with claims, a group NE under OR has to match the users that are not in the group, including the ones
+         * with no group at all, which makes it a NOT EXISTS over the equality match.
+         */
+        boolean isNotEqualOperation = ExpressionOperation.NE.toString().equals(operation);
+        String effectiveOperation = isNotEqualOperation ? ExpressionOperation.EQ.toString() : operation;
+        String comparison;
+        String value = attributeValue;
+
+        if (ExpressionOperation.EQ.toString().equals(effectiveOperation)) {
+            comparison = "R.UM_ROLE_NAME = ?";
+        } else if (ExpressionOperation.CO.toString().equals(effectiveOperation)) {
+            comparison = "R.UM_ROLE_NAME LIKE ?";
+            value = "%" + attributeValue + "%";
+        } else if (ExpressionOperation.EW.toString().equals(effectiveOperation)) {
+            comparison = "R.UM_ROLE_NAME LIKE ?";
+            value = "%" + attributeValue;
+        } else if (ExpressionOperation.SW.toString().equals(effectiveOperation)) {
+            comparison = "R.UM_ROLE_NAME LIKE ?";
+            value = attributeValue + "%";
+        } else if (ExpressionOperation.GE.toString().equals(effectiveOperation)) {
+            comparison = "R.UM_ROLE_NAME >= ?";
+        } else if (ExpressionOperation.LE.toString().equals(effectiveOperation)) {
+            comparison = "R.UM_ROLE_NAME <= ?";
+        } else {
+            throw new UserStoreClientException("Unsupported expression operation: " + operation);
+        }
+
+        String subQuery = "SELECT 1 FROM UM_USER_ROLE UR INNER JOIN UM_ROLE R ON R.UM_ID = UR.UM_ROLE_ID "
+                + "WHERE UR.UM_USER_ID = U.UM_ID AND UR.UM_TENANT_ID = ? AND R.UM_TENANT_ID = ? AND " + comparison;
+        sqlBuilder.orWhere(existsPredicate(subQuery, isNotEqualOperation), orParameters(tenantId, tenantId, value));
+    }
+
+    private String existsPredicate(String subQuery, boolean negated) {
+
+        return (negated ? "NOT EXISTS (" : "EXISTS (") + subQuery + ")";
+    }
+
+    private List<Object> orParameters(Object... values) {
+
+        return Arrays.asList(values);
+    }
+
+    /**
+     * Check whether the expressions of the given condition are combined only with the OR operation.
+     *
+     * @param condition Condition tree.
+     * @return True if the tree holds at least one OR operation and no AND operation.
+     * @throws UserStoreException If the tree mixes AND and OR operations.
+     */
+    private boolean isOrOperation(Condition condition) throws UserStoreException {
+
+        Set<String> operations = new HashSet<>();
+        collectOperationalOperations(condition, operations);
+        if (operations.size() > 1) {
+            throw new UserStoreClientException("Filter conditions combining both " + OperationalOperation.AND
+                    + " and " + OperationalOperation.OR + " operations are not supported.");
+        }
+        return operations.contains(OperationalOperation.OR.toString());
+    }
+
+    private void collectOperationalOperations(Condition condition, Set<String> operations) {
+
+        if (!(condition instanceof OperationalCondition)) {
+            return;
+        }
+        String operation = condition.getOperation();
+        if (StringUtils.isNotBlank(operation)) {
+            operations.add(operation.toUpperCase());
+        }
+        collectOperationalOperations(((OperationalCondition) condition).getLeftCondition(), operations);
+        collectOperationalOperations(((OperationalCondition) condition).getRightCondition(), operations);
+    }
+
     private void multiGroupQueryBuilder(SqlBuilder sqlBuilder, SqlBuilder header, boolean hitFirstRound,
             ExpressionCondition expressionCondition) {
 
@@ -5043,6 +5300,12 @@ public class UniqueIDJDBCUserStoreManager extends JDBCUserStoreManager {
 
     @Override
     public boolean isUniqueUserIdEnabled() {
+
+        return true;
+    }
+
+    @Override
+    protected boolean isOrConditionSupported() {
 
         return true;
     }

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/model/SqlBuilder.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/model/SqlBuilder.java
@@ -33,6 +33,7 @@ public class SqlBuilder {
     private static final String CLOSE_PARENTHESES = ")";
 
     private List<String> wheres = new ArrayList<>();
+    private List<String> orWheres = new ArrayList<>();
     private StringBuilder sql;
     private StringBuilder tail;
     private int count = 1;
@@ -59,6 +60,28 @@ public class SqlBuilder {
             }
             sql.append(s);
         }
+        appendOrGroup(sql);
+    }
+
+    /**
+     * Append the pending OR group, if any, as a single parenthesized clause. The members of the group are combined
+     * with OR, and the group itself is combined with the AND-ed where clauses using AND.
+     *
+     * @param sql SQL string being built.
+     */
+    private void appendOrGroup(StringBuilder sql) {
+
+        if (orWheres.isEmpty()) {
+            return;
+        }
+        if (addedWhereStatement) {
+            sql.append(" AND ");
+        } else {
+            sql.append(" WHERE ");
+            this.addedWhereStatement = true;
+        }
+        sql.append(START_PARENTHESES).append(String.join(" OR ", orWheres)).append(CLOSE_PARENTHESES);
+        orWheres = new ArrayList<>();
     }
 
     public String getQuery() {
@@ -111,6 +134,59 @@ public class SqlBuilder {
         timestampParameters.put(count, value);
         count++;
         return this;
+    }
+
+    /**
+     * Add a predicate to the pending OR group. Predicates added through this method are combined with each other
+     * using OR, and the resulting group is combined with the where clauses added through {@code where(..)} using AND.
+     * <p>
+     * A single predicate may carry more than one placeholder, so its parameters are passed as an ordered list and are
+     * registered in that order. When the predicate references the user attribute value column, the last string
+     * parameter is taken as the attribute value; callers must therefore build such predicates with the attribute value
+     * as the final placeholder.
+     *
+     * @param expr   Predicate with a placeholder for each of the given values.
+     * @param values Parameters of the predicate, in the order the placeholders appear.
+     * @return This builder.
+     */
+    public SqlBuilder orWhere(String expr, List<Object> values) {
+
+        orWheres.add(expr);
+        if (values == null) {
+            return this;
+        }
+        int attributeValueIndex = expr.contains(UserCoreConstants.UM_ATTRIBUTE_COLUMN)
+                ? lastStringParameterIndex(values) : -1;
+        for (int i = 0; i < values.size(); i++) {
+            Object value = values.get(i);
+            if (value instanceof String) {
+                if (i == attributeValueIndex) {
+                    attrValueIndexes.add(count);
+                }
+                stringParameters.put(count, (String) value);
+            } else if (value instanceof Integer) {
+                integerParameters.put(count, (Integer) value);
+            } else if (value instanceof Long) {
+                longParameters.put(count, (Long) value);
+            } else if (value instanceof Timestamp) {
+                timestampParameters.put(count, (Timestamp) value);
+            } else {
+                throw new IllegalArgumentException("Unsupported parameter type in the OR predicate: "
+                        + (value == null ? "null" : value.getClass().getName()));
+            }
+            count++;
+        }
+        return this;
+    }
+
+    private int lastStringParameterIndex(List<Object> values) {
+
+        for (int i = values.size() - 1; i >= 0; i--) {
+            if (values.get(i) instanceof String) {
+                return i;
+            }
+        }
+        return -1;
     }
 
     public List<Integer> getAttributeValueIndexes() {

--- a/core/org.wso2.carbon.user.core/src/test/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCUserStoreManagerOrFilterTest.java
+++ b/core/org.wso2.carbon.user.core/src/test/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCUserStoreManagerOrFilterTest.java
@@ -38,6 +38,7 @@ import org.wso2.carbon.user.core.model.ExpressionCondition;
 import org.wso2.carbon.user.core.model.ExpressionOperation;
 import org.wso2.carbon.user.core.model.OperationalCondition;
 import org.wso2.carbon.user.core.model.OperationalOperation;
+import org.wso2.carbon.user.core.model.SqlBuilder;
 import org.wso2.carbon.user.core.util.DatabaseUtil;
 import org.wso2.carbon.utils.dbcreator.DatabaseCreator;
 import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
@@ -209,6 +210,49 @@ public class UniqueIDJDBCUserStoreManagerOrFilterTest {
         Condition condition = or(usernameEquals("orUser1"),
                 or(usernameEquals("orUser2"), usernameEquals("orUser3")));
         assertEquals(userStoreManager.getUsersCount(condition, null, null, 10, 1, true), 3);
+    }
+
+    @Test
+    public void testOrQueryShapeForDefaultDatabase() throws Exception {
+
+        // The user store under test is case sensitive, hence the predicates carry no LOWER(..).
+        SqlBuilder sqlBuilder = buildOrQuery("h2");
+        assertEquals(sqlBuilder.getQuery(),
+                "SELECT U.UM_USER_ID, U.UM_USER_NAME FROM UM_USER U WHERE U.UM_TENANT_ID = ? AND ("
+                        + "U.UM_USER_NAME = ?"
+                        + " OR EXISTS (SELECT 1 FROM UM_USER_ATTRIBUTE UA WHERE UA.UM_USER_ID = U.UM_ID "
+                        + "AND UA.UM_TENANT_ID = ? AND UA.UM_PROFILE_ID = ? AND UA.UM_ATTR_NAME = ? "
+                        + "AND UA.UM_ATTR_VALUE = ?)"
+                        + " OR NOT EXISTS (SELECT 1 FROM UM_USER_ROLE UR INNER JOIN UM_ROLE R "
+                        + "ON R.UM_ID = UR.UM_ROLE_ID WHERE UR.UM_USER_ID = U.UM_ID AND UR.UM_TENANT_ID = ? "
+                        + "AND R.UM_TENANT_ID = ? AND R.UM_ROLE_NAME = ?)"
+                        + ") ORDER BY UM_USER_NAME ASC LIMIT ? OFFSET ?");
+        /*
+         * Tenant id, the username value, the four parameters of the claim sub query, the three parameters of the role
+         * sub query and the limit/offset pair.
+         */
+        assertEquals(sqlBuilder.getOrderedParameters().size(), 11);
+    }
+
+    @Test
+    public void testOrQueryIsPaginatedPerDatabaseType() throws Exception {
+
+        assertTrue(buildOrQuery("mssql").getQuery()
+                .endsWith(") ORDER BY UM_USER_NAME ASC OFFSET ? ROWS FETCH NEXT ? ROWS ONLY"));
+        assertTrue(buildOrQuery("oracle").getQuery()
+                .endsWith(") ORDER BY UM_USER_NAME) where rownum <= ?) WHERE  rnum > ?"));
+        assertTrue(buildOrQuery("db2").getQuery().endsWith(") AS p) WHERE rn BETWEEN ? AND ?"));
+    }
+
+    private SqlBuilder buildOrQuery(String dbType) throws UserStoreException {
+
+        List<ExpressionCondition> expressionConditions = Arrays.asList(
+                usernameEquals("orUser1"),
+                claimEquals(ATTRIBUTE_1, "alpha"),
+                new ExpressionCondition(ExpressionOperation.NE.toString(), ExpressionAttribute.ROLE.toString(),
+                        "orRole1"));
+        return ((UniqueIDJDBCUserStoreManager) userStoreManager)
+                .getQueryStringForOrOperation(expressionConditions, 10, 0, "default", dbType);
     }
 
     @Test

--- a/core/org.wso2.carbon.user.core/src/test/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCUserStoreManagerOrFilterTest.java
+++ b/core/org.wso2.carbon.user.core/src/test/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCUserStoreManagerOrFilterTest.java
@@ -1,0 +1,277 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.user.core.jdbc;
+
+import org.apache.tomcat.dbcp.dbcp2.BasicDataSource;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.wso2.carbon.CarbonConstants;
+import org.wso2.carbon.context.PrivilegedCarbonContext;
+import org.wso2.carbon.user.api.RealmConfiguration;
+import org.wso2.carbon.user.core.ClaimTestUtil;
+import org.wso2.carbon.user.core.UserCoreTestConstants;
+import org.wso2.carbon.user.core.UserRealm;
+import org.wso2.carbon.user.core.UserStoreException;
+import org.wso2.carbon.user.core.common.AbstractUserStoreManager;
+import org.wso2.carbon.user.core.common.DefaultRealm;
+import org.wso2.carbon.user.core.common.User;
+import org.wso2.carbon.user.core.config.TestRealmConfigBuilder;
+import org.wso2.carbon.user.core.model.Condition;
+import org.wso2.carbon.user.core.model.ExpressionAttribute;
+import org.wso2.carbon.user.core.model.ExpressionCondition;
+import org.wso2.carbon.user.core.model.ExpressionOperation;
+import org.wso2.carbon.user.core.model.OperationalCondition;
+import org.wso2.carbon.user.core.model.OperationalOperation;
+import org.wso2.carbon.user.core.util.DatabaseUtil;
+import org.wso2.carbon.utils.dbcreator.DatabaseCreator;
+import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
+
+import java.io.File;
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
+/**
+ * Tests conditional user filtering where the filter expressions are combined with the OR operation, against an H2
+ * backed JDBC user store.
+ */
+public class UniqueIDJDBCUserStoreManagerOrFilterTest {
+
+    private static final String JDBC_TEST_USERMGT_XML = "user-mgt-test-uniqueId.xml";
+    private static final String DB_FOLDER = "target/OrFilterUniqueIDJDBCDatabaseTest";
+    private static final String TEST_URL = "jdbc:h2:./" + DB_FOLDER + "/CARBON_TEST";
+
+    // Attributes the test claims are mapped to. See ClaimTestUtil.
+    private static final String ATTRIBUTE_1 = "attr1";
+    private static final String ATTRIBUTE_2 = "attr2";
+
+    private AbstractUserStoreManager userStoreManager;
+
+    @BeforeClass
+    public void setUp() throws Exception {
+
+        File carbonHome = new File("src/test/resources/dbscripts/group_uuid_disable");
+        if (carbonHome.exists()) {
+            System.setProperty("carbon.home", carbonHome.getAbsolutePath());
+        }
+        CarbonConstants.ENABLE_LEGACY_AUTHZ_RUNTIME = true;
+        PrivilegedCarbonContext.getThreadLocalCarbonContext()
+                .setTenantDomain(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
+        PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantId(MultitenantConstants.SUPER_TENANT_ID);
+
+        deleteDirectory(new File(DB_FOLDER));
+        DatabaseUtil.closeDatabasePoolConnection();
+
+        BasicDataSource dataSource = new BasicDataSource();
+        dataSource.setDriverClassName(UserCoreTestConstants.DB_DRIVER);
+        dataSource.setUrl(TEST_URL);
+        new DatabaseCreator(dataSource).createRegistryDatabase();
+
+        UserRealm realm = new DefaultRealm();
+        try (InputStream inStream = this.getClass().getClassLoader().getResource(JDBC_TEST_USERMGT_XML).openStream()) {
+            RealmConfiguration realmConfig =
+                    TestRealmConfigBuilder.buildRealmConfigWithJDBCConnectionUrl(inStream, TEST_URL);
+            realm.init(realmConfig, ClaimTestUtil.getClaimTestData(), ClaimTestUtil.getProfileTestData(),
+                    MultitenantConstants.SUPER_TENANT_ID);
+        }
+        dataSource.close();
+        DatabaseUtil.closeDatabasePoolConnection();
+
+        userStoreManager = (AbstractUserStoreManager) realm.getUserStoreManager();
+        addFixtures();
+    }
+
+    private void addFixtures() throws Exception {
+
+        userStoreManager.addRole("orRole1", null, null);
+        userStoreManager.addUser("orUser1", "orPass1", new String[]{"orRole1"}, null, null, false);
+        userStoreManager.addUser("orUser2", "orPass2", null, null, null, false);
+        userStoreManager.addUser("orUser3", "orPass3", null, null, null, false);
+
+        userStoreManager.setUserClaimValue("orUser1", ClaimTestUtil.CLAIM_URI1, "alpha", null);
+        userStoreManager.setUserClaimValue("orUser1", ClaimTestUtil.CLAIM_URI2, "alphaToo", null);
+        userStoreManager.setUserClaimValue("orUser2", ClaimTestUtil.CLAIM_URI1, "beta", null);
+        userStoreManager.setUserClaimValue("orUser3", ClaimTestUtil.CLAIM_URI2, "gamma", null);
+    }
+
+    @Test
+    public void testFilterUsersWithOrOnUsername() throws UserStoreException {
+
+        Condition condition = or(usernameEquals("orUser1"), usernameEquals("orUser2"));
+        assertEquals(filteredUsernames(condition, 10, 1), Arrays.asList("orUser1", "orUser2"));
+    }
+
+    @Test
+    public void testFilterUsersWithOrOnClaims() throws UserStoreException {
+
+        Condition condition = or(claimEquals(ATTRIBUTE_1, "beta"), claimEquals(ATTRIBUTE_2, "gamma"));
+        assertEquals(filteredUsernames(condition, 10, 1), Arrays.asList("orUser2", "orUser3"));
+    }
+
+    @Test
+    public void testFilterUsersWithOrOnUsernameAndClaim() throws UserStoreException {
+
+        Condition condition = or(usernameEquals("orUser1"), claimEquals(ATTRIBUTE_2, "gamma"));
+        assertEquals(filteredUsernames(condition, 10, 1), Arrays.asList("orUser1", "orUser3"));
+    }
+
+    @Test
+    public void testFilterUsersWithOrOnGroupAndClaim() throws UserStoreException {
+
+        Condition condition = or(groupEquals("orRole1"), claimEquals(ATTRIBUTE_2, "gamma"));
+        assertEquals(filteredUsernames(condition, 10, 1), Arrays.asList("orUser1", "orUser3"));
+    }
+
+    @Test
+    public void testFilterUsersWithNestedOr() throws UserStoreException {
+
+        Condition condition = or(usernameEquals("orUser1"),
+                or(claimEquals(ATTRIBUTE_1, "beta"), claimEquals(ATTRIBUTE_2, "gamma")));
+        assertEquals(filteredUsernames(condition, 10, 1), Arrays.asList("orUser1", "orUser2", "orUser3"));
+    }
+
+    @Test
+    public void testFilterUsersWithOrDoesNotDuplicateUsers() throws UserStoreException {
+
+        // orUser1 matches both expressions and must still be returned exactly once.
+        Condition condition = or(claimEquals(ATTRIBUTE_1, "alpha"), claimEquals(ATTRIBUTE_2, "alphaToo"));
+        assertEquals(filteredUsernames(condition, 10, 1), Collections.singletonList("orUser1"));
+    }
+
+    @Test
+    public void testFilterUsersWithOrOnPartialMatchOperations() throws UserStoreException {
+
+        Condition condition = or(new ExpressionCondition(ExpressionOperation.SW.toString(),
+                        ExpressionAttribute.USERNAME.toString(), "orUser1"),
+                new ExpressionCondition(ExpressionOperation.CO.toString(), ATTRIBUTE_1, "et"));
+        assertEquals(filteredUsernames(condition, 10, 1), Arrays.asList("orUser1", "orUser2"));
+    }
+
+    @Test
+    public void testFilterUsersWithOrOnNotEqualClaim() throws UserStoreException {
+
+        /*
+         * A claim NE under OR has to match the users that do not carry the value at all, and not only the ones that
+         * carry a different value. Hence orUser2, which has no attr2 value, is expected in the result.
+         */
+        Condition condition = or(claimNotEquals(ATTRIBUTE_2, "gamma"), usernameEquals("orUser3"));
+        List<String> usernames = filteredUsernames(condition, 100, 1);
+        assertTrue(usernames.contains("orUser1"));
+        assertTrue(usernames.contains("orUser2"));
+        assertTrue(usernames.contains("orUser3"));
+        assertEquals(usernames.size(), (int) usernames.stream().distinct().count());
+    }
+
+    @Test
+    public void testFilterUsersWithOrOnNotEqualUsername() throws UserStoreException {
+
+        Condition condition = or(new ExpressionCondition(ExpressionOperation.NE.toString(),
+                ExpressionAttribute.USERNAME.toString(), "orUser1"), usernameEquals("orUser1"));
+        List<String> usernames = filteredUsernames(condition, 100, 1);
+        assertTrue(usernames.containsAll(Arrays.asList("orUser1", "orUser2", "orUser3")));
+    }
+
+    @Test
+    public void testFilterUsersWithOrIsPaginated() throws UserStoreException {
+
+        Condition condition = or(usernameEquals("orUser1"),
+                or(usernameEquals("orUser2"), usernameEquals("orUser3")));
+        assertEquals(filteredUsernames(condition, 2, 1), Arrays.asList("orUser1", "orUser2"));
+        assertEquals(filteredUsernames(condition, 2, 2), Arrays.asList("orUser2", "orUser3"));
+        assertEquals(filteredUsernames(condition, 10, 3), Collections.singletonList("orUser3"));
+    }
+
+    @Test
+    public void testCountUsersWithOr() throws UserStoreException {
+
+        Condition condition = or(usernameEquals("orUser1"),
+                or(usernameEquals("orUser2"), usernameEquals("orUser3")));
+        assertEquals(userStoreManager.getUsersCount(condition, null, null, 10, 1, true), 3);
+    }
+
+    @Test
+    public void testFilterUsersWithMixedAndOrIsNotSupported() {
+
+        Condition condition = new OperationalCondition(OperationalOperation.AND.toString(),
+                usernameEquals("orUser1"), or(usernameEquals("orUser2"), usernameEquals("orUser3")));
+        try {
+            userStoreManager.getUserListWithID(condition, null, null, 10, 1, null, null);
+            fail("A filter mixing the AND and OR operations should not be accepted.");
+        } catch (UserStoreException e) {
+            // Expected.
+        }
+    }
+
+    private Condition or(Condition left, Condition right) {
+
+        return new OperationalCondition(OperationalOperation.OR.toString(), left, right);
+    }
+
+    private ExpressionCondition usernameEquals(String username) {
+
+        return new ExpressionCondition(ExpressionOperation.EQ.toString(), ExpressionAttribute.USERNAME.toString(),
+                username);
+    }
+
+    private ExpressionCondition groupEquals(String groupName) {
+
+        return new ExpressionCondition(ExpressionOperation.EQ.toString(), ExpressionAttribute.ROLE.toString(),
+                groupName);
+    }
+
+    private ExpressionCondition claimEquals(String attributeName, String attributeValue) {
+
+        return new ExpressionCondition(ExpressionOperation.EQ.toString(), attributeName, attributeValue);
+    }
+
+    private ExpressionCondition claimNotEquals(String attributeName, String attributeValue) {
+
+        return new ExpressionCondition(ExpressionOperation.NE.toString(), attributeName, attributeValue);
+    }
+
+    private List<String> filteredUsernames(Condition condition, int limit, int offset) throws UserStoreException {
+
+        return userStoreManager.getUserListWithID(condition, null, null, limit, offset, null, null).stream()
+                .map(User::getUsername).collect(Collectors.toList());
+    }
+
+    private static void deleteDirectory(File directory) {
+
+        if (!directory.exists()) {
+            return;
+        }
+        if (directory.isDirectory()) {
+            File[] children = directory.listFiles();
+            if (children != null) {
+                for (File child : children) {
+                    deleteDirectory(child);
+                }
+            }
+        }
+        if (!directory.delete()) {
+            directory.deleteOnExit();
+        }
+    }
+}


### PR DESCRIPTION
## Issue

Conditional user filtering accepts only the AND operation — `validateCondition` rejects anything else
with `Unsupported Conditional operation: OR`. So a filter such as `userName eq alice or userName eq bob`
cannot be evaluated by the JDBC user store at all, and the SCIM 2.0 layer above has no way to support
the `or` operator.

## Fix

The AND query builder is written around narrowing the result set — each extra group or claim expression
becomes another `INTERSECT` (or another joined sub query on MySQL/MariaDB). An OR filter widens it
instead, so `UniqueIDJDBCUserStoreManager.getQueryStringForOrOperation(..)` builds it separately rather
than threading a second operator through the existing builder. Each expression becomes an independent
predicate on `UM_USER`, OR-ed together; role and claim expressions become correlated `(NOT) EXISTS` sub
queries, which keeps the result at one row per user — so no `DISTINCT` is needed and `LIMIT`/`OFFSET`
pagination stays correct — and lets each sub query use its own index. `NE` is rendered as `NOT EXISTS`
over the equality match, so it also matches users that carry no such attribute or role at all.

Mixing AND and OR in one filter stays unsupported. OR is opt-in per user store manager through
`isOrConditionSupported()`, which only the unique-ID JDBC manager overrides — every other manager keeps
rejecting OR rather than silently evaluating it as AND. OR combined with an identity claim is rejected
too, since those are resolved against the identity data store and then intersected with the user store
result, which cannot express a union.

Covered by `UniqueIDJDBCUserStoreManagerOrFilterTest`, which runs the generated SQL against H2.
