### PR TITLE
Bump hazelcast orbit bundle to 5.3.7.wso2v2

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -497,7 +497,7 @@
 
         <version.eclipse.ecj>3.28.0</version.eclipse.ecj>
 
-        <orbit.version.hazelcast>5.3.6.wso2v1</orbit.version.hazelcast>
+        <orbit.version.hazelcast>5.3.7.wso2v2</orbit.version.hazelcast>
         <version.apacheds.shared.ldap>0.9.18</version.apacheds.shared.ldap>
 
         <!-- hibernate -->


### PR DESCRIPTION
## Purpose

Pick up `hazelcast 5.3.7.wso2v2`, which re-shades jackson to **2.22.2** in place of the copy upstream
hazelcast embeds in `com.hazelcast.shaded.com.fasterxml.jackson`. That version is not reachable from
any pom property, so the fix is a new orbit bundle rather than a version bump here.

## Approach

`parent/pom.xml`: `orbit.version.hazelcast` `5.3.6.wso2v1` → `5.3.7.wso2v2`.

Hazelcast itself moves 5.3.6 → 5.3.7, a patch release. Its embedded dependency set is unchanged from
5.3.6 — everit-json-schema 1.14.3, HikariCP 4.0.3, classgraph 4.8.158, org.json 20231013,
snakeyaml-engine 2.6 — so jackson is the only thing that changes.

`5.3.7.wso2v2`'s OSGi manifest is identical to `5.3.7.wso2v1`'s when both are built with the same
toolchain: 654 `Import-Package` and 571 `Export-Package` entries, same sets, no mandatory imports.

## Blocked on

wso2/orbit#1408 — needs `5.3.7.wso2v2` released to Nexus before this can build. Draft until then.
