### PR TITLE
[carbon-kernel] Bump Jackson to 2.22.2

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -643,11 +643,11 @@
         <version.hubspot.immutables>1.11.2</version.hubspot.immutables>
         <version.cava-toml>0.5.0</version.cava-toml>
         <version.checkstyle>7.8.2</version.checkstyle>
-        <version.jackson>2.21.2</version.jackson>
-        <version.jackson.annotations>2.21</version.jackson.annotations>
-        <version.jackson.databind>2.21.4</version.jackson.databind>
-        <version.jackson.dataformat>2.21.2</version.jackson.dataformat>
-        <version.jackson.datatype>2.21.2</version.jackson.datatype>
+        <version.jackson>2.22.2</version.jackson>
+        <version.jackson.annotations>2.22</version.jackson.annotations>
+        <version.jackson.databind>2.22.2</version.jackson.databind>
+        <version.jackson.dataformat>2.22.2</version.jackson.dataformat>
+        <version.jackson.datatype>2.22.2</version.jackson.datatype>
         <version.jsoup>1.15.3</version.jsoup>
         <!--Please make sure to update the Guava and Guava FailureAccess versions in the carbon-registry repository as
         well.-->


### PR DESCRIPTION
## Purpose

Upgrade the Jackson artifacts to the latest stable 2.x release, `2.22.2`.

`2.21.2` is still within the affected range of GHSA-r7wm-3cxj-wff9 (`[2.19.0, 2.21.4)`), which is
the follow-up to CVE-2026-18401 and is described upstream as an incomplete fix for it. `2.22.2` is
the current latest on the 2.x line and is clear of both.

## Approach

Version property bumps only — no code or logic changes.

`parent/pom.xml`:

- `version.jackson`: `2.21.2` → `2.22.2`
- `version.jackson.databind`: `2.21.4` → `2.22.2`
- `version.jackson.dataformat`: `2.21.2` → `2.22.2`
- `version.jackson.datatype`: `2.21.2` → `2.22.2`
- `version.jackson.annotations`: `2.21` → `2.22`

> `jackson-annotations` follows a two-segment version scheme, so it keeps its own property value.
