### PR TITLE
Fix silently ignored JDBC user-store connection-pool properties

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/util/DatabaseUtil.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/util/DatabaseUtil.java
@@ -206,7 +206,7 @@ public class DatabaseUtil {
         }
 
         if (StringUtils.isNotEmpty(realmConfig.getUserStoreProperty(JDBCRealmConstants.INITIAL_SIZE)) &&
-                StringUtils.isNumeric(JDBCRealmConstants.INITIAL_SIZE)) {
+                StringUtils.isNumeric(realmConfig.getUserStoreProperty(JDBCRealmConstants.INITIAL_SIZE))) {
             poolProperties.setInitialSize(Integer.parseInt(realmConfig.getUserStoreProperty(JDBCRealmConstants
                     .INITIAL_SIZE)));
         }
@@ -230,7 +230,8 @@ public class DatabaseUtil {
         }
 
         if (StringUtils.isNotEmpty(realmConfig.getUserStoreProperty(JDBCRealmConstants.NUM_TESTS_PER_EVICTION_RUN)) &&
-                StringUtils.isNumeric(JDBCRealmConstants.NUM_TESTS_PER_EVICTION_RUN)) {
+                StringUtils.isNumeric(realmConfig.getUserStoreProperty(
+                        JDBCRealmConstants.NUM_TESTS_PER_EVICTION_RUN))) {
             poolProperties.setNumTestsPerEvictionRun(Integer.parseInt(realmConfig.getUserStoreProperty(
                     JDBCRealmConstants.NUM_TESTS_PER_EVICTION_RUN)));
         }
@@ -249,7 +250,8 @@ public class DatabaseUtil {
         }
 
         if (StringUtils.isNotEmpty(realmConfig.getUserStoreProperty(JDBCRealmConstants.REMOVE_ABANDONED_TIMEOUT)) &&
-                StringUtils.isNumeric(JDBCRealmConstants.REMOVE_ABANDONED_TIMEOUT)) {
+                StringUtils.isNumeric(realmConfig.getUserStoreProperty(
+                        JDBCRealmConstants.REMOVE_ABANDONED_TIMEOUT))) {
             poolProperties.setRemoveAbandonedTimeout(Integer.parseInt(realmConfig.getUserStoreProperty(
                     JDBCRealmConstants.REMOVE_ABANDONED_TIMEOUT)));
         }
@@ -288,7 +290,9 @@ public class DatabaseUtil {
                     (JDBCRealmConstants.FAIR_QUEUE)));
         }
 
-        if (StringUtils.isNumeric(JDBCRealmConstants.ABANDON_WHEN_PERCENTAGE_FULL)) {
+        if (StringUtils.isNotEmpty(realmConfig.getUserStoreProperty(JDBCRealmConstants.ABANDON_WHEN_PERCENTAGE_FULL))
+                && StringUtils.isNumeric(realmConfig.getUserStoreProperty(
+                        JDBCRealmConstants.ABANDON_WHEN_PERCENTAGE_FULL))) {
             poolProperties.setAbandonWhenPercentageFull(Integer.parseInt(realmConfig.getUserStoreProperty(
                     JDBCRealmConstants.ABANDON_WHEN_PERCENTAGE_FULL)));
         }
@@ -305,13 +309,14 @@ public class DatabaseUtil {
         }
 
         if (StringUtils.isNotEmpty(realmConfig.getUserStoreProperty(JDBCRealmConstants.SUSPECT_TIMEOUT)) &&
-                StringUtils.isNumeric(JDBCRealmConstants.SUSPECT_TIMEOUT)) {
+                StringUtils.isNumeric(realmConfig.getUserStoreProperty(JDBCRealmConstants.SUSPECT_TIMEOUT))) {
             poolProperties.setSuspectTimeout(Integer.parseInt(realmConfig.getUserStoreProperty(JDBCRealmConstants
                     .SUSPECT_TIMEOUT)));
         }
 
         if (StringUtils.isNotEmpty(realmConfig.getUserStoreProperty(JDBCRealmConstants.VALIDATION_QUERY_TIMEOUT))
-                && StringUtils.isNumeric(JDBCRealmConstants.VALIDATION_QUERY_TIMEOUT)) {
+                && StringUtils.isNumeric(realmConfig.getUserStoreProperty(
+                        JDBCRealmConstants.VALIDATION_QUERY_TIMEOUT))) {
             poolProperties.setValidationQueryTimeout(Integer.parseInt(realmConfig.getUserStoreProperty(
                     JDBCRealmConstants.VALIDATION_QUERY_TIMEOUT)));
         }
@@ -438,7 +443,7 @@ public class DatabaseUtil {
         }
 
         if (StringUtils.isNotEmpty(realmConfig.getRealmProperty(JDBCRealmConstants.INITIAL_SIZE)) &&
-                StringUtils.isNumeric(JDBCRealmConstants.INITIAL_SIZE)) {
+                StringUtils.isNumeric(realmConfig.getRealmProperty(JDBCRealmConstants.INITIAL_SIZE))) {
             poolProperties.setInitialSize(Integer.parseInt(realmConfig.getRealmProperty(JDBCRealmConstants
                     .INITIAL_SIZE)));
         }
@@ -462,7 +467,8 @@ public class DatabaseUtil {
         }
 
         if (StringUtils.isNotEmpty(realmConfig.getRealmProperty(JDBCRealmConstants.NUM_TESTS_PER_EVICTION_RUN)) &&
-                StringUtils.isNumeric(JDBCRealmConstants.NUM_TESTS_PER_EVICTION_RUN)) {
+                StringUtils.isNumeric(realmConfig.getRealmProperty(
+                        JDBCRealmConstants.NUM_TESTS_PER_EVICTION_RUN))) {
             poolProperties.setNumTestsPerEvictionRun(Integer.parseInt(realmConfig.getRealmProperty(
                     JDBCRealmConstants.NUM_TESTS_PER_EVICTION_RUN)));
         }
@@ -481,7 +487,8 @@ public class DatabaseUtil {
         }
 
         if (StringUtils.isNotEmpty(realmConfig.getRealmProperty(JDBCRealmConstants.REMOVE_ABANDONED_TIMEOUT)) &&
-                StringUtils.isNumeric(JDBCRealmConstants.REMOVE_ABANDONED_TIMEOUT)) {
+                StringUtils.isNumeric(realmConfig.getRealmProperty(
+                        JDBCRealmConstants.REMOVE_ABANDONED_TIMEOUT))) {
             poolProperties.setRemoveAbandonedTimeout(Integer.parseInt(realmConfig.getRealmProperty(
                     JDBCRealmConstants.REMOVE_ABANDONED_TIMEOUT)));
         }
@@ -515,13 +522,15 @@ public class DatabaseUtil {
                     (JDBCRealmConstants.FAIR_QUEUE)));
         }
 
-        if (StringUtils.isNumeric(JDBCRealmConstants.ABANDON_WHEN_PERCENTAGE_FULL)) {
+        if (StringUtils.isNotEmpty(realmConfig.getRealmProperty(JDBCRealmConstants.ABANDON_WHEN_PERCENTAGE_FULL))
+                && StringUtils.isNumeric(realmConfig.getRealmProperty(
+                        JDBCRealmConstants.ABANDON_WHEN_PERCENTAGE_FULL))) {
             poolProperties.setAbandonWhenPercentageFull(Integer.parseInt(realmConfig.getRealmProperty(
                     JDBCRealmConstants.ABANDON_WHEN_PERCENTAGE_FULL)));
         }
 
         if (StringUtils.isNotEmpty(realmConfig.getRealmProperty(JDBCRealmConstants.MAX_AGE)) &&
-                StringUtils.isNumeric(JDBCRealmConstants.MAX_AGE)) {
+                StringUtils.isNumeric(realmConfig.getRealmProperty(JDBCRealmConstants.MAX_AGE))) {
             poolProperties.setMaxAge(Integer.parseInt(realmConfig.getRealmProperty(JDBCRealmConstants.MAX_AGE)));
         }
 
@@ -532,13 +541,14 @@ public class DatabaseUtil {
         }
 
         if (StringUtils.isNotEmpty(realmConfig.getRealmProperty(JDBCRealmConstants.SUSPECT_TIMEOUT)) &&
-                StringUtils.isNumeric(JDBCRealmConstants.SUSPECT_TIMEOUT)) {
+                StringUtils.isNumeric(realmConfig.getRealmProperty(JDBCRealmConstants.SUSPECT_TIMEOUT))) {
             poolProperties.setSuspectTimeout(Integer.parseInt(realmConfig.getRealmProperty(JDBCRealmConstants
                     .SUSPECT_TIMEOUT)));
         }
 
         if (StringUtils.isNotEmpty(realmConfig.getRealmProperty(JDBCRealmConstants.VALIDATION_QUERY_TIMEOUT))
-                && StringUtils.isNumeric(JDBCRealmConstants.VALIDATION_QUERY_TIMEOUT)) {
+                && StringUtils.isNumeric(realmConfig.getRealmProperty(
+                        JDBCRealmConstants.VALIDATION_QUERY_TIMEOUT))) {
             poolProperties.setValidationQueryTimeout(Integer.parseInt(realmConfig.getRealmProperty(
                     JDBCRealmConstants.VALIDATION_QUERY_TIMEOUT)));
         }


### PR DESCRIPTION
Resolves: wso2/product-is#28182

### Problem

Seven connection-pool properties that are exposed to administrators as JDBC user-store **Advanced Properties** never reach the underlying Tomcat JDBC pool:

`initialSize`, `numTestsPerEvictionRun`, `removeAbandonedTimeout`, `abandonWhenPercentageFull`, `maxAge`, `suspectTimeout`, `validationQueryTimeout`

Each is guarded by `StringUtils.isNumeric(JDBCRealmConstants.<CONST>)`, which tests the **property name** (e.g. `"maxAge"`) rather than the configured value. `isNumeric("maxAge")` is always `false`, so the branch is never entered and the setter is never called. The Console shows the knob with a description, but it has no effect.

The same defect is present in both `createUserStoreDataSource` and `createRealmDataSource` — 13 guards on this branch, `maxAge` in `createUserStoreDataSource` having already been corrected. For contrast, `validationInterval` a few lines above uses the correct value-guarded form.

The customer impact driving this is `maxAge`: it is set to cap connection lifetime when the database sits behind a connection-reaping layer (AWS RDS Proxy, or an NLB/firewall with a max-session timeout). Because it is dropped, connections are never age-recycled and the pool keeps handing out connections the proxy already closed, surfacing as `PSQLException: An I/O error occurred while sending to the backend` / `java.io.EOFException` on first use of a borrowed connection.

### Fix

Guard on the configured value in all 13 places, matching the existing `validationInterval` pattern:

```java
- StringUtils.isNumeric(JDBCRealmConstants.MAX_AGE)
+ StringUtils.isNumeric(realmConfig.getRealmProperty(JDBCRealmConstants.MAX_AGE))
```

One related correction in the same guards:

- **`abandonWhenPercentageFull`** had no `isNotEmpty` check at all — it was the lone single-condition guard. Since commons-lang 2.6 `isNumeric("")` returns `true`, correcting the guard alone would turn an empty-valued property into a `NumberFormatException` at user-store load. Added the missing conjunct.
